### PR TITLE
feat: Sentence Practice backend implementation

### DIFF
--- a/docs/specs/practice-sessions.md
+++ b/docs/specs/practice-sessions.md
@@ -2,11 +2,13 @@
 
 ## Overview
 
-This spec defines the **practice session** capability in `tome-ms-language`. A practice session represents a single timed exercise in which a user is presented with a set of words and submits answers. This spec covers the full session lifecycle: starting a session, retrieving an active session, recording answers, and completing the session.
+This spec defines the **practice session** capability in `tome-ms-language`. A practice session represents a single timed exercise in which a user is presented with a set of items (words or sentences) and submits answers. This spec covers the full session lifecycle: starting a session, retrieving an active session, recording answers, and completing the session.
 
-Sessions are **generic by design**: the `practiceType` field allows new practice types to be added in the future without structural changes. The only practice type defined in this spec is **`"vocabulary"`** (English → Target Language translation).
+Sessions are **generic by design**: the `practiceType` field allows new practice types to be added without structural changes. The practice types defined in this spec are:
+- **`"vocabulary"`** — English → Target Language word translation
+- **`"sentences"`** — English → Target Language sentence recall
 
-Sessions are **user-specific**: all data (sessions, word statistics) is scoped to the authenticated user. User identity is taken from the `UserContext` provided by the `totoms` framework.
+Sessions are **user-specific**: all data (sessions, word/sentence statistics) is scoped to the authenticated user. User identity is taken from the `UserContext` provided by the `totoms` framework.
 
 ---
 
@@ -15,10 +17,13 @@ Sessions are **user-specific**: all data (sessions, word statistics) is scoped t
 ### Practice Type: Vocabulary
 A vocabulary session presents the user with `N` English words. For each word, the user must type the translation in the Target Language from memory. The session ends when all words have been answered correctly (words that were answered incorrectly are re-queued by the frontend until they are mastered).
 
-### Frontend Queue Ownership
-The frontend is responsible for managing the **word queue** during a session (the order in which words are presented, deferring incorrect answers to the end, tracking mastered vs. deferred state). The backend only stores the original list of words assigned to the session and records each submitted answer.
+### Practice Type: Sentences
+A sentences session presents the user with `M` English sentence translations. For each entry, the user must type the full Danish sentence from memory. The session ends when all sentences have been typed correctly (sentences answered incorrectly are re-queued by the frontend until they are mastered).
 
-This means that on session resume, the backend returns the original word list. The frontend is responsible for restoring its local queue state (e.g. from localStorage). If local state is lost, the frontend falls back to presenting all words as pending.
+### Frontend Queue Ownership
+The frontend is responsible for managing the **item queue** during a session (the order in which items are presented, deferring incorrect answers to the end, tracking mastered vs. deferred state). The backend only stores the original list of items assigned to the session and records each submitted answer.
+
+This means that on session resume, the backend returns the original item list. The frontend is responsible for restoring its local queue state (e.g. from localStorage). If local state is lost, the frontend falls back to presenting all items as pending.
 
 ### One Active Session per User
 A user may have **at most one active session at a time** across all languages and practice types. Attempting to start a new session while one is already active results in a `409 Conflict`.
@@ -72,7 +77,33 @@ The `payload` sub-document for a vocabulary session has the following shape:
 | `isCorrect`   | boolean | Whether the answer was marked correct                    |
 | `submittedAt` | string  | ISO 8601 timestamp of when the answer was submitted      |
 
-The field name `entityId` is used (rather than `wordId`) to keep the answer schema generic across practice types. In a vocabulary session, `entityId` always maps to a `wordId`.
+The field name `entityId` is used (rather than `wordId`) to keep the answer schema generic across practice types. In a vocabulary session, `entityId` always maps to a `wordId`. In a sentences session, `entityId` maps to a `sentenceId`.
+
+#### Sentence Session Payload (`practiceType = "sentences"`)
+
+The `payload` sub-document for a sentences session has the following shape:
+
+| Field            | Type             | Description                                                           |
+|------------------|------------------|-----------------------------------------------------------------------|
+| `sentences`      | array of objects | The sentences assigned to this session (see `sentences` entry below)  |
+| `totalSentences` | number           | Total number of sentences in the session                              |
+| `answers`        | array of objects | All answers submitted during the session, in order (see below)        |
+
+##### `payload.sentences` Entry
+
+| Field         | Type   | Description                                   |
+|---------------|--------|-----------------------------------------------|
+| `sentenceId`  | string | MongoDB ObjectId of the sentence entry        |
+| `sentence`    | string | The Danish sentence                           |
+| `translation` | string | The English translation                       |
+
+##### `payload.answers` Entry (same schema as vocabulary)
+
+| Field         | Type    | Description                                                    |
+|---------------|---------|----------------------------------------------------------------|
+| `entityId`    | string  | The `sentenceId` of the sentence this answer relates to        |
+| `isCorrect`   | boolean | Whether the answer was marked correct                          |
+| `submittedAt` | string  | ISO 8601 timestamp of when the answer was submitted            |
 
 ---
 
@@ -93,6 +124,27 @@ Tracks per-user, per-word practice statistics used to weight word selection.
 | `updatedAt`     | string  | ISO 8601 timestamp of the last update to this document              |
 
 **Index**: `{ userId: 1, wordId: 1 }` (unique) — supports fast upsert by user+word.  
+**Index**: `{ userId: 1, language: 1 }` — supports loading all stats for a user's language in one query.
+
+---
+
+### `sentence_stats` Collection
+
+Tracks per-user, per-sentence practice statistics used to weight sentence selection.
+
+| Field           | Type     | Description                                                             |
+|-----------------|----------|-------------------------------------------------------------------------|
+| `_id`           | ObjectId | MongoDB-generated identifier                                            |
+| `userId`        | string   | User identifier                                                         |
+| `sentenceId`    | string   | MongoDB ObjectId of the sentence entry                                  |
+| `language`      | string   | Target language code                                                    |
+| `totalAttempts` | number   | Total number of times this sentence has been submitted across all sessions |
+| `totalFailures` | number   | Total number of incorrect answers across all sessions                   |
+| `failureRatio`  | number   | Pre-computed `totalFailures / totalAttempts` (0.0–1.0)                 |
+| `lastPracticed` | string   | ISO 8601 timestamp of the last session that included this sentence      |
+| `updatedAt`     | string   | ISO 8601 timestamp of the last update to this document                 |
+
+**Index**: `{ userId: 1, sentenceId: 1 }` (unique) — supports fast upsert by user+sentence.  
 **Index**: `{ userId: 1, language: 1 }` — supports loading all stats for a user's language in one query.
 
 ---
