### PR TITLE
Add wordCount to GET /vocabulary/:language response

### DIFF
--- a/src/dlg/GetVocabulary.ts
+++ b/src/dlg/GetVocabulary.ts
@@ -23,6 +23,7 @@ export class GetVocabulary extends TotoDelegate<GetVocabularyRequest, GetVocabul
 
         return {
             language: req.language,
+            wordCount: words.length,
             words: words.map(w => ({
                 id: w.id!,
                 english: w.english,
@@ -40,6 +41,7 @@ interface GetVocabularyRequest {
 
 interface GetVocabularyResponse {
     language: string;
+    wordCount: number;
     words: Array<{
         id: string;
         english: string;


### PR DESCRIPTION
## Summary
- Adds a `wordCount` field to the response of `GET /vocabulary/:language` endpoint
- The field returns the total number of words in the vocabulary for the requested language
- Field is placed at top level alongside `language` and `words`