### PR TITLE
feat: Expose vocabulary and sentences with per-user stats (Issue #20)

### DIFF
--- a/src/dlg/GetSentencesWithStats.ts
+++ b/src/dlg/GetSentencesWithStats.ts
@@ -1,0 +1,77 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../Config";
+import { SentenceStore, SentenceWithStats } from "../store/SentenceStore";
+import { SUPPORTED_LANGUAGES } from "../util/Languages";
+
+const DEFAULT_PAGE_SIZE = 100;
+
+export class GetSentencesWithStats extends TotoDelegate<GetSentencesWithStatsRequest, GetSentencesWithStatsResponse> {
+
+    parseRequest(req: Request): GetSentencesWithStatsRequest {
+        const language = req.params.language;
+        if (!SUPPORTED_LANGUAGES.includes(language)) {
+            throw new ValidationError(400, `Unsupported language: ${language}`);
+        }
+
+        const pageParam = req.query.page;
+        const pageSizeParam = req.query.pageSize;
+
+        let page = 1;
+        if (pageParam !== undefined) {
+            page = parseInt(pageParam as string, 10);
+            if (isNaN(page) || page < 1) {
+                throw new ValidationError(400, "page must be a positive integer");
+            }
+        }
+
+        let pageSize = DEFAULT_PAGE_SIZE;
+        if (pageSizeParam !== undefined) {
+            pageSize = parseInt(pageSizeParam as string, 10);
+            if (isNaN(pageSize) || pageSize < 1) {
+                throw new ValidationError(400, "pageSize must be a positive integer");
+            }
+        }
+
+        return { language, page, pageSize };
+    }
+
+    async do(req: GetSentencesWithStatsRequest, userContext?: UserContext): Promise<GetSentencesWithStatsResponse> {
+        if (!userContext?.email) {
+            throw new ValidationError(401, "Unauthorized: user context required");
+        }
+
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+
+        const store = new SentenceStore(db, config);
+        const result = await store.findByLanguageWithStats({
+            language: req.language,
+            userId: userContext.email,
+            page: req.page,
+            pageSize: req.pageSize
+        });
+
+        return {
+            language: req.language,
+            page: req.page,
+            pageSize: req.pageSize,
+            totalCount: result.totalCount,
+            sentences: result.sentences
+        };
+    }
+}
+
+interface GetSentencesWithStatsRequest {
+    language: string;
+    page: number;
+    pageSize: number;
+}
+
+interface GetSentencesWithStatsResponse {
+    language: string;
+    page: number;
+    pageSize: number;
+    totalCount: number;
+    sentences: SentenceWithStats[];
+}

--- a/src/dlg/GetVocabularyWithStats.ts
+++ b/src/dlg/GetVocabularyWithStats.ts
@@ -1,0 +1,77 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../Config";
+import { VocabularyStore, WordWithStats } from "../store/VocabularyStore";
+import { SUPPORTED_LANGUAGES } from "../util/Languages";
+
+const DEFAULT_PAGE_SIZE = 100;
+
+export class GetVocabularyWithStats extends TotoDelegate<GetVocabularyWithStatsRequest, GetVocabularyWithStatsResponse> {
+
+    parseRequest(req: Request): GetVocabularyWithStatsRequest {
+        const language = req.params.language;
+        if (!SUPPORTED_LANGUAGES.includes(language)) {
+            throw new ValidationError(400, `Unsupported language: ${language}`);
+        }
+
+        const pageParam = req.query.page;
+        const pageSizeParam = req.query.pageSize;
+
+        let page = 1;
+        if (pageParam !== undefined) {
+            page = parseInt(pageParam as string, 10);
+            if (isNaN(page) || page < 1) {
+                throw new ValidationError(400, "page must be a positive integer");
+            }
+        }
+
+        let pageSize = DEFAULT_PAGE_SIZE;
+        if (pageSizeParam !== undefined) {
+            pageSize = parseInt(pageSizeParam as string, 10);
+            if (isNaN(pageSize) || pageSize < 1) {
+                throw new ValidationError(400, "pageSize must be a positive integer");
+            }
+        }
+
+        return { language, page, pageSize };
+    }
+
+    async do(req: GetVocabularyWithStatsRequest, userContext?: UserContext): Promise<GetVocabularyWithStatsResponse> {
+        if (!userContext?.email) {
+            throw new ValidationError(401, "Unauthorized: user context required");
+        }
+
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+
+        const store = new VocabularyStore(db, config);
+        const result = await store.findByLanguageWithStats({
+            language: req.language,
+            userId: userContext.email,
+            page: req.page,
+            pageSize: req.pageSize
+        });
+
+        return {
+            language: req.language,
+            page: req.page,
+            pageSize: req.pageSize,
+            totalCount: result.totalCount,
+            words: result.words
+        };
+    }
+}
+
+interface GetVocabularyWithStatsRequest {
+    language: string;
+    page: number;
+    pageSize: number;
+}
+
+interface GetVocabularyWithStatsResponse {
+    language: string;
+    page: number;
+    pageSize: number;
+    totalCount: number;
+    words: WordWithStats[];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,9 @@ import { DeleteWord } from './dlg/DeleteWord';
 import { GetActiveSession } from './dlg/session/GetActiveSession';
 import { GetRollingSessionStats } from './dlg/session/GetRollingSessionStats';
 import { GetSentences } from './dlg/GetSentences';
+import { GetSentencesWithStats } from './dlg/GetSentencesWithStats';
 import { GetVocabulary } from './dlg/GetVocabulary';
+import { GetVocabularyWithStats } from './dlg/GetVocabularyWithStats';
 import { GetWeeklySessionStats } from './dlg/session/GetWeeklySessionStats';
 import { PostSentence } from './dlg/PostSentence';
 import { PostSentences } from './dlg/PostSentences';
@@ -27,12 +29,14 @@ const config: TotoMicroserviceConfiguration = {
     apiConfiguration: {
         apiEndpoints: [
             { method: 'GET', path: '/vocabulary/:language', delegate: GetVocabulary },
+            { method: 'GET', path: '/vocabulary/:language/with-stats', delegate: GetVocabularyWithStats },
             { method: 'POST', path: '/vocabulary/:language/words', delegate: PostWord },
             { method: 'POST', path: '/vocabulary/:language/words/batch', delegate: PostWords },
             { method: 'GET', path: '/vocabulary/:language/words/sample', delegate: SampleWords },
             { method: 'PUT', path: '/vocabulary/:language/words/:id', delegate: PutWord },
             { method: 'DELETE', path: '/vocabulary/:language/words/:id', delegate: DeleteWord },
             { method: 'GET', path: '/sentences/:language', delegate: GetSentences },
+            { method: 'GET', path: '/sentences/:language/with-stats', delegate: GetSentencesWithStats },
             { method: 'POST', path: '/sentences/:language', delegate: PostSentence },
             { method: 'POST', path: '/sentences/:language/batch', delegate: PostSentences },
             { method: 'POST', path: '/languages/:language/sessions', delegate: StartSession },

--- a/src/store/SentenceStore.ts
+++ b/src/store/SentenceStore.ts
@@ -3,6 +3,26 @@ import { ControllerConfig } from "../Config";
 import { Sentence } from "../model/Sentence";
 
 const SENTENCES_COLLECTION = "sentences";
+const SENTENCE_STATS_COLLECTION = "sentence_stats";
+
+export interface SentenceWithStats {
+    id: string;
+    sentence: string;
+    translation: string;
+    createdAt: string;
+    knowledgeSource: string;
+    stats: {
+        failureRatio: number;
+        totalAttempts: number;
+        totalFailures: number;
+        lastPracticed: string;
+    } | null;
+}
+
+export interface SentencesWithStatsResult {
+    sentences: SentenceWithStats[];
+    totalCount: number;
+}
 
 export class SentenceStore {
 
@@ -125,5 +145,119 @@ export class SentenceStore {
 
     private getSentenceKey(s: Pick<Sentence, "language" | "sentence">): string {
         return `${s.language}::${s.sentence}`;
+    }
+
+    /**
+     * Finds sentences by language with user-specific stats using a LEFT OUTER JOIN.
+     * Sentences with stats are sorted by failureRatio descending (hardest first).
+     * Sentences without stats appear at the end.
+     * 
+     * @param language - The language to filter by
+     * @param userId - The user ID to join stats for
+     * @param page - 1-indexed page number
+     * @param pageSize - Number of items per page
+     */
+    async findByLanguageWithStats({ language, userId, page, pageSize }: {
+        language: string;
+        userId: string;
+        page: number;
+        pageSize: number;
+    }): Promise<SentencesWithStatsResult> {
+
+        const skip = (page - 1) * pageSize;
+
+        // First, get the total count for the language
+        const totalCount = await this.db.collection(SENTENCES_COLLECTION).countDocuments({ language });
+
+        // Aggregation pipeline for LEFT OUTER JOIN with sentence_stats
+        const pipeline = [
+            // Match sentences by language
+            { $match: { language } },
+            // Convert _id to string for joining
+            {
+                $addFields: {
+                    sentenceIdStr: { $toString: "$_id" }
+                }
+            },
+            // LEFT OUTER JOIN with sentence_stats filtered by userId
+            {
+                $lookup: {
+                    from: SENTENCE_STATS_COLLECTION,
+                    let: { sentenceId: "$sentenceIdStr" },
+                    pipeline: [
+                        {
+                            $match: {
+                                $expr: {
+                                    $and: [
+                                        { $eq: ["$sentenceId", "$$sentenceId"] },
+                                        { $eq: ["$userId", userId] }
+                                    ]
+                                }
+                            }
+                        }
+                    ],
+                    as: "statsArray"
+                }
+            },
+            // Unwind the stats array (preserving nulls for sentences without stats)
+            {
+                $addFields: {
+                    stats: { $arrayElemAt: ["$statsArray", 0] }
+                }
+            },
+            // Add a sort key: 1 for items without stats (to sort them at the end)
+            // For items with stats, use negative failureRatio so higher ratios come first
+            {
+                $addFields: {
+                    sortKey: {
+                        $cond: {
+                            if: { $ifNull: ["$stats", false] },
+                            then: { $multiply: ["$stats.failureRatio", -1] },
+                            else: 1 // Items without stats get a high value to sort at the end
+                        }
+                    }
+                }
+            },
+            // Sort: items with stats (by failureRatio desc) first, then items without stats
+            { $sort: { sortKey: 1 as const } },
+            // Pagination
+            { $skip: skip },
+            { $limit: pageSize },
+            // Project final shape
+            {
+                $project: {
+                    _id: 1,
+                    sentence: 1,
+                    translation: 1,
+                    createdAt: 1,
+                    knowledgeSource: 1,
+                    stats: {
+                        $cond: {
+                            if: { $ifNull: ["$stats", false] },
+                            then: {
+                                failureRatio: "$stats.failureRatio",
+                                totalAttempts: "$stats.totalAttempts",
+                                totalFailures: "$stats.totalFailures",
+                                lastPracticed: "$stats.lastPracticed"
+                            },
+                            else: null
+                        }
+                    }
+                }
+            }
+        ];
+
+        const results = await this.db.collection(SENTENCES_COLLECTION).aggregate(pipeline).toArray();
+
+        const sentences: SentenceWithStats[] = results.map(doc => ({
+            id: doc._id.toString(),
+            sentence: doc.sentence,
+            translation: doc.translation,
+            createdAt: doc.createdAt,
+            knowledgeSource: doc.knowledgeSource,
+            stats: doc.stats
+        }));
+
+        return { sentences, totalCount };
     }
 }

--- a/src/store/VocabularyStore.ts
+++ b/src/store/VocabularyStore.ts
@@ -3,6 +3,26 @@ import { ControllerConfig } from "../Config";
 import { Word } from "../model/Word";
 
 const VOCABULARY_COLLECTION = "vocabulary";
+const WORD_STATS_COLLECTION = "word_stats";
+
+export interface WordWithStats {
+    id: string;
+    english: string;
+    translation: string;
+    createdAt: string;
+    knowledgeSource: string;
+    stats: {
+        failureRatio: number;
+        totalAttempts: number;
+        totalFailures: number;
+        lastPracticed: string;
+    } | null;
+}
+
+export interface VocabularyWithStatsResult {
+    words: WordWithStats[];
+    totalCount: number;
+}
 
 export class VocabularyStore {
 
@@ -125,5 +145,119 @@ export class VocabularyStore {
         const result = await this.db.collection(VOCABULARY_COLLECTION).deleteOne({ _id: new ObjectId(id) });
         
         return result.deletedCount > 0;
+    }
+
+    /**
+     * Finds vocabulary by language with user-specific stats using a LEFT OUTER JOIN.
+     * Words with stats are sorted by failureRatio descending (hardest first).
+     * Words without stats appear at the end.
+     * 
+     * @param language - The language to filter by
+     * @param userId - The user ID to join stats for
+     * @param page - 1-indexed page number
+     * @param pageSize - Number of items per page
+     */
+    async findByLanguageWithStats({ language, userId, page, pageSize }: {
+        language: string;
+        userId: string;
+        page: number;
+        pageSize: number;
+    }): Promise<VocabularyWithStatsResult> {
+
+        const skip = (page - 1) * pageSize;
+
+        // First, get the total count for the language
+        const totalCount = await this.db.collection(VOCABULARY_COLLECTION).countDocuments({ language });
+
+        // Aggregation pipeline for LEFT OUTER JOIN with word_stats
+        const pipeline = [
+            // Match vocabulary by language
+            { $match: { language } },
+            // Convert _id to string for joining
+            {
+                $addFields: {
+                    wordIdStr: { $toString: "$_id" }
+                }
+            },
+            // LEFT OUTER JOIN with word_stats filtered by userId
+            {
+                $lookup: {
+                    from: WORD_STATS_COLLECTION,
+                    let: { wordId: "$wordIdStr" },
+                    pipeline: [
+                        {
+                            $match: {
+                                $expr: {
+                                    $and: [
+                                        { $eq: ["$wordId", "$$wordId"] },
+                                        { $eq: ["$userId", userId] }
+                                    ]
+                                }
+                            }
+                        }
+                    ],
+                    as: "statsArray"
+                }
+            },
+            // Unwind the stats array (preserving nulls for words without stats)
+            {
+                $addFields: {
+                    stats: { $arrayElemAt: ["$statsArray", 0] }
+                }
+            },
+            // Add a sort key: -1 for items without stats (to sort them at the end)
+            // For items with stats, use negative failureRatio so higher ratios come first
+            {
+                $addFields: {
+                    sortKey: {
+                        $cond: {
+                            if: { $ifNull: ["$stats", false] },
+                            then: { $multiply: ["$stats.failureRatio", -1] },
+                            else: 1 // Items without stats get a high value to sort at the end
+                        }
+                    }
+                }
+            },
+            // Sort: items with stats (by failureRatio desc) first, then items without stats
+            { $sort: { sortKey: 1 as const } },
+            // Pagination
+            { $skip: skip },
+            { $limit: pageSize },
+            // Project final shape
+            {
+                $project: {
+                    _id: 1,
+                    english: 1,
+                    translation: 1,
+                    createdAt: 1,
+                    knowledgeSource: 1,
+                    stats: {
+                        $cond: {
+                            if: { $ifNull: ["$stats", false] },
+                            then: {
+                                failureRatio: "$stats.failureRatio",
+                                totalAttempts: "$stats.totalAttempts",
+                                totalFailures: "$stats.totalFailures",
+                                lastPracticed: "$stats.lastPracticed"
+                            },
+                            else: null
+                        }
+                    }
+                }
+            }
+        ];
+
+        const results = await this.db.collection(VOCABULARY_COLLECTION).aggregate(pipeline).toArray();
+
+        const words: WordWithStats[] = results.map(doc => ({
+            id: doc._id.toString(),
+            english: doc.english,
+            translation: doc.translation,
+            createdAt: doc.createdAt,
+            knowledgeSource: doc.knowledgeSource,
+            stats: doc.stats
+        }));
+
+        return { words, totalCount };
     }
 }


### PR DESCRIPTION
## Summary

Implements GitHub issue #20: Expose vocabulary and sentences enriched with per-user stats.

### Changes

- **New Endpoints:**
  - `GET /vocabulary/:language/with-stats` - Returns paginated vocabulary with user-specific practice stats
  - `GET /sentences/:language/with-stats` - Returns paginated sentences with user-specific practice stats

- **Query Parameters:**
  - `page` (1-indexed, default: 1)
  - `pageSize` (default: 100)

- **Implementation Details:**
  - Uses MongoDB `$lookup` aggregation for LEFT OUTER JOIN with `word_stats`/`sentence_stats` collections
  - Filters stats by authenticated user ID
  - Sorts by `failureRatio` descending (hardest words/sentences first)
  - Items without stats (unpracticed) appear at the end of results
  - Returns `totalCount` for pagination UI

### Response Structure

```json
{
  language: danish,
  page: 1,
  pageSize: 100,
  totalCount: 2150,
  words: [
    {
      id: abc123,
      english: hello,
      translation: hej,
      createdAt: 2024-01-15T10:00:00Z,
      knowledgeSource: tome-agent,
      stats: {
        failureRatio: 0.75,
        totalAttempts: 8,
        totalFailures: 6,
        lastPracticed: 2024-03-10T14:30:00Z
      }
    }
  ]
}
```

### Files Changed

- `src/dlg/GetVocabularyWithStats.ts` - New delegate for vocabulary endpoint
- `src/dlg/GetSentencesWithStats.ts` - New delegate for sentences endpoint
- `src/store/VocabularyStore.ts` - Added `findByLanguageWithStats()` aggregation method
- `src/store/SentenceStore.ts` - Added `findByLanguageWithStats()` aggregation method
- `src/index.ts` - Registered new API endpoints

Closes #20