@@ -136,18 +188,35 @@ Starts a new practice session for the authenticated user.
 
 #### Behaviour
 
-1. Validate `language` (must be in the supported list) and `practiceType` (must be `"vocabulary"`).
+1. Validate `language` (must be in the supported list) and `practiceType` (must be `"vocabulary"` or `"sentences"`).
 2. Check whether the user already has an active session (`status = "active"`) — if yes, return `409 Conflict`.
-3. Load all vocabulary words for the given language from the `vocabulary` collection.
-4. Load all `word_stats` documents for the user + language from the `word_stats` collection.
-5. Compute a **selection weight** for each vocabulary word:
+3. Dispatch to the appropriate type-specific handler based on `practiceType`:
+
+##### For `practiceType = "vocabulary"`:
+
+1. Load all vocabulary words for the given language from the `vocabulary` collection.
+2. Load all `word_stats` documents for the user + language from the `word_stats` collection.
+3. Compute a **selection weight** for each vocabulary word:
    - If the word has existing stats: `weight = word_stats.failureRatio`
    - If the word has no stats (never practiced): `weight = settings.config.defaultFailureRatio` (from the `settings` collection)
-6. Sample `settings.config.wordCount` words from the vocabulary using **weighted random sampling without replacement** (see [Word Selection Algorithm](#word-selection-algorithm)).
-7. Create a session document with `status = "active"` and a `payload` containing the selected `words`, `totalWords = settings.config.wordCount`, and `answers = []`.
-8. Return the session.
+4. Sample `settings.config.wordCount` words from the vocabulary using **weighted random sampling without replacement** (see [Item Selection Algorithm](#item-selection-algorithm)).
+5. Create a session document with `status = "active"` and a `payload` containing the selected `words`, `totalWords = settings.config.wordCount`, and `answers = []`.
+6. Return the session.
+
+##### For `practiceType = "sentences"`:
+
+1. Load all sentences for the given language from the `sentences` collection.
+2. Load all `sentence_stats` documents for the user + language from the `sentence_stats` collection.
+3. Compute a **selection weight** for each sentence:
+   - If the sentence has existing stats: `weight = sentence_stats.failureRatio`
+   - If the sentence has no stats (never practiced): `weight = settings.config.defaultFailureRatio` (from the `settings` collection)
+4. Sample `settings.config.sentenceCount` sentences using **weighted random sampling without replacement** (same algorithm as vocabulary).
+5. Create a session document with `status = "active"` and a `payload` containing the selected `sentences`, `totalSentences = settings.config.sentenceCount`, and `answers = []`.
+6. Return the session.
 
 #### Response — `201 Created`
+
+**For `practiceType = "vocabulary"`:**
 
 ```json
 {
@@ -164,14 +233,31 @@ Starts a new practice session for the authenticated user.
 }
 ```
 
+**For `practiceType = "sentences"`:**
+
+```json
+{
+  "sessionId": "664abc123def456789abcdef",
+  "language": "danish",
+  "practiceType": "sentences",
+  "payload": {
+    "sentences": [
+      { "sentenceId": "664abc123def456789aaaaaa", "sentence": "Jeg kan godt lide at læse.", "translation": "I like to read." },
+      { "sentenceId": "664abc123def456789bbbbbb", "sentence": "Hun bor i København.", "translation": "She lives in Copenhagen." }
+    ],
+    "totalSentences": 5
+  }
+}
+```
+
 #### Error Cases
 
 | Condition                                | Status | Description                                         |
 |------------------------------------------|--------|-----------------------------------------------------|
 | Unsupported `language`                   | `400`  | Language is not in the supported list               |
-| Unknown or unsupported `practiceType`    | `400`  | Only `"vocabulary"` is currently supported          |
+| Unknown or unsupported `practiceType`    | `400`  | Must be `"vocabulary"` or `"sentences"`             |
 | User already has an active session       | `409`  | Caller should resume or complete the existing session |
-| Fewer words in vocabulary than `settings.config.wordCount` | `400` | Not enough words to start a session — indicates the vocabulary needs to be populated first |
+| Fewer items than configured session count | `400` | Not enough words/sentences to start a session       |
 
 ---
 
@@ -185,7 +271,7 @@ Query the `sessions` collection for a document matching `{ userId, status: "acti
 
 #### Response — `200 OK`
 
-Same structure as the `StartSession` response.
+Same structure as the `StartSession` response. The `practiceType` field in the response indicates whether the active session is a vocabulary or sentences session — the frontend uses this to determine which practice page to navigate to on resume.
 
 ```json
 {
@@ -211,7 +297,7 @@ Same structure as the `StartSession` response.
 
 ### POST `/sessions/:sessionId/answers` — SubmitAnswer
 
-Records a single answer for a word within the session. Called by the frontend each time the user submits a translation attempt (correct or incorrect). Multiple answers for the same word are allowed (the word may be retried after an incorrect answer).
+Records a single answer for an item within the session. Called by the frontend each time the user submits a translation attempt (correct or incorrect). Multiple answers for the same item are allowed (items answered incorrectly are retried).
 
 #### Path Parameters
 
@@ -228,16 +314,16 @@ Records a single answer for a word within the session. Called by the frontend ea
 }
 ```
 
-| Field       | Required | Description                                                                    |
-|-------------|----------|--------------------------------------------------------------------------------|
-| `entityId`  | Yes      | The ID of the item being answered. For vocabulary sessions, this is a `wordId` |
-| `isCorrect` | Yes      | Whether the answer was correct                                                 |
+| Field       | Required | Description                                                                                             |
+|-------------|----------|---------------------------------------------------------------------------------------------------------|
+| `entityId`  | Yes      | The ID of the item being answered. For vocabulary sessions, a `wordId`; for sentences sessions, a `sentenceId`. |
+| `isCorrect` | Yes      | Whether the answer was correct                                                                          |
 
 #### Behaviour
 
 1. Load the session by `sessionId`.
 2. Validate: session must exist, belong to the authenticated user, and be `"active"`.
-3. Validate: `entityId` must match the `wordId` of an entry in `session.payload.words`.
+3. Validate: for `practiceType = "vocabulary"`, `entityId` must match a `wordId` in `session.payload.words`; for `practiceType = "sentences"`, `entityId` must match a `sentenceId` in `session.payload.sentences`.
 4. Append `{ entityId, isCorrect, submittedAt: now() }` to `session.payload.answers`.
 
 #### Response — `200 OK`
@@ -259,7 +345,7 @@ Records a single answer for a word within the session. Called by the frontend ea
 
 ### POST `/sessions/:sessionId/completion` — CompleteSession
 
-Marks the session as completed and updates word statistics for all words in the session.
+Marks the session as completed and updates statistics for all items in the session.
 
 #### Path Parameters
 
@@ -275,10 +361,14 @@ Marks the session as completed and updates word statistics for all words in the 
 
 1. Load the session by `sessionId`.
 2. Validate: session must exist, belong to the authenticated user, and be `"active"`.
+3. Dispatch to the appropriate type-specific handler based on `session.practiceType`:
+
+##### For `practiceType = "vocabulary"`:
+
 3. For each word in `session.payload.words`, compute from `session.payload.answers`:
    - `sessionAttempts` = number of answer entries where `entityId === word.wordId`
    - `sessionFailures` = number of incorrect answers where `entityId === word.wordId`
-   - `firstAttemptCorrect` = `true` if the first answer entry for this `wordId` is correct (i.e. `sessionFailures === 0`)
+   - `firstAttemptCorrect` = `true` if the first answer entry for this `wordId` is correct
 4. Upsert a `word_stats` document for each `(userId, wordId)` pair:
    - `totalAttempts += sessionAttempts`
    - `totalFailures += sessionFailures`
@@ -286,9 +376,26 @@ Marks the session as completed and updates word statistics for all words in the 
    - `lastPracticed = now()`
    - `updatedAt = now()`
 5. Mark the session: `status = "completed"`, `completedAt = now()`.
-6. Return the session summary.
+6. Return the session summary (see response below).
+
+##### For `practiceType = "sentences"`:
+
+3. For each sentence in `session.payload.sentences`, compute from `session.payload.answers`:
+   - `sessionAttempts` = number of answer entries where `entityId === sentence.sentenceId`
+   - `sessionFailures` = number of incorrect answers where `entityId === sentence.sentenceId`
+   - `firstAttemptCorrect` = `true` if the first answer entry for this `sentenceId` is correct
+4. Upsert a `sentence_stats` document for each `(userId, sentenceId)` pair:
+   - `totalAttempts += sessionAttempts`
+   - `totalFailures += sessionFailures`
+   - `failureRatio = newTotalFailures / newTotalAttempts`
+   - `lastPracticed = now()`
+   - `updatedAt = now()`
+5. Mark the session: `status = "completed"`, `completedAt = now()`.
+6. Return the session summary (see response below).
 
 #### Response — `200 OK`
+
+**For `practiceType = "vocabulary"`:**
 
 ```json
 {
@@ -319,6 +426,37 @@ Marks the session as completed and updates word statistics for all words in the 
 | `accuracy`             | `round(firstAttemptCorrect / totalWords * 100)` (integer %)    |
 | `wordResults`          | Per-word result, including total failed attempts in this session |
 
+**For `practiceType = "sentences"`:**
+
+```json
+{
+  "totalSentences": 5,
+  "firstAttemptCorrect": 3,
+  "accuracy": 60,
+  "sentenceResults": [
+    {
+      "sentenceId": "664abc123def456789aaaaaa",
+      "sentence": "Jeg kan godt lide at læse.",
+      "translation": "I like to read.",
+      "failedAttempts": 0
+    },
+    {
+      "sentenceId": "664abc123def456789bbbbbb",
+      "sentence": "Hun bor i København.",
+      "translation": "She lives in Copenhagen.",
+      "failedAttempts": 2
+    }
+  ]
+}
+```
+
+| Field                  | Description                                                         |
+|------------------------|---------------------------------------------------------------------|
+| `totalSentences`       | Total number of sentences in the session                            |
+| `firstAttemptCorrect`  | Number of sentences answered correctly on the very first attempt    |
+| `accuracy`             | `round(firstAttemptCorrect / totalSentences * 100)` (integer %)    |
+| `sentenceResults`      | Per-sentence result, including total failed attempts in this session |
+
 #### Error Cases
 
 | Condition                              | Status | Description                                    |
@@ -329,23 +467,23 @@ Marks the session as completed and updates word statistics for all words in the 
 
 ---
 
-## Word Selection Algorithm
+## Item Selection Algorithm
 
-The goal is to select `settings.config.wordCount` words from the vocabulary such that words the user struggles with most (high failure ratio) are selected with higher probability.
+The same weighted random sampling algorithm is used for both vocabulary and sentences sessions. The goal is to preferentially select items the user struggles with most (high failure ratio).
 
 ### Steps
 
-1. Build a weight list: for each vocabulary word, assign `weight = failureRatio` if stats exist, else `weight = settings.config.defaultFailureRatio`.
-2. Apply **weighted random sampling without replacement**: each word's probability of being selected at each draw is proportional to its weight relative to the remaining candidates.
-3. A practical implementation is the **exponential-key method** (Efraimidis-Spirakis): assign each word a key `k = -log(U) / weight` where `U` is drawn from `Uniform(0, 1)`, then select the `settings.config.wordCount` words with the lowest `k` values. This is efficient and avoids iterative re-normalisation.
+1. Build a weight list: for each item, assign `weight = failureRatio` if stats exist, else `weight = settings.config.defaultFailureRatio`.
+2. Apply **weighted random sampling without replacement**: each item's probability of being selected at each draw is proportional to its weight relative to the remaining candidates.
+3. A practical implementation is the **exponential-key method** (Efraimidis-Spirakis): assign each item a key `k = -log(U) / weight` where `U` is drawn from `Uniform(0, 1)`, then select the configured count of items with the lowest `k` values. This is efficient and avoids iterative re-normalisation.
 
 ### Edge Cases
 
 | Condition | Handling |
 |-----------|----------|
-| All words have `failureRatio = 0` | All weights equal `0`. Fall back to uniform random sampling (equal probability for all words). |
-| A word has `totalAttempts > 0` and `failureRatio = 0` (always answered correctly) | Weight = `0`. Such words are effectively excluded from weighted selection; they may still appear via the fallback uniform round if needed to fill the session. |
-| Fewer vocabulary words than `settings.config.wordCount` | Return `400` — session cannot be started. |
+| All items have `failureRatio = 0` | All weights equal `0`. Fall back to uniform random sampling (equal probability for all items). |
+| An item has `totalAttempts > 0` and `failureRatio = 0` (always answered correctly) | Weight = `0`. Such items are effectively excluded from weighted selection; they may still appear via the fallback uniform round if needed to fill the session. |
+| Fewer items than the configured session count | Return `400` — session cannot be started. |
 
 ---
 
@@ -376,6 +514,15 @@ Each document represents the settings for one practice type:
 
 If no settings document exists for `"vocabulary"`, the service falls back to the above defaults.
 
+### Sentences Settings (`practiceType = "sentences"`)
+
+| Setting                  | Default | Description                                                                  |
+|--------------------------|---------|------------------------------------------------------------------------------|
+| `config.sentenceCount`   | `5`     | Number of sentences selected per session                                     |
+| `config.defaultFailureRatio` | `0.5` | Weight assigned to sentences with no prior practice history              |
+
+If no settings document exists for `"sentences"`, the service falls back to the above defaults.
+
 **Note**: The `SettingsStore.getOrDefault()` method centralises this fallback behaviour — no defaults are scattered through delegates.
 
 ---
@@ -383,26 +530,16 @@ If no settings document exists for `"vocabulary"`, the service falls back to the
 ## Business Rules
 
 1. **One active session per user**: A user may not start a new session while one is active. The frontend must call `CompleteSession` (or the user must abandon and the session eventually cleaned up) before starting a new one.
-2. **Answer accumulation, not replacement**: Multiple answers for the same `wordId` within a session are all stored. The full history is needed to accurately compute `firstAttemptCorrect` and `failedAttempts`.
-3. **Stats updated only at session completion**: `word_stats` is not updated incrementally during a session. Stats are updated atomically (as a batch) when `CompleteSession` is called. This simplifies rollback scenarios and avoids partial updates.
-4. **`failureRatio` pre-computed**: `failureRatio` is stored as a pre-computed field on each `word_stats` document and updated at `CompleteSession` time. This avoids computing it at query time when loading words for a new session.
-5. **Entity ownership check in SubmitAnswer**: The backend validates that the submitted `entityId` belongs to the session's item list (i.e. it is a `wordId` present in `session.payload.words`). This prevents stale frontend state from writing incorrect answer records.
+2. **Answer accumulation, not replacement**: Multiple answers for the same `entityId` within a session are all stored. The full history is needed to accurately compute `firstAttemptCorrect` and `failedAttempts`.
+3. **Stats updated only at session completion**: `word_stats` and `sentence_stats` are not updated incrementally during a session. Stats are updated atomically (as a batch) when `CompleteSession` is called. This simplifies rollback scenarios and avoids partial updates.
+4. **`failureRatio` pre-computed**: `failureRatio` is stored as a pre-computed field on each stats document and updated at `CompleteSession` time. This avoids computing it at query time when loading items for a new session.
+5. **Entity ownership check in SubmitAnswer**: The backend validates that the submitted `entityId` belongs to the session's item list. This prevents stale frontend state from writing incorrect answer records.
 
 ---
 
 ## Extending to New Practice Types
 
 When adding a new `practiceType`, define a dedicated `payload` shape and document it in a separate spec. The generic session header fields (`userId`, `language`, `practiceType`, `status`, `createdAt`, `completedAt`) remain unchanged across all practice types.
-
-For example, a future `"grammar"` session might define its payload as:
-
-```json
-{
-  "sentences": [ { "sentenceId": "...", "prompt": "...", "answer": "..." } ],
-  "totalSentences": 5,
-  "answers": [ { "entityId": "...", "isCorrect": true, "submittedAt": "..." } ]
-}
-```
 
 The `StartSession`, `GetActiveSession`, `SubmitAnswer`, and `CompleteSession` endpoints are shared across all practice types. Where a new type requires different business logic (item selection, stats tracking, summary computation), that logic is encapsulated in type-specific handlers within each delegate — selected by a `switch` on `practiceType`.
 
@@ -413,5 +550,4 @@ The `StartSession`, `GetActiveSession`, `SubmitAnswer`, and `CompleteSession` en
 - Session expiry / auto-cleanup of abandoned sessions (future work).
 - Practitioner-defined session size (the size is fixed by server config).
 - Leaderboards, global statistics, or cross-user comparisons.
-- Practice types other than `"vocabulary"` (the architecture supports them, but they are not defined here).
 - Re-opening a completed session.

--- a/docs/specs/sentence-management.md
+++ b/docs/specs/sentence-management.md
@@ -259,5 +259,4 @@ The sample is **random** — there is no ordering guarantee. Each call may retur
 - Pagination of `GetSentences` results.
 - Filtering sentences by `knowledgeSource`.
 - Soft deletes.
-- Sentence practice / flashcard sessions (may be specified separately).
 - Audio pronunciation or TTS for sentences.

--- a/src/dlg/session/CompleteSession.ts
+++ b/src/dlg/session/CompleteSession.ts
@@ -1,6 +1,8 @@
 import { Request } from "express";
 import { TotoDelegate, UserContext, ValidationError } from "totoms";
 import { ControllerConfig } from "../../Config";
+import { SentenceSessionPayload, VocabularySessionPayload } from "../../model/Session";
+import { SentenceStatsStore } from "../../store/SentenceStatsStore";
 import { SessionsStore } from "../../store/SessionsStore";
 import { WordStatsStore } from "../../store/WordStatsStore";
 
@@ -24,47 +26,95 @@ export class CompleteSession extends TotoDelegate<CompleteSessionRequest, Comple
 
         const now = new Date().toISOString();
 
-        // Compute per-word answer stats from the session answer history
-        const wordStats = session.payload.words.map(word => {
-            const wordAnswers = session.payload.answers.filter(a => a.entityId === word.wordId);
+        if (session.practiceType === "vocabulary") {
+            const vocabPayload = session.payload as VocabularySessionPayload;
+
+            const wordStats = vocabPayload.words.map(word => {
+                const wordAnswers = vocabPayload.answers.filter(a => a.entityId === word.wordId);
+                return {
+                    wordId: word.wordId,
+                    sessionAttempts: wordAnswers.length,
+                    sessionFailures: wordAnswers.filter(a => !a.isCorrect).length,
+                    firstAttemptCorrect: wordAnswers.length > 0 && wordAnswers[0].isCorrect,
+                };
+            });
+
+            const wordStatsStore = new WordStatsStore({ db, config });
+            await wordStatsStore.upsertBatch({
+                statsList: wordStats.map(ws => ({
+                    userId,
+                    wordId: ws.wordId,
+                    language: session.language,
+                    sessionAttempts: ws.sessionAttempts,
+                    sessionFailures: ws.sessionFailures,
+                    lastPracticed: now,
+                })),
+            });
+
+            await sessionsStore.completeSession({ sessionId: req.sessionId });
+
+            const firstAttemptCorrectCount = wordStats.filter(ws => ws.firstAttemptCorrect).length;
+            const totalWords = vocabPayload.words.length;
+
             return {
-                wordId: word.wordId,
-                sessionAttempts: wordAnswers.length,
-                sessionFailures: wordAnswers.filter(a => !a.isCorrect).length,
-                firstAttemptCorrect: wordAnswers.length > 0 && wordAnswers[0].isCorrect,
+                practiceType: "vocabulary",
+                totalWords,
+                firstAttemptCorrect: firstAttemptCorrectCount,
+                accuracy: Math.round((firstAttemptCorrectCount / totalWords) * 100),
+                wordResults: vocabPayload.words.map(word => {
+                    const ws = wordStats.find(s => s.wordId === word.wordId)!;
+                    return {
+                        wordId: word.wordId,
+                        english: word.english,
+                        translation: word.translation,
+                        failedAttempts: ws.sessionFailures,
+                    };
+                }),
+            };
+        }
+
+        // sentences branch
+        const sentencePayload = session.payload as SentenceSessionPayload;
+
+        const sentenceStats = sentencePayload.sentences.map(s => {
+            const sentenceAnswers = sentencePayload.answers.filter(a => a.entityId === s.sentenceId);
+            return {
+                sentenceId: s.sentenceId,
+                sessionAttempts: sentenceAnswers.length,
+                sessionFailures: sentenceAnswers.filter(a => !a.isCorrect).length,
+                firstAttemptCorrect: sentenceAnswers.length > 0 && sentenceAnswers[0].isCorrect,
             };
         });
 
-        // Upsert word_stats BEFORE marking the session completed so a stats
-        // failure leaves the session active and the caller can retry
-        const wordStatsStore = new WordStatsStore({ db, config });
-        await wordStatsStore.upsertBatch({
-            statsList: wordStats.map(ws => ({
+        const sentenceStatsStore = new SentenceStatsStore({ db, config });
+        await sentenceStatsStore.upsertBatch({
+            statsList: sentenceStats.map(ss => ({
                 userId,
-                wordId: ws.wordId,
+                sentenceId: ss.sentenceId,
                 language: session.language,
-                sessionAttempts: ws.sessionAttempts,
-                sessionFailures: ws.sessionFailures,
+                sessionAttempts: ss.sessionAttempts,
+                sessionFailures: ss.sessionFailures,
                 lastPracticed: now,
             })),
         });
 
         await sessionsStore.completeSession({ sessionId: req.sessionId });
 
-        const firstAttemptCorrectCount = wordStats.filter(ws => ws.firstAttemptCorrect).length;
-        const totalWords = session.payload.words.length;
+        const firstAttemptCorrectCount = sentenceStats.filter(ss => ss.firstAttemptCorrect).length;
+        const totalSentences = sentencePayload.sentences.length;
 
         return {
-            totalWords,
+            practiceType: "sentences",
+            totalSentences,
             firstAttemptCorrect: firstAttemptCorrectCount,
-            accuracy: Math.round((firstAttemptCorrectCount / totalWords) * 100),
-            wordResults: session.payload.words.map(word => {
-                const ws = wordStats.find(s => s.wordId === word.wordId)!;
+            accuracy: Math.round((firstAttemptCorrectCount / totalSentences) * 100),
+            sentenceResults: sentencePayload.sentences.map(s => {
+                const ss = sentenceStats.find(stat => stat.sentenceId === s.sentenceId)!;
                 return {
-                    wordId: word.wordId,
-                    english: word.english,
-                    translation: word.translation,
-                    failedAttempts: ws.sessionFailures,
+                    sentenceId: s.sentenceId,
+                    sentence: s.sentence,
+                    translation: s.translation,
+                    failedAttempts: ss.sessionFailures,
                 };
             }),
         };
@@ -76,13 +126,24 @@ interface CompleteSessionRequest {
 }
 
 interface CompleteSessionResponse {
-    totalWords: number;
-    firstAttemptCorrect: number;
-    accuracy: number;
-    wordResults: Array<{
+    practiceType: string;
+    // vocabulary fields
+    totalWords?: number;
+    wordResults?: Array<{
         wordId: string;
         english: string;
         translation: string;
         failedAttempts: number;
     }>;
+    // sentences fields
+    totalSentences?: number;
+    sentenceResults?: Array<{
+        sentenceId: string;
+        sentence: string;
+        translation: string;
+        failedAttempts: number;
+    }>;
+    // common
+    firstAttemptCorrect: number;
+    accuracy: number;
 }

--- a/src/dlg/session/GetActiveSession.ts
+++ b/src/dlg/session/GetActiveSession.ts
@@ -1,6 +1,7 @@
 import { Request } from "express";
 import { TotoDelegate, UserContext, ValidationError } from "totoms";
 import { ControllerConfig } from "../../Config";
+import { SentenceSessionPayload, VocabularySessionPayload } from "../../model/Session";
 import { SessionsStore } from "../../store/SessionsStore";
 
 export class GetActiveSession extends TotoDelegate<GetActiveSessionRequest, GetActiveSessionResponse> {
@@ -19,13 +20,28 @@ export class GetActiveSession extends TotoDelegate<GetActiveSessionRequest, GetA
 
         if (!session) throw new ValidationError(404, "No active session found");
 
+        if (session.practiceType === "vocabulary") {
+            const vocabPayload = session.payload as VocabularySessionPayload;
+            return {
+                sessionId: session.id!,
+                language: session.language,
+                practiceType: session.practiceType,
+                payload: {
+                    words: vocabPayload.words,
+                    totalWords: vocabPayload.totalWords,
+                },
+            };
+        }
+
+        // sentences
+        const sentencePayload = session.payload as SentenceSessionPayload;
         return {
             sessionId: session.id!,
             language: session.language,
             practiceType: session.practiceType,
             payload: {
-                words: session.payload.words,
-                totalWords: session.payload.totalWords,
+                sentences: sentencePayload.sentences,
+                totalSentences: sentencePayload.totalSentences,
             },
         };
     }
@@ -38,7 +54,9 @@ interface GetActiveSessionResponse {
     language: string;
     practiceType: string;
     payload: {
-        words: Array<{ wordId: string; english: string; translation: string }>;
-        totalWords: number;
+        words?: Array<{ wordId: string; english: string; translation: string }>;
+        totalWords?: number;
+        sentences?: Array<{ sentenceId: string; sentence: string; translation: string }>;
+        totalSentences?: number;
     };
 }

--- a/src/dlg/session/StartSession.ts
+++ b/src/dlg/session/StartSession.ts
@@ -1,13 +1,16 @@
 import { Request } from "express";
 import { TotoDelegate, UserContext, ValidationError } from "totoms";
 import { ControllerConfig } from "../../Config";
-import { Session, VocabularySessionPayload } from "../../model/Session";
+import { SentenceSessionPayload, Session, VocabularySessionPayload } from "../../model/Session";
+import { SentenceStatsStore } from "../../store/SentenceStatsStore";
 import { SessionsStore } from "../../store/SessionsStore";
 import { SettingsStore } from "../../store/SettingsStore";
 import { VocabularyStore } from "../../store/VocabularyStore";
 import { WordStatsStore } from "../../store/WordStatsStore";
 import { SUPPORTED_LANGUAGES } from "../../util/Languages";
 import { weightedSample } from "../../util/WeightedSampler";
+import { SentenceStore } from "../../store/SentenceStore";
+import { SentencePracticeConfig, VocabularyPracticeConfig } from "../../model/PracticeSettings";
 
 export class StartSession extends TotoDelegate<StartSessionRequest, StartSessionResponse> {
 
@@ -18,7 +21,9 @@ export class StartSession extends TotoDelegate<StartSessionRequest, StartSession
         }
         const practiceType = req.body?.practiceType;
         if (!practiceType) throw new ValidationError(400, "No practiceType provided");
-        if (practiceType !== "vocabulary") throw new ValidationError(400, `Unsupported practiceType: ${practiceType}`);
+        if (practiceType !== "vocabulary" && practiceType !== "sentences") {
+            throw new ValidationError(400, `Unsupported practiceType: ${practiceType}`);
+        }
         return { language, practiceType };
     }
 
@@ -33,29 +38,79 @@ export class StartSession extends TotoDelegate<StartSessionRequest, StartSession
         if (existing) throw new ValidationError(409, "User already has an active session");
 
         const settingsStore = new SettingsStore({ db, config });
-        const practiceSettings = await settingsStore.getOrDefault({ practiceType: "vocabulary" });
-        const wordCount = (practiceSettings.config as { wordCount: number }).wordCount;
-        const defaultFailureRatio = (practiceSettings.config as { defaultFailureRatio: number }).defaultFailureRatio;
 
-        const vocabularyStore = new VocabularyStore(db, config);
-        const allWords = await vocabularyStore.findByLanguage(req.language);
-        if (allWords.length < wordCount) {
-            throw new ValidationError(400, `Not enough words in vocabulary: ${allWords.length} available, ${wordCount} required`);
+        if (req.practiceType === "vocabulary") {
+            const practiceSettings = await settingsStore.getOrDefault({ practiceType: "vocabulary" });
+            const { wordCount, defaultFailureRatio } = practiceSettings.config as VocabularyPracticeConfig;
+
+            const vocabularyStore = new VocabularyStore(db, config);
+            const allWords = await vocabularyStore.findByLanguage(req.language);
+            if (allWords.length < wordCount) {
+                throw new ValidationError(400, `Not enough words in vocabulary: ${allWords.length} available, ${wordCount} required`);
+            }
+
+            const wordStatsStore = new WordStatsStore({ db, config });
+            const statsList = await wordStatsStore.findByUserAndLanguage({ userId, language: req.language });
+            const statsMap = new Map(statsList.map(s => [s.wordId, s.failureRatio]));
+
+            const selectedWords = weightedSample(
+                allWords,
+                word => statsMap.has(word.id!) ? statsMap.get(word.id!)! : defaultFailureRatio,
+                wordCount
+            );
+
+            const payload: VocabularySessionPayload = {
+                words: selectedWords.map(w => ({ wordId: w.id!, english: w.english, translation: w.translation })),
+                totalWords: selectedWords.length,
+                answers: [],
+            };
+
+            const session = new Session({
+                userId,
+                language: req.language,
+                practiceType: req.practiceType,
+                status: "active",
+                payload,
+                createdAt: new Date().toISOString(),
+                completedAt: null,
+            });
+
+            const sessionId = await sessionsStore.createSession({ session });
+
+            return {
+                sessionId,
+                language: req.language,
+                practiceType: req.practiceType,
+                payload: {
+                    words: payload.words,
+                    totalWords: payload.totalWords,
+                },
+            };
         }
 
-        const wordStatsStore = new WordStatsStore({ db, config });
-        const statsList = await wordStatsStore.findByUserAndLanguage({ userId, language: req.language });
-        const statsMap = new Map(statsList.map(s => [s.wordId, s.failureRatio]));
+        // sentences branch
+        const practiceSettings = await settingsStore.getOrDefault({ practiceType: "sentences" });
+        const { sentenceCount, defaultFailureRatio } = practiceSettings.config as SentencePracticeConfig;
 
-        const selectedWords = weightedSample(
-            allWords,
-            word => statsMap.has(word.id!) ? statsMap.get(word.id!)! : defaultFailureRatio,
-            wordCount
+        const sentenceStore = new SentenceStore(db, config);
+        const allSentences = await sentenceStore.findByLanguage(req.language);
+        if (allSentences.length < sentenceCount) {
+            throw new ValidationError(400, `Not enough sentences: ${allSentences.length} available, ${sentenceCount} required`);
+        }
+
+        const sentenceStatsStore = new SentenceStatsStore({ db, config });
+        const statsList = await sentenceStatsStore.findByUserAndLanguage({ userId, language: req.language });
+        const statsMap = new Map(statsList.map(s => [s.sentenceId, s.failureRatio]));
+
+        const selectedSentences = weightedSample(
+            allSentences,
+            s => statsMap.has(s.id!) ? statsMap.get(s.id!)! : defaultFailureRatio,
+            sentenceCount
         );
 
-        const payload: VocabularySessionPayload = {
-            words: selectedWords.map(w => ({ wordId: w.id!, english: w.english, translation: w.translation })),
-            totalWords: selectedWords.length,
+        const payload: SentenceSessionPayload = {
+            sentences: selectedSentences.map(s => ({ sentenceId: s.id!, sentence: s.sentence, translation: s.translation })),
+            totalSentences: selectedSentences.length,
             answers: [],
         };
 
@@ -76,8 +131,8 @@ export class StartSession extends TotoDelegate<StartSessionRequest, StartSession
             language: req.language,
             practiceType: req.practiceType,
             payload: {
-                words: payload.words,
-                totalWords: payload.totalWords,
+                sentences: payload.sentences,
+                totalSentences: payload.totalSentences,
             },
         };
     }
@@ -93,7 +148,11 @@ interface StartSessionResponse {
     language: string;
     practiceType: string;
     payload: {
-        words: Array<{ wordId: string; english: string; translation: string }>;
-        totalWords: number;
+        // vocabulary
+        words?: Array<{ wordId: string; english: string; translation: string }>;
+        totalWords?: number;
+        // sentences
+        sentences?: Array<{ sentenceId: string; sentence: string; translation: string }>;
+        totalSentences?: number;
     };
 }

--- a/src/dlg/session/SubmitAnswer.ts
+++ b/src/dlg/session/SubmitAnswer.ts
@@ -1,7 +1,7 @@
 import { Request } from "express";
 import { TotoDelegate, UserContext, ValidationError } from "totoms";
 import { ControllerConfig } from "../../Config";
-import { SessionAnswer } from "../../model/Session";
+import { SentenceSessionPayload, SessionAnswer, VocabularySessionPayload } from "../../model/Session";
 import { SessionsStore } from "../../store/SessionsStore";
 
 export class SubmitAnswer extends TotoDelegate<SubmitAnswerRequest, SubmitAnswerResponse> {
@@ -26,8 +26,17 @@ export class SubmitAnswer extends TotoDelegate<SubmitAnswerRequest, SubmitAnswer
         if (session.userId !== userId) throw new ValidationError(403, "Session does not belong to the authenticated user");
         if (session.status === "completed") throw new ValidationError(400, "Session is already completed");
 
-        const wordExists = session.payload.words.some(w => w.wordId === req.entityId);
-        if (!wordExists) throw new ValidationError(400, `entityId ${req.entityId} is not part of this session`);
+        if (session.practiceType === "vocabulary") {
+            const vocabPayload = session.payload as VocabularySessionPayload;
+            const wordExists = vocabPayload.words.some(w => w.wordId === req.entityId);
+            if (!wordExists) throw new ValidationError(400, `entityId ${req.entityId} is not part of this session`);
+        } else if (session.practiceType === "sentences") {
+            const sentencePayload = session.payload as SentenceSessionPayload;
+            const sentenceExists = sentencePayload.sentences.some(s => s.sentenceId === req.entityId);
+            if (!sentenceExists) throw new ValidationError(400, `entityId ${req.entityId} is not part of this session`);
+        } else {
+            throw new ValidationError(400, `Unsupported practiceType: ${session.practiceType}`);
+        }
 
         const answer: SessionAnswer = {
             entityId: req.entityId,

--- a/src/model/PracticeSettings.ts
+++ b/src/model/PracticeSettings.ts
@@ -1,15 +1,18 @@
 import { WithId } from "mongodb";
 
-export type PracticeType = "vocabulary";
+export type PracticeType = "vocabulary" | "sentences";
 
 export interface VocabularyPracticeConfig {
     wordCount: number;
     defaultFailureRatio: number;
 }
 
-// When new practice types are added, extend this union:
-// export type PracticeConfig = VocabularyPracticeConfig | NewTypePracticeConfig;
-export type PracticeConfig = VocabularyPracticeConfig;
+export interface SentencePracticeConfig {
+    sentenceCount: number;
+    defaultFailureRatio: number;
+}
+
+export type PracticeConfig = VocabularyPracticeConfig | SentencePracticeConfig;
 
 export class PracticeSettings {
 
@@ -39,6 +42,20 @@ export class PracticeSettings {
             }
 
             return new PracticeSettings({ practiceType, config: { wordCount, defaultFailureRatio } });
+        }
+
+        if (practiceType === "sentences") {
+            const sentenceCount = config.sentenceCount;
+            const defaultFailureRatio = config.defaultFailureRatio;
+
+            if (typeof sentenceCount !== "number" || !Number.isInteger(sentenceCount) || sentenceCount <= 0) {
+                throw new Error(`PracticeSettings: invalid sentenceCount: ${sentenceCount}`);
+            }
+            if (typeof defaultFailureRatio !== "number" || !isFinite(defaultFailureRatio) || defaultFailureRatio < 0 || defaultFailureRatio > 1) {
+                throw new Error(`PracticeSettings: invalid defaultFailureRatio: ${defaultFailureRatio}`);
+            }
+
+            return new PracticeSettings({ practiceType, config: { sentenceCount, defaultFailureRatio } });
         }
 
         throw new Error(`PracticeSettings: unsupported practiceType: ${practiceType}`);

--- a/src/model/SentenceStats.ts
+++ b/src/model/SentenceStats.ts
@@ -1,0 +1,63 @@
+import { WithId } from "mongodb";
+
+export class SentenceStats {
+
+    id?: string;
+    userId: string;
+    sentenceId: string;
+    language: string;
+    totalAttempts: number;
+    totalFailures: number;
+    failureRatio: number;
+    lastPracticed: string;
+    updatedAt: string;
+
+    constructor({ id, userId, sentenceId, language, totalAttempts, totalFailures, failureRatio, lastPracticed, updatedAt }: {
+        id?: string;
+        userId: string;
+        sentenceId: string;
+        language: string;
+        totalAttempts: number;
+        totalFailures: number;
+        failureRatio: number;
+        lastPracticed: string;
+        updatedAt: string;
+    }) {
+        this.id = id;
+        this.userId = userId;
+        this.sentenceId = sentenceId;
+        this.language = language;
+        this.totalAttempts = totalAttempts;
+        this.totalFailures = totalFailures;
+        this.failureRatio = failureRatio;
+        this.lastPracticed = lastPracticed;
+        this.updatedAt = updatedAt;
+    }
+
+    static fromBSON(data: WithId<any>): SentenceStats {
+        return new SentenceStats({
+            id: data._id.toString(),
+            userId: data.userId,
+            sentenceId: data.sentenceId,
+            language: data.language,
+            totalAttempts: data.totalAttempts,
+            totalFailures: data.totalFailures,
+            failureRatio: data.failureRatio,
+            lastPracticed: data.lastPracticed,
+            updatedAt: data.updatedAt,
+        });
+    }
+
+    toBSON(): any {
+        return {
+            userId: this.userId,
+            sentenceId: this.sentenceId,
+            language: this.language,
+            totalAttempts: this.totalAttempts,
+            totalFailures: this.totalFailures,
+            failureRatio: this.failureRatio,
+            lastPracticed: this.lastPracticed,
+            updatedAt: this.updatedAt,
+        };
+    }
+}

--- a/src/model/Session.ts
+++ b/src/model/Session.ts
@@ -6,6 +6,12 @@ export interface SessionWord {
     translation: string;
 }
 
+export interface SessionSentence {
+    sentenceId: string;
+    sentence: string;
+    translation: string;
+}
+
 export interface SessionAnswer {
     entityId: string;
     isCorrect: boolean;
@@ -18,6 +24,14 @@ export interface VocabularySessionPayload {
     answers: SessionAnswer[];
 }
 
+export interface SentenceSessionPayload {
+    sentences: SessionSentence[];
+    totalSentences: number;
+    answers: SessionAnswer[];
+}
+
+export type SessionPayload = VocabularySessionPayload | SentenceSessionPayload;
+
 export class Session {
 
     id?: string;
@@ -25,7 +39,7 @@ export class Session {
     language: string;
     practiceType: string;
     status: string;
-    payload: VocabularySessionPayload;
+    payload: SessionPayload;
     createdAt: string;
     completedAt: string | null;
 
@@ -35,7 +49,7 @@ export class Session {
         language: string;
         practiceType: string;
         status: string;
-        payload: VocabularySessionPayload;
+        payload: SessionPayload;
         createdAt: string;
         completedAt: string | null;
     }) {

--- a/src/store/SentenceStatsStore.ts
+++ b/src/store/SentenceStatsStore.ts
@@ -1,0 +1,70 @@
+import { Db } from "mongodb";
+import { ControllerConfig } from "../Config";
+import { SentenceStats } from "../model/SentenceStats";
+
+const SENTENCE_STATS_COLLECTION = "sentence_stats";
+
+export class SentenceStatsStore {
+
+    private db: Db;
+    private config: ControllerConfig;
+
+    constructor({ db, config }: { db: Db; config: ControllerConfig }) {
+        this.db = db;
+        this.config = config;
+    }
+
+    async findByUserAndLanguage({ userId, language }: { userId: string; language: string }): Promise<SentenceStats[]> {
+        const results = await this.db.collection(SENTENCE_STATS_COLLECTION).find({ userId, language }).toArray();
+        return results.map(doc => SentenceStats.fromBSON(doc as any));
+    }
+
+    /**
+     * Upserts sentence stats for a batch of sentences in a single bulkWrite.
+     * Uses an aggregation pipeline update to atomically increment counters
+     * and recompute failureRatio in one operation per sentence.
+     */
+    async upsertBatch({ statsList }: {
+        statsList: Array<{
+            userId: string;
+            sentenceId: string;
+            language: string;
+            sessionAttempts: number;
+            sessionFailures: number;
+            lastPracticed: string;
+        }>
+    }): Promise<void> {
+        if (statsList.length === 0) return;
+
+        const operations = statsList.map(stat => ({
+            updateOne: {
+                filter: { userId: stat.userId, sentenceId: stat.sentenceId },
+                update: [
+                    {
+                        $set: {
+                            language: stat.language,
+                            lastPracticed: stat.lastPracticed,
+                            updatedAt: stat.lastPracticed,
+                            totalAttempts: { $add: [{ $ifNull: ["$totalAttempts", 0] }, stat.sessionAttempts] },
+                            totalFailures: { $add: [{ $ifNull: ["$totalFailures", 0] }, stat.sessionFailures] },
+                        },
+                    },
+                    {
+                        $set: {
+                            failureRatio: {
+                                $cond: {
+                                    if: { $gt: ["$totalAttempts", 0] },
+                                    then: { $divide: ["$totalFailures", "$totalAttempts"] },
+                                    else: 0,
+                                },
+                            },
+                        },
+                    },
+                ],
+                upsert: true,
+            },
+        }));
+
+        await this.db.collection(SENTENCE_STATS_COLLECTION).bulkWrite(operations as any);
+    }
+}

--- a/src/store/SettingsStore.ts
+++ b/src/store/SettingsStore.ts
@@ -1,11 +1,12 @@
 import { Db } from "mongodb";
 import { ControllerConfig } from "../Config";
-import { PracticeSettings, PracticeType, VocabularyPracticeConfig } from "../model/PracticeSettings";
+import { PracticeConfig, PracticeSettings, PracticeType, SentencePracticeConfig, VocabularyPracticeConfig } from "../model/PracticeSettings";
 
 const SETTINGS_COLLECTION = "settings";
 
-const DEFAULTS: Record<PracticeType, VocabularyPracticeConfig> = {
-    vocabulary: { wordCount: 10, defaultFailureRatio: 0.5 },
+const DEFAULTS: Record<PracticeType, PracticeConfig> = {
+    vocabulary: { wordCount: 10, defaultFailureRatio: 0.5 } as VocabularyPracticeConfig,
+    sentences: { sentenceCount: 5, defaultFailureRatio: 0.5 } as SentencePracticeConfig,
 };
 
 export class SettingsStore {


### PR DESCRIPTION
## Summary

Implements full backend support for sentence practice sessions.

### New files
- SentenceStats model (mirrors WordStats using sentenceId)
- SentenceStatsStore (sentence_stats collection with weighted-sampling upsert)

### Updated files
- PracticeSettings: SentencePracticeConfig, PracticeType union extended to include sentences
- SettingsStore: adds sentences defaults (sentenceCount=5, defaultFailureRatio=0.5)
- Session model: adds SentenceSessionPayload and SessionPayload union type
- StartSession: dispatches on practiceType; sentences branch samples with weighted stats
- GetActiveSession: returns correct payload shape per practiceType
- SubmitAnswer: validates entityId against correct entity collection per practiceType
- CompleteSession: dispatches per type, upserts sentence_stats, returns typed results

Closes #18
Closes #19