### PR TITLE
feat: Expose vocabulary and sentences with per-user stats (Issue #20)

### DIFF
--- a/docs/specs/vocabulary-sentences-with-stats.md
+++ b/docs/specs/vocabulary-sentences-with-stats.md
@@ -1,0 +1,276 @@
+# Vocabulary & Sentences with User Stats — Feature Spec
+
+## Overview
+
+This spec defines two new **paginated endpoints** that expose vocabulary and sentences enriched with per-user practice statistics. These endpoints enable the Tome App to display words and sentences sorted by user-specific difficulty (e.g., hardest words first) without leaking database join concerns to the frontend.
+
+**Problem solved**: Words and sentences are stored in shared collections (`vocabulary`, `sentences`), while practice statistics are stored in per-user collections (`word_stats`, `sentence_stats`). Without server-side joins, the frontend would have to fetch both collections and join them client-side — inefficient and coupling the UI to backend data concerns.
+
+**Solution**: Use MongoDB `$lookup` aggregation to perform LEFT OUTER JOINs server-side, returning items enriched with their user-specific stats in a single response.
+
+---
+
+## Data Model
+
+This feature does not introduce new collections. It uses existing collections:
+
+### Source Collections (Shared)
+- `vocabulary` — Word pairs shared across all users
+- `sentences` — Sentence pairs shared across all users
+
+### Stats Collections (Per-User)
+- `word_stats` — Per-user practice statistics keyed by `(userId, wordId)`
+- `sentence_stats` — Per-user practice statistics keyed by `(userId, sentenceId)`
+
+### Enriched Response Objects
+
+#### WordWithStats
+
+| Field             | Type                | Description                                         |
+|-------------------|---------------------|-----------------------------------------------------|
+| `id`              | string              | MongoDB ObjectId of the word                        |
+| `english`         | string              | English source word                                 |
+| `translation`     | string              | Target language translation                         |
+| `createdAt`       | string              | ISO 8601 timestamp                                  |
+| `knowledgeSource` | string              | Data source identifier                              |
+| `stats`           | object \| null      | User-specific practice stats (null if never practiced) |
+
+#### Stats Object
+
+| Field           | Type    | Description                              |
+|-----------------|---------|------------------------------------------|
+| `failureRatio`  | number  | Ratio of failures to total attempts (0-1)|
+| `totalAttempts` | number  | Total number of practice attempts        |
+| `totalFailures` | number  | Total number of failed attempts          |
+| `lastPracticed` | string  | ISO 8601 timestamp of last practice      |
+
+#### SentenceWithStats
+
+Same structure as `WordWithStats`, but with `sentence` instead of `english`.
+
+---
+
+## API Endpoints
+
+All paths are relative to the service base path `/tomelang`.
+
+| Operation                | Method | Path                                  | Delegate                 |
+|--------------------------|--------|---------------------------------------|--------------------------|
+| GetVocabularyWithStats   | `GET`  | `/vocabulary/{language}/with-stats`   | `GetVocabularyWithStats` |
+| GetSentencesWithStats    | `GET`  | `/sentences/{language}/with-stats`    | `GetSentencesWithStats`  |
+
+---
+
+## Endpoint Specifications
+
+### GET `/vocabulary/{language}/with-stats` — GetVocabularyWithStats
+
+Returns vocabulary entries for the specified language, enriched with per-user practice statistics. Results are paginated and sorted by difficulty (hardest first).
+
+#### Path Parameters
+
+| Parameter  | Description                       |
+|------------|-----------------------------------|
+| `language` | Target language (e.g. `"danish"`) |
+
+#### Query Parameters
+
+| Parameter  | Required | Default | Description                        |
+|------------|----------|---------|------------------------------------|
+| `page`     | No       | 1       | Page number (1-indexed)            |
+| `pageSize` | No       | 100     | Number of items per page           |
+
+#### Authentication
+
+This endpoint **requires authentication**. The user's email from the authenticated context is used to filter stats.
+
+#### Response — `200 OK`
+
+```json
+{
+  "language": "danish",
+  "page": 1,
+  "pageSize": 100,
+  "totalCount": 2150,
+  "words": [
+    {
+      "id": "abc123",
+      "english": "hello",
+      "translation": "hej",
+      "createdAt": "2024-01-15T10:00:00Z",
+      "knowledgeSource": "tome-agent",
+      "stats": {
+        "failureRatio": 0.75,
+        "totalAttempts": 8,
+        "totalFailures": 6,
+        "lastPracticed": "2024-03-10T14:30:00Z"
+      }
+    },
+    {
+      "id": "def456",
+      "english": "goodbye",
+      "translation": "farvel",
+      "createdAt": "2024-01-15T10:00:00Z",
+      "knowledgeSource": "tome-agent",
+      "stats": null
+    }
+  ]
+}
+```
+
+#### Sorting Logic
+
+1. **Words with stats**: Sorted by `failureRatio` descending (highest failure ratio = hardest word = first)
+2. **Words without stats** (`stats: null`): Appear at the end of the results
+
+This ensures that users see their most challenging words first, with unpracticed words at the end.
+
+#### Error Cases
+
+| Condition                       | Status | Description                           |
+|---------------------------------|--------|---------------------------------------|
+| Unknown / unsupported `language`| `400`  | Language is not in the supported list |
+| Invalid `page` parameter        | `400`  | Must be a positive integer            |
+| Invalid `pageSize` parameter    | `400`  | Must be a positive integer            |
+| Missing authentication          | `401`  | User context required                 |
+
+---
+
+### GET `/sentences/{language}/with-stats` — GetSentencesWithStats
+
+Returns sentence entries for the specified language, enriched with per-user practice statistics. Results are paginated and sorted by difficulty (hardest first).
+
+#### Path Parameters
+
+| Parameter  | Description                       |
+|------------|-----------------------------------|
+| `language` | Target language (e.g. `"danish"`) |
+
+#### Query Parameters
+
+| Parameter  | Required | Default | Description                        |
+|------------|----------|---------|------------------------------------|
+| `page`     | No       | 1       | Page number (1-indexed)            |
+| `pageSize` | No       | 100     | Number of items per page           |
+
+#### Authentication
+
+This endpoint **requires authentication**. The user's email from the authenticated context is used to filter stats.
+
+#### Response — `200 OK`
+
+```json
+{
+  "language": "danish",
+  "page": 1,
+  "pageSize": 100,
+  "totalCount": 500,
+  "sentences": [
+    {
+      "id": "sent123",
+      "sentence": "jeg elsker dig",
+      "translation": "I love you",
+      "createdAt": "2024-01-15T10:00:00Z",
+      "knowledgeSource": "tome-agent",
+      "stats": {
+        "failureRatio": 0.50,
+        "totalAttempts": 10,
+        "totalFailures": 5,
+        "lastPracticed": "2024-03-10T14:30:00Z"
+      }
+    },
+    {
+      "id": "sent456",
+      "sentence": "god morgen",
+      "translation": "good morning",
+      "createdAt": "2024-01-15T10:00:00Z",
+      "knowledgeSource": "tome-agent",
+      "stats": null
+    }
+  ]
+}
+```
+
+#### Sorting Logic
+
+Same as vocabulary endpoint:
+1. **Sentences with stats**: Sorted by `failureRatio` descending
+2. **Sentences without stats**: Appear at the end
+
+#### Error Cases
+
+Same as vocabulary endpoint.
+
+---
+
+## Core Logic
+
+### MongoDB Aggregation Pipeline
+
+Both endpoints use the same aggregation pattern:
+
+1. **Match** — Filter by language
+2. **AddFields** — Convert `_id` to string for joining (MongoDB stores IDs as ObjectId, stats store them as strings)
+3. **Lookup** — LEFT OUTER JOIN with stats collection, filtering by userId
+4. **AddFields** — Extract first (and only) stats document from array
+5. **AddFields** — Compute sort key: `-failureRatio` for items with stats, `1` for items without (ensures unpracticed items sort last)
+6. **Sort** — By sort key ascending
+7. **Skip/Limit** — Pagination
+8. **Project** — Shape final response
+
+### Count Query
+
+A separate `countDocuments` query runs in parallel to get total count for pagination metadata.
+
+---
+
+## Implementation
+
+### Delegates
+
+- `src/dlg/GetVocabularyWithStats.ts` — Handles vocabulary endpoint
+- `src/dlg/GetSentencesWithStats.ts` — Handles sentences endpoint
+
+Both delegates:
+1. Parse and validate path/query parameters
+2. Require user authentication (throw 401 if missing)
+3. Call the corresponding store method
+4. Return paginated response
+
+### Store Methods
+
+- `VocabularyStore.findByLanguageWithStats({ language, userId, page, pageSize })`
+- `SentenceStore.findByLanguageWithStats({ language, userId, page, pageSize })`
+
+Both methods:
+1. Execute aggregation pipeline for LEFT OUTER JOIN
+2. Execute count query for total
+3. Return `{ words/sentences, totalCount }`
+
+### Types
+
+New exported interfaces in store files:
+- `WordWithStats` — Response shape for vocabulary items
+- `VocabularyWithStatsResult` — Store method return type
+- `SentenceWithStats` — Response shape for sentence items  
+- `SentencesWithStatsResult` — Store method return type
+
+---
+
+## Out of Scope
+
+The following are explicitly **not** included in this implementation:
+
+| Item                              | Reason                                              |
+|-----------------------------------|-----------------------------------------------------|
+| Secondary sort options            | Start simple; add if users request                  |
+| Cursor-based pagination           | Skip/limit sufficient for expected scale (2000 items) |
+| Filtering by difficulty bucket    | YAGNI — start simple                                |
+| Caching layer                     | Premature optimization                              |
+| Materialized views                | Adds sync complexity; lookup is sufficient          |
+
+---
+
+## References
+
+- Parent issue: [#20 - Expose vocabulary and sentences enriched with per-user stats](https://github.com/nicolasances/tome-ms-language/issues/20)

--- a/src/dlg/GetSentencesWithStats.ts
+++ b/src/dlg/GetSentencesWithStats.ts
@@ -1,0 +1,77 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../Config";
+import { SentenceStore, SentenceWithStats } from "../store/SentenceStore";
+import { SUPPORTED_LANGUAGES } from "../util/Languages";
+
+const DEFAULT_PAGE_SIZE = 100;
+
+export class GetSentencesWithStats extends TotoDelegate<GetSentencesWithStatsRequest, GetSentencesWithStatsResponse> {
+
+    parseRequest(req: Request): GetSentencesWithStatsRequest {
+        const language = req.params.language;
+        if (!SUPPORTED_LANGUAGES.includes(language)) {
+            throw new ValidationError(400, `Unsupported language: ${language}`);
+        }
+
+        const pageParam = req.query.page;
+        const pageSizeParam = req.query.pageSize;
+
+        let page = 1;
+        if (pageParam !== undefined) {
+            page = parseInt(pageParam as string, 10);
+            if (isNaN(page) || page < 1) {
+                throw new ValidationError(400, "page must be a positive integer");
+            }
+        }
+
+        let pageSize = DEFAULT_PAGE_SIZE;
+        if (pageSizeParam !== undefined) {
+            pageSize = parseInt(pageSizeParam as string, 10);
+            if (isNaN(pageSize) || pageSize < 1) {
+                throw new ValidationError(400, "pageSize must be a positive integer");
+            }
+        }
+
+        return { language, page, pageSize };
+    }
+
+    async do(req: GetSentencesWithStatsRequest, userContext?: UserContext): Promise<GetSentencesWithStatsResponse> {
+        if (!userContext?.email) {
+            throw new ValidationError(401, "Unauthorized: user context required");
+        }
+
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+
+        const store = new SentenceStore(db, config);
+        const result = await store.findByLanguageWithStats({
+            language: req.language,
+            userId: userContext.email,
+            page: req.page,
+            pageSize: req.pageSize
+        });
+
+        return {
+            language: req.language,
+            page: req.page,
+            pageSize: req.pageSize,
+            totalCount: result.totalCount,
+            sentences: result.sentences
+        };
+    }
+}
+
+interface GetSentencesWithStatsRequest {
+    language: string;
+    page: number;
+    pageSize: number;
+}
+
+interface GetSentencesWithStatsResponse {
+    language: string;
+    page: number;
+    pageSize: number;
+    totalCount: number;
+    sentences: SentenceWithStats[];
+}

--- a/src/dlg/GetVocabularyWithStats.ts
+++ b/src/dlg/GetVocabularyWithStats.ts
@@ -1,0 +1,77 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../Config";
+import { VocabularyStore, WordWithStats } from "../store/VocabularyStore";
+import { SUPPORTED_LANGUAGES } from "../util/Languages";
+
+const DEFAULT_PAGE_SIZE = 100;
+
+export class GetVocabularyWithStats extends TotoDelegate<GetVocabularyWithStatsRequest, GetVocabularyWithStatsResponse> {
+
+    parseRequest(req: Request): GetVocabularyWithStatsRequest {
+        const language = req.params.language;
+        if (!SUPPORTED_LANGUAGES.includes(language)) {
+            throw new ValidationError(400, `Unsupported language: ${language}`);
+        }
+
+        const pageParam = req.query.page;
+        const pageSizeParam = req.query.pageSize;
+
+        let page = 1;
+        if (pageParam !== undefined) {
+            page = parseInt(pageParam as string, 10);
+            if (isNaN(page) || page < 1) {
+                throw new ValidationError(400, "page must be a positive integer");
+            }
+        }
+
+        let pageSize = DEFAULT_PAGE_SIZE;
+        if (pageSizeParam !== undefined) {
+            pageSize = parseInt(pageSizeParam as string, 10);
+            if (isNaN(pageSize) || pageSize < 1) {
+                throw new ValidationError(400, "pageSize must be a positive integer");
+            }
+        }
+
+        return { language, page, pageSize };
+    }
+
+    async do(req: GetVocabularyWithStatsRequest, userContext?: UserContext): Promise<GetVocabularyWithStatsResponse> {
+        if (!userContext?.email) {
+            throw new ValidationError(401, "Unauthorized: user context required");
+        }
+
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+
+        const store = new VocabularyStore(db, config);
+        const result = await store.findByLanguageWithStats({
+            language: req.language,
+            userId: userContext.email,
+            page: req.page,
+            pageSize: req.pageSize
+        });
+
+        return {
+            language: req.language,
+            page: req.page,
+            pageSize: req.pageSize,
+            totalCount: result.totalCount,
+            words: result.words
+        };
+    }
+}
+
+interface GetVocabularyWithStatsRequest {
+    language: string;
+    page: number;
+    pageSize: number;
+}
+
+interface GetVocabularyWithStatsResponse {
+    language: string;
+    page: number;
+    pageSize: number;
+    totalCount: number;
+    words: WordWithStats[];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,9 @@ import { DeleteWord } from './dlg/DeleteWord';
 import { GetActiveSession } from './dlg/session/GetActiveSession';
 import { GetRollingSessionStats } from './dlg/session/GetRollingSessionStats';
 import { GetSentences } from './dlg/GetSentences';
+import { GetSentencesWithStats } from './dlg/GetSentencesWithStats';
 import { GetVocabulary } from './dlg/GetVocabulary';
+import { GetVocabularyWithStats } from './dlg/GetVocabularyWithStats';
 import { GetWeeklySessionStats } from './dlg/session/GetWeeklySessionStats';
 import { PostSentence } from './dlg/PostSentence';
 import { PostSentences } from './dlg/PostSentences';
@@ -27,12 +29,14 @@ const config: TotoMicroserviceConfiguration = {
     apiConfiguration: {
         apiEndpoints: [
             { method: 'GET', path: '/vocabulary/:language', delegate: GetVocabulary },
+            { method: 'GET', path: '/vocabulary/:language/with-stats', delegate: GetVocabularyWithStats },
             { method: 'POST', path: '/vocabulary/:language/words', delegate: PostWord },
             { method: 'POST', path: '/vocabulary/:language/words/batch', delegate: PostWords },
             { method: 'GET', path: '/vocabulary/:language/words/sample', delegate: SampleWords },
             { method: 'PUT', path: '/vocabulary/:language/words/:id', delegate: PutWord },
             { method: 'DELETE', path: '/vocabulary/:language/words/:id', delegate: DeleteWord },
             { method: 'GET', path: '/sentences/:language', delegate: GetSentences },
+            { method: 'GET', path: '/sentences/:language/with-stats', delegate: GetSentencesWithStats },
             { method: 'POST', path: '/sentences/:language', delegate: PostSentence },
             { method: 'POST', path: '/sentences/:language/batch', delegate: PostSentences },
             { method: 'POST', path: '/languages/:language/sessions', delegate: StartSession },

--- a/src/store/SentenceStore.ts
+++ b/src/store/SentenceStore.ts
@@ -3,6 +3,26 @@ import { ControllerConfig } from "../Config";
 import { Sentence } from "../model/Sentence";
 
 const SENTENCES_COLLECTION = "sentences";
+const SENTENCE_STATS_COLLECTION = "sentence_stats";
+
+export interface SentenceWithStats {
+    id: string;
+    sentence: string;
+    translation: string;
+    createdAt: string;
+    knowledgeSource: string;
+    stats: {
+        failureRatio: number;
+        totalAttempts: number;
+        totalFailures: number;
+        lastPracticed: string;
+    } | null;
+}
+
+export interface SentencesWithStatsResult {
+    sentences: SentenceWithStats[];
+    totalCount: number;
+}
 
 export class SentenceStore {
 
@@ -125,5 +145,119 @@ export class SentenceStore {
 
     private getSentenceKey(s: Pick<Sentence, "language" | "sentence">): string {
         return `${s.language}::${s.sentence}`;
+    }
+
+    /**
+     * Finds sentences by language with user-specific stats using a LEFT OUTER JOIN.
+     * Sentences with stats are sorted by failureRatio descending (hardest first).
+     * Sentences without stats appear at the end.
+     * 
+     * @param language - The language to filter by
+     * @param userId - The user ID to join stats for
+     * @param page - 1-indexed page number
+     * @param pageSize - Number of items per page
+     */
+    async findByLanguageWithStats({ language, userId, page, pageSize }: {
+        language: string;
+        userId: string;
+        page: number;
+        pageSize: number;
+    }): Promise<SentencesWithStatsResult> {
+
+        const skip = (page - 1) * pageSize;
+
+        // First, get the total count for the language
+        const totalCount = await this.db.collection(SENTENCES_COLLECTION).countDocuments({ language });
+
+        // Aggregation pipeline for LEFT OUTER JOIN with sentence_stats
+        const pipeline = [
+            // Match sentences by language
+            { $match: { language } },
+            // Convert _id to string for joining
+            {
+                $addFields: {
+                    sentenceIdStr: { $toString: "$_id" }
+                }
+            },
+            // LEFT OUTER JOIN with sentence_stats filtered by userId
+            {
+                $lookup: {
+                    from: SENTENCE_STATS_COLLECTION,
+                    let: { sentenceId: "$sentenceIdStr" },
+                    pipeline: [
+                        {
+                            $match: {
+                                $expr: {
+                                    $and: [
+                                        { $eq: ["$sentenceId", "$$sentenceId"] },
+                                        { $eq: ["$userId", userId] }
+                                    ]
+                                }
+                            }
+                        }
+                    ],
+                    as: "statsArray"
+                }
+            },
+            // Unwind the stats array (preserving nulls for sentences without stats)
+            {
+                $addFields: {
+                    stats: { $arrayElemAt: ["$statsArray", 0] }
+                }
+            },
+            // Add a sort key: 1 for items without stats (to sort them at the end)
+            // For items with stats, use negative failureRatio so higher ratios come first
+            {
+                $addFields: {
+                    sortKey: {
+                        $cond: {
+                            if: { $ifNull: ["$stats", false] },
+                            then: { $multiply: ["$stats.failureRatio", -1] },
+                            else: 1 // Items without stats get a high value to sort at the end
+                        }
+                    }
+                }
+            },
+            // Sort: items with stats (by failureRatio desc) first, then items without stats
+            { $sort: { sortKey: 1 as const } },
+            // Pagination
+            { $skip: skip },
+            { $limit: pageSize },
+            // Project final shape
+            {
+                $project: {
+                    _id: 1,
+                    sentence: 1,
+                    translation: 1,
+                    createdAt: 1,
+                    knowledgeSource: 1,
+                    stats: {
+                        $cond: {
+                            if: { $ifNull: ["$stats", false] },
+                            then: {
+                                failureRatio: "$stats.failureRatio",
+                                totalAttempts: "$stats.totalAttempts",
+                                totalFailures: "$stats.totalFailures",
+                                lastPracticed: "$stats.lastPracticed"
+                            },
+                            else: null
+                        }
+                    }
+                }
+            }
+        ];
+
+        const results = await this.db.collection(SENTENCES_COLLECTION).aggregate(pipeline).toArray();
+
+        const sentences: SentenceWithStats[] = results.map(doc => ({
+            id: doc._id.toString(),
+            sentence: doc.sentence,
+            translation: doc.translation,
+            createdAt: doc.createdAt,
+            knowledgeSource: doc.knowledgeSource,
+            stats: doc.stats
+        }));
+
+        return { sentences, totalCount };
     }
 }

--- a/src/store/VocabularyStore.ts
+++ b/src/store/VocabularyStore.ts
@@ -3,6 +3,26 @@ import { ControllerConfig } from "../Config";
 import { Word } from "../model/Word";
 
 const VOCABULARY_COLLECTION = "vocabulary";
+const WORD_STATS_COLLECTION = "word_stats";
+
+export interface WordWithStats {
+    id: string;
+    english: string;
+    translation: string;
+    createdAt: string;
+    knowledgeSource: string;
+    stats: {
+        failureRatio: number;
+        totalAttempts: number;
+        totalFailures: number;
+        lastPracticed: string;
+    } | null;
+}
+
+export interface VocabularyWithStatsResult {
+    words: WordWithStats[];
+    totalCount: number;
+}
 
 export class VocabularyStore {
 
@@ -125,5 +145,119 @@ export class VocabularyStore {
         const result = await this.db.collection(VOCABULARY_COLLECTION).deleteOne({ _id: new ObjectId(id) });
         
         return result.deletedCount > 0;
+    }
+
+    /**
+     * Finds vocabulary by language with user-specific stats using a LEFT OUTER JOIN.
+     * Words with stats are sorted by failureRatio descending (hardest first).
+     * Words without stats appear at the end.
+     * 
+     * @param language - The language to filter by
+     * @param userId - The user ID to join stats for
+     * @param page - 1-indexed page number
+     * @param pageSize - Number of items per page
+     */
+    async findByLanguageWithStats({ language, userId, page, pageSize }: {
+        language: string;
+        userId: string;
+        page: number;
+        pageSize: number;
+    }): Promise<VocabularyWithStatsResult> {
+
+        const skip = (page - 1) * pageSize;
+
+        // First, get the total count for the language
+        const totalCount = await this.db.collection(VOCABULARY_COLLECTION).countDocuments({ language });
+
+        // Aggregation pipeline for LEFT OUTER JOIN with word_stats
+        const pipeline = [
+            // Match vocabulary by language
+            { $match: { language } },
+            // Convert _id to string for joining
+            {
+                $addFields: {
+                    wordIdStr: { $toString: "$_id" }
+                }
+            },
+            // LEFT OUTER JOIN with word_stats filtered by userId
+            {
+                $lookup: {
+                    from: WORD_STATS_COLLECTION,
+                    let: { wordId: "$wordIdStr" },
+                    pipeline: [
+                        {
+                            $match: {
+                                $expr: {
+                                    $and: [
+                                        { $eq: ["$wordId", "$$wordId"] },
+                                        { $eq: ["$userId", userId] }
+                                    ]
+                                }
+                            }
+                        }
+                    ],
+                    as: "statsArray"
+                }
+            },
+            // Unwind the stats array (preserving nulls for words without stats)
+            {
+                $addFields: {
+                    stats: { $arrayElemAt: ["$statsArray", 0] }
+                }
+            },
+            // Add a sort key: -1 for items without stats (to sort them at the end)
+            // For items with stats, use negative failureRatio so higher ratios come first
+            {
+                $addFields: {
+                    sortKey: {
+                        $cond: {
+                            if: { $ifNull: ["$stats", false] },
+                            then: { $multiply: ["$stats.failureRatio", -1] },
+                            else: 1 // Items without stats get a high value to sort at the end
+                        }
+                    }
+                }
+            },
+            // Sort: items with stats (by failureRatio desc) first, then items without stats
+            { $sort: { sortKey: 1 as const } },
+            // Pagination
+            { $skip: skip },
+            { $limit: pageSize },
+            // Project final shape
+            {
+                $project: {
+                    _id: 1,
+                    english: 1,
+                    translation: 1,
+                    createdAt: 1,
+                    knowledgeSource: 1,
+                    stats: {
+                        $cond: {
+                            if: { $ifNull: ["$stats", false] },
+                            then: {
+                                failureRatio: "$stats.failureRatio",
+                                totalAttempts: "$stats.totalAttempts",
+                                totalFailures: "$stats.totalFailures",
+                                lastPracticed: "$stats.lastPracticed"
+                            },
+                            else: null
+                        }
+                    }
+                }
+            }
+        ];
+
+        const results = await this.db.collection(VOCABULARY_COLLECTION).aggregate(pipeline).toArray();
+
+        const words: WordWithStats[] = results.map(doc => ({
+            id: doc._id.toString(),
+            english: doc.english,
+            translation: doc.translation,
+            createdAt: doc.createdAt,
+            knowledgeSource: doc.knowledgeSource,
+            stats: doc.stats
+        }));
+
+        return { words, totalCount };
     }
 }


### PR DESCRIPTION
## Summary

Implements GitHub issue #20: Expose vocabulary and sentences enriched with per-user stats.

This PR enables the Tome App to display vocabulary and sentences sorted by user-specific difficulty (failureRatio) without leaking database join concerns to the frontend.

### New Endpoints

- `GET /vocabulary/:language/with-stats` - Returns paginated vocabulary with user-specific practice stats
- `GET /sentences/:language/with-stats` - Returns paginated sentences with user-specific practice stats

### Query Parameters

- `page` (1-indexed, default: 1)
- `pageSize` (default: 100)

### Implementation Details

- Uses MongoDB `$lookup` aggregation for LEFT OUTER JOIN with `word_stats`/`sentence_stats` collections
- Filters stats by authenticated user ID
- Sorts by `failureRatio` descending (hardest words/sentences first)
- Items without stats (unpracticed) appear at the end of results
- Returns `totalCount` for pagination UI

### Response Structure

```json
{
  language: danish,
  page: 1,
  pageSize: 100,
  totalCount: 2150,
  words: [
    {
      id: abc123,
      english: hello,
      translation: hej,
      createdAt: 2024-01-15T10:00:00Z,
      knowledgeSource: tome-agent,
      stats: {
        failureRatio: 0.75,
        totalAttempts: 8,
        totalFailures: 6,
        lastPracticed: 2024-03-10T14:30:00Z
      }
    }
  ]
}
```

### Files Changed

- `src/dlg/GetVocabularyWithStats.ts` - New delegate for vocabulary endpoint
- `src/dlg/GetSentencesWithStats.ts` - New delegate for sentences endpoint
- `src/store/VocabularyStore.ts` - Added `findByLanguageWithStats()` aggregation method
- `src/store/SentenceStore.ts` - Added `findByLanguageWithStats()` aggregation method
- `src/index.ts` - Registered new API endpoints
- `docs/specs/vocabulary-sentences-with-stats.md` - Technical specification

Closes #20