### PR TITLE
feat: session stats endpoints (weekly ISO week + rolling N-day)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ Resources:
 |----------|-------------|
 | [Vocabulary Management](docs/specs/vocabulary-management.md) | CRUD API for managing word-translation pairs per target language (e.g. Danish). |
 | [Practice Sessions](docs/specs/practice-sessions.md) | Generic session lifecycle API (start, resume, submit answers, complete) with probabilistic word selection based on per-user failure ratios. |
+| [Session Stats](docs/specs/session-stats.md) | Stats endpoints returning per-day completed session counts: ISO week view and rolling N-day window. |

--- a/docs/specs/session-stats.md
+++ b/docs/specs/session-stats.md
@@ -1,0 +1,196 @@
+# Session Stats — Feature Spec
+
+## Overview
+
+This spec defines the **session stats** endpoints in `tome-ms-language`. These endpoints allow clients to query the number of completed practice sessions per day, aggregated over a given time window.
+
+Two variants are provided, designed to cover different UI use cases:
+
+| Variant | Endpoint | Description |
+|---------|----------|-------------|
+| **ISO week** | `GET /sessions/stats/weekly` | Returns one count per day for a given ISO Mon–Sun week |
+| **Rolling window** | `GET /sessions/stats/rolling` | Returns one count per day for the last N calendar days (inclusive today) |
+
+Both endpoints:
+- Are scoped to the authenticated user (via `UserContext`)
+- Count **all completed sessions** regardless of `language` or `practiceType`
+- Return zero-count entries for days with no completed sessions (so the client always receives the full requested range)
+
+---
+
+## Endpoints
+
+### `GET /sessions/stats/weekly`
+
+Returns the count of completed sessions for each day of a given ISO week (Mon–Sun).
+
+#### Query Parameters
+
+| Parameter | Type     | Required | Description |
+|-----------|----------|----------|-------------|
+| `from`    | `string` | Yes      | The **Monday** of the week to query, in `YYYYMMDD` format (e.g. `20260428`) |
+
+#### Response
+
+```json
+{
+  "days": [
+    { "date": "20260428", "count": 2 },
+    { "date": "20260429", "count": 0 },
+    { "date": "20260430", "count": 1 },
+    { "date": "20260501", "count": 0 },
+    { "date": "20260502", "count": 3 },
+    { "date": "20260503", "count": 0 },
+    { "date": "20260504", "count": 0 }
+  ]
+}
+```
+
+- Always returns **exactly 7 entries**, one per day Mon through Sun.
+- `date` is in `YYYYMMDD` format.
+- `count` is `0` for days with no completed sessions.
+
+#### Validation
+
+- `from` is required. If missing or invalid, return `400 Bad Request`.
+- `from` must represent a Monday. If it does not, return `400 Bad Request` with message `"'from' must be a Monday (YYYYMMDD)"`.
+
+---
+
+### `GET /sessions/stats/rolling`
+
+Returns the count of completed sessions for each of the last N calendar days, inclusive of today.
+
+#### Query Parameters
+
+| Parameter | Type     | Required | Default | Description |
+|-----------|----------|----------|---------|-------------|
+| `days`    | `number` | No       | `7`     | Number of days to include (must be between 1 and 365) |
+
+#### Response
+
+Same shape as the weekly endpoint:
+
+```json
+{
+  "days": [
+    { "date": "20260426", "count": 1 },
+    { "date": "20260427", "count": 0 },
+    { "date": "20260428", "count": 2 },
+    { "date": "20260429", "count": 0 },
+    { "date": "20260430", "count": 1 },
+    { "date": "20260501", "count": 0 },
+    { "date": "20260502", "count": 3 }
+  ]
+}
+```
+
+- Returns **exactly `days` entries**, ordered chronologically oldest → newest.
+- The last entry is always **today** (server-side date, UTC).
+- `count` is `0` for days with no completed sessions.
+
+#### Validation
+
+- If `days` is provided, it must be a positive integer between 1 and 365. Otherwise return `400 Bad Request`.
+
+---
+
+## Data Source
+
+Both endpoints query the `sessions` collection (see [Practice Sessions spec](practice-sessions.md) for the full schema).
+
+Relevant fields:
+
+| Field         | Used for |
+|---------------|----------|
+| `userId`      | Scoping to the authenticated user |
+| `status`      | Filter to `"completed"` sessions only |
+| `completedAt` | Grouping by date (ISO 8601 string, e.g. `"2026-04-28T14:30:00.000Z"`) |
+
+The aggregation extracts the date portion of `completedAt` and groups by it to produce per-day counts. Sessions with `status != "completed"` or `completedAt == null` are excluded.
+
+---
+
+## Implementation
+
+### Delegates
+
+| File | Route |
+|------|-------|
+| `src/dlg/session/GetWeeklySessionStats.ts` | `GET /sessions/stats/weekly` |
+| `src/dlg/session/GetRollingSessionStats.ts` | `GET /sessions/stats/rolling` |
+
+Both delegates follow the standard `TotoDelegate<Req, Res>` pattern:
+- `parseRequest(req)` validates query parameters and throws `ValidationError` for invalid input.
+- `do(req, userContext)` calls `SessionsStore` and fills in zero-count entries for missing days before returning.
+
+### Store
+
+Add a new method to `SessionsStore`:
+
+```typescript
+async countCompletedByDateRange({ userId, from, to }: {
+    userId: string;
+    from: Date;
+    to: Date;
+}): Promise<Array<{ date: string; count: number }>>
+```
+
+- Filters: `userId`, `status: "completed"`, `completedAt >= from` and `completedAt <= to` (ISO string comparison or `$gte`/`$lte` after converting to Date).
+- Groups by the `YYYYMMDD` portion of `completedAt`.
+- Returns an array of `{ date: string; count: number }` objects — **only entries where count > 0**. Zero-filling for missing days is done in the delegate.
+
+#### MongoDB Aggregation (reference)
+
+```json
+[
+  {
+    "$match": {
+      "userId": "<userId>",
+      "status": "completed",
+      "completedAt": { "$gte": "<from ISO>", "$lte": "<to ISO>" }
+    }
+  },
+  {
+    "$addFields": {
+      "dateStr": {
+        "$dateToString": { "format": "%Y%m%d", "date": { "$dateFromString": { "dateString": "$completedAt" } } }
+      }
+    }
+  },
+  {
+    "$group": {
+      "_id": "$dateStr",
+      "count": { "$sum": 1 }
+    }
+  }
+]
+```
+
+Result documents: `{ _id: "20260428", count: 2 }`.
+
+### Zero-filling (delegate responsibility)
+
+After calling the store, each delegate generates the full set of expected dates and merges the store results:
+
+```
+expectedDates = [<date 1>, <date 2>, ..., <date N>]  // generated in the delegate
+storeCounts   = Map<date, count>                       // built from store results
+result        = expectedDates.map(d => ({ date: d, count: storeCounts.get(d) ?? 0 }))
+```
+
+### Route registration (`src/index.ts`)
+
+```typescript
+{ method: 'GET', path: '/sessions/stats/weekly',  delegate: GetWeeklySessionStats },
+{ method: 'GET', path: '/sessions/stats/rolling', delegate: GetRollingSessionStats },
+```
+
+---
+
+## Date Handling Notes
+
+- `completedAt` is stored as an ISO 8601 string (e.g. `"2026-04-28T14:30:00.000Z"`), in UTC.
+- All date arithmetic in the delegates uses UTC to avoid timezone-driven miscounts.
+- The `from` parameter for the weekly endpoint is parsed as `YYYYMMDD` at UTC midnight (`T00:00:00.000Z`); the corresponding `to` is `from + 6 days` at `T23:59:59.999Z`.
+- The rolling endpoint computes `to` as today at `T23:59:59.999Z` UTC and `from` as `today - (days - 1)` at `T00:00:00.000Z` UTC.

--- a/src/dlg/session/GetRollingSessionStats.ts
+++ b/src/dlg/session/GetRollingSessionStats.ts
@@ -1,0 +1,55 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../../Config";
+import { SessionsStore } from "../../store/SessionsStore";
+
+export class GetRollingSessionStats extends TotoDelegate<GetRollingSessionStatsRequest, GetRollingSessionStatsResponse> {
+
+    parseRequest(req: Request): GetRollingSessionStatsRequest {
+        const raw = req.query.days;
+        if (raw === undefined) return { days: 7 };
+
+        if (typeof raw !== 'string' || !/^\d+$/.test(raw)) {
+            throw new ValidationError(400, "'days' must be a positive integer between 1 and 365");
+        }
+        const days = parseInt(raw, 10);
+        if (days < 1 || days > 365) {
+            throw new ValidationError(400, "'days' must be between 1 and 365");
+        }
+        return { days };
+    }
+
+    async do(req: GetRollingSessionStatsRequest, userContext?: UserContext): Promise<GetRollingSessionStatsResponse> {
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+        const userId = userContext!.userId;
+
+        const now = new Date();
+        const to   = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 23, 59, 59, 999));
+        const from = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - (req.days - 1), 0, 0, 0, 0));
+
+        const store = new SessionsStore({ db, config });
+        const counts = await store.countCompletedByDateRange({ userId, from, to });
+        const countsMap = new Map(counts.map(c => [c.date, c.count]));
+
+        const days = Array.from({ length: req.days }, (_, i) => {
+            const d = new Date(from.getTime() + i * 24 * 60 * 60 * 1000);
+            const date = dateToYYYYMMDD(d);
+            return { date, count: countsMap.get(date) ?? 0 };
+        });
+
+        return { days };
+    }
+}
+
+function dateToYYYYMMDD(d: Date): string {
+    return `${d.getUTCFullYear()}${String(d.getUTCMonth() + 1).padStart(2, '0')}${String(d.getUTCDate()).padStart(2, '0')}`;
+}
+
+interface GetRollingSessionStatsRequest {
+    days: number;
+}
+
+interface GetRollingSessionStatsResponse {
+    days: Array<{ date: string; count: number }>;
+}

--- a/src/dlg/session/GetWeeklySessionStats.ts
+++ b/src/dlg/session/GetWeeklySessionStats.ts
@@ -1,0 +1,66 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../../Config";
+import { SessionsStore } from "../../store/SessionsStore";
+
+export class GetWeeklySessionStats extends TotoDelegate<GetWeeklySessionStatsRequest, GetWeeklySessionStatsResponse> {
+
+    parseRequest(req: Request): GetWeeklySessionStatsRequest {
+        const from = req.query.from as string | undefined;
+        if (!from || !/^\d{8}$/.test(from)) throw new ValidationError(400, "Missing or invalid 'from' — expected YYYYMMDD");
+
+        const parsed = yyyymmddToUTCDate(from);
+        if (!parsed) throw new ValidationError(400, "Invalid 'from' date (YYYYMMDD)");
+        if (parsed.getUTCDay() !== 1) throw new ValidationError(400, "'from' must be a Monday (YYYYMMDD)");
+
+        return { from };
+    }
+
+    async do(req: GetWeeklySessionStatsRequest, userContext?: UserContext): Promise<GetWeeklySessionStatsResponse> {
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+        const userId = userContext!.userId;
+
+        const from = yyyymmddToUTCDate(req.from)!;
+        const to = new Date(from.getTime() + 6 * 24 * 60 * 60 * 1000);
+        to.setUTCHours(23, 59, 59, 999);
+
+        const store = new SessionsStore({ db, config });
+        const counts = await store.countCompletedByDateRange({ userId, from, to });
+        const countsMap = new Map(counts.map(c => [c.date, c.count]));
+
+        const days = Array.from({ length: 7 }, (_, i) => {
+            const d = new Date(from.getTime() + i * 24 * 60 * 60 * 1000);
+            const date = dateToYYYYMMDD(d);
+            return { date, count: countsMap.get(date) ?? 0 };
+        });
+
+        return { days };
+    }
+}
+
+/**
+ * Parses a YYYYMMDD string into a UTC midnight Date.
+ * Returns null if the input does not represent a valid calendar date.
+ */
+function yyyymmddToUTCDate(s: string): Date | null {
+    const year  = parseInt(s.slice(0, 4), 10);
+    const month = parseInt(s.slice(4, 6), 10);
+    const day   = parseInt(s.slice(6, 8), 10);
+    const d = new Date(Date.UTC(year, month - 1, day));
+    // Round-trip check: rejects invalid dates like 20260230 that JS normalises
+    if (dateToYYYYMMDD(d) !== s) return null;
+    return d;
+}
+
+function dateToYYYYMMDD(d: Date): string {
+    return `${d.getUTCFullYear()}${String(d.getUTCMonth() + 1).padStart(2, '0')}${String(d.getUTCDate()).padStart(2, '0')}`;
+}
+
+interface GetWeeklySessionStatsRequest {
+    from: string;
+}
+
+interface GetWeeklySessionStatsResponse {
+    days: Array<{ date: string; count: number }>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,9 @@ import { ControllerConfig } from "./Config";
 import { CompleteSession } from './dlg/session/CompleteSession';
 import { DeleteWord } from './dlg/DeleteWord';
 import { GetActiveSession } from './dlg/session/GetActiveSession';
+import { GetRollingSessionStats } from './dlg/session/GetRollingSessionStats';
 import { GetVocabulary } from './dlg/GetVocabulary';
+import { GetWeeklySessionStats } from './dlg/session/GetWeeklySessionStats';
 import { PostWord } from './dlg/PostWord';
 import { PostWords } from './dlg/PostWords';
 import { PutWord } from './dlg/PutWord';
@@ -27,6 +29,8 @@ const config: TotoMicroserviceConfiguration = {
             { method: 'DELETE', path: '/vocabulary/:language/words/:id', delegate: DeleteWord },
             { method: 'POST', path: '/languages/:language/sessions', delegate: StartSession },
             { method: 'GET', path: '/sessions/active', delegate: GetActiveSession },
+            { method: 'GET', path: '/sessions/stats/weekly', delegate: GetWeeklySessionStats },
+            { method: 'GET', path: '/sessions/stats/rolling', delegate: GetRollingSessionStats },
             { method: 'POST', path: '/sessions/:sessionId/answers', delegate: SubmitAnswer },
             { method: 'POST', path: '/sessions/:sessionId/completion', delegate: CompleteSession },
         ],

--- a/src/store/SessionsStore.ts
+++ b/src/store/SessionsStore.ts
@@ -48,4 +48,45 @@ export class SessionsStore {
             { $set: { status: "completed", completedAt: new Date().toISOString() } }
         );
     }
+
+    /**
+     * Aggregates completed sessions per day within [from, to] (UTC).
+     * Returns only days that have at least one session; zero-filling is the caller's responsibility.
+     */
+    async countCompletedByDateRange({ userId, from, to }: {
+        userId: string;
+        from: Date;
+        to: Date;
+    }): Promise<Array<{ date: string; count: number }>> {
+        const results = await this.db.collection(SESSIONS_COLLECTION).aggregate([
+            {
+                $match: {
+                    userId,
+                    status: "completed",
+                    completedAt: { $gte: from.toISOString(), $lte: to.toISOString() },
+                }
+            },
+            {
+                $addFields: {
+                    dateStr: {
+                        $dateToString: {
+                            format: "%Y%m%d",
+                            timezone: "UTC",
+                            date: {
+                                $dateFromString: {
+                                    dateString: "$completedAt",
+                                    onError: null,
+                                    onNull: null,
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            { $match: { dateStr: { $ne: null } } },
+            { $group: { _id: "$dateStr", count: { $sum: 1 } } },
+        ]).toArray();
+
+        return results.map(r => ({ date: r._id as string, count: r.count as number }));
+    }
 }


### PR DESCRIPTION
## Summary

Implements two new endpoints for querying completed practice session counts per day.

Spec: `docs/specs/session-stats.md`

## Changes

### `src/store/SessionsStore.ts`
- Added `countCompletedByDateRange({ userId, from, to })` — MongoDB aggregation using `$dateToString` (UTC timezone) with a `$dateFromString` + `onError: null` guard for malformed stored values

### `src/dlg/session/GetWeeklySessionStats.ts` (new)
- `GET /sessions/stats/weekly?from=YYYYMMDD`
- Validates `from`: present, 8 digits, valid calendar date (round-trip check catches e.g. `20260230`), and falls on a Monday
- Returns exactly 7 entries Mon–Sun with zero-fill

### `src/dlg/session/GetRollingSessionStats.ts` (new)
- `GET /sessions/stats/rolling?days=N` (default 7)
- Validates `days`: digit-only, 1–365
- Returns exactly N entries ending today (UTC), oldest first, with zero-fill

### `src/index.ts`
- Registered both routes (placed before the `:sessionId` path-param routes to avoid route conflicts)

## Closes

Closes #12
Closes #13