### PR TITLE
feat: sort vocabulary and sentences by difficulty

### DIFF
--- a/docs/specs/vocabulary-sentences-with-stats.md
+++ b/docs/specs/vocabulary-sentences-with-stats.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This spec defines two new **paginated endpoints** that expose vocabulary and sentences enriched with per-user practice statistics. These endpoints enable the Tome App to display words and sentences sorted by user-specific difficulty (e.g., hardest words first) without leaking database join concerns to the frontend.
+This spec defines two **paginated endpoints** that expose vocabulary and sentences enriched with per-user practice statistics. These endpoints enable the Tome App to display words and sentences optionally sorted by user-specific difficulty without leaking database join concerns to the frontend.
 
 **Problem solved**: Words and sentences are stored in shared collections (`vocabulary`, `sentences`), while practice statistics are stored in per-user collections (`word_stats`, `sentence_stats`). Without server-side joins, the frontend would have to fetch both collections and join them client-side — inefficient and coupling the UI to backend data concerns.
 
@@ -75,10 +75,12 @@ Returns vocabulary entries for the specified language, enriched with per-user pr
 
 #### Query Parameters
 
-| Parameter  | Required | Default | Description                        |
-|------------|----------|---------|------------------------------------|
-| `page`     | No       | 1       | Page number (1-indexed)            |
-| `pageSize` | No       | 100     | Number of items per page           |
+| Parameter  | Required | Default | Description                                        |
+|------------|----------|---------|----------------------------------------------------|
+| `page`     | No       | 1       | Page number (1-indexed)                            |
+| `pageSize` | No       | 100     | Number of items per page                           |
+| `sortBy`   | No       | —       | Sort field. Only accepted value: `"difficulty"`    |
+| `sortDir`  | No       | `"asc"` | Sort direction: `"asc"` or `"desc"`                |
 
 #### Authentication
 
@@ -120,25 +122,25 @@ This endpoint **requires authentication**. The user's email from the authenticat
 
 #### Sorting Logic
 
-1. **Words with stats**: Sorted by `failureRatio` descending (highest failure ratio = hardest word = first)
-2. **Words without stats** (`stats: null`): Appear at the end of the results
-
-This ensures that users see their most challenging words first, with unpracticed words at the end.
+- **Default (no `sortBy`)**: Alphabetical by `translation` field ascending.
+- **`sortBy=difficulty`**: Sort by `failureRatio`. Direction is controlled by `sortDir` (`"asc"` = lowest failure ratio first, `"desc"` = highest failure ratio first). Items without stats (`stats: null`) always appear **at the end**, regardless of `sortDir`.
 
 #### Error Cases
 
-| Condition                       | Status | Description                           |
-|---------------------------------|--------|---------------------------------------|
-| Unknown / unsupported `language`| `400`  | Language is not in the supported list |
-| Invalid `page` parameter        | `400`  | Must be a positive integer            |
-| Invalid `pageSize` parameter    | `400`  | Must be a positive integer            |
-| Missing authentication          | `401`  | User context required                 |
+| Condition                       | Status | Description                                        |
+|---------------------------------|--------|----------------------------------------------------|
+| Unknown / unsupported `language`| `400`  | Language is not in the supported list              |
+| Invalid `page` parameter        | `400`  | Must be a positive integer                         |
+| Invalid `pageSize` parameter    | `400`  | Must be a positive integer                         |
+| Invalid `sortBy` value          | `400`  | Only `"difficulty"` is accepted                    |
+| Invalid `sortDir` value         | `400`  | Only `"asc"` or `"desc"` are accepted              |
+| Missing authentication          | `401`  | User context required                              |
 
 ---
 
 ### GET `/sentences/{language}/with-stats` — GetSentencesWithStats
 
-Returns sentence entries for the specified language, enriched with per-user practice statistics. Results are paginated and sorted by difficulty (hardest first).
+Returns sentence entries for the specified language, enriched with per-user practice statistics. Results are paginated.
 
 #### Path Parameters
 
@@ -148,10 +150,12 @@ Returns sentence entries for the specified language, enriched with per-user prac
 
 #### Query Parameters
 
-| Parameter  | Required | Default | Description                        |
-|------------|----------|---------|------------------------------------|
-| `page`     | No       | 1       | Page number (1-indexed)            |
-| `pageSize` | No       | 100     | Number of items per page           |
+| Parameter  | Required | Default | Description                                        |
+|------------|----------|---------|----------------------------------------------------|
+| `page`     | No       | 1       | Page number (1-indexed)                            |
+| `pageSize` | No       | 100     | Number of items per page                           |
+| `sortBy`   | No       | —       | Sort field. Only accepted value: `"difficulty"`    |
+| `sortDir`  | No       | `"asc"` | Sort direction: `"asc"` or `"desc"`                |
 
 #### Authentication
 
@@ -193,9 +197,8 @@ This endpoint **requires authentication**. The user's email from the authenticat
 
 #### Sorting Logic
 
-Same as vocabulary endpoint:
-1. **Sentences with stats**: Sorted by `failureRatio` descending
-2. **Sentences without stats**: Appear at the end
+- **Default (no `sortBy`)**: Alphabetical by `sentence` field ascending.
+- **`sortBy=difficulty`**: Sort by `failureRatio`. Direction controlled by `sortDir`. Items without stats always appear **at the end**.
 
 #### Error Cases
 
@@ -213,10 +216,19 @@ Both endpoints use the same aggregation pattern:
 2. **AddFields** — Convert `_id` to string for joining (MongoDB stores IDs as ObjectId, stats store them as strings)
 3. **Lookup** — LEFT OUTER JOIN with stats collection, filtering by userId
 4. **AddFields** — Extract first (and only) stats document from array
-5. **AddFields** — Compute sort key: `-failureRatio` for items with stats, `1` for items without (ensures unpracticed items sort last)
-6. **Sort** — By sort key ascending
-7. **Skip/Limit** — Pagination
-8. **Project** — Shape final response
+5. **Sort** — Determined by `sortBy` / `sortDir` params:
+   - **Default (no `sortBy`)**: Sort alphabetically by `translation` (words) or `sentence` (sentences)
+   - **`sortBy=difficulty, sortDir=desc`**: Sort by `failureRatio` descending; items without stats get a sentinel value of `-1` so they sort last
+   - **`sortBy=difficulty, sortDir=asc`**: Sort by `failureRatio` ascending; items without stats get a sentinel value of `Infinity` (`Number.MAX_VALUE` in BSON) so they sort last
+6. **Skip/Limit** — Pagination
+7. **Project** — Shape final response
+
+### Sort Key Computation (difficulty mode)
+
+To ensure items without stats always appear last regardless of sort direction:
+
+- `sortDir=desc`: `sortKey = stats ? -failureRatio : 1` → sort ascending on key (negation inverts order; `1` > any valid `-failureRatio` in `[−1, 0]`)
+- `sortDir=asc`: `sortKey = stats ? failureRatio : MAX_VALUE` → sort ascending on key (`MAX_VALUE` > any valid `failureRatio` in `[0, 1]`)
 
 ### Count Query
 
@@ -239,13 +251,15 @@ Both delegates:
 
 ### Store Methods
 
-- `VocabularyStore.findByLanguageWithStats({ language, userId, page, pageSize })`
-- `SentenceStore.findByLanguageWithStats({ language, userId, page, pageSize })`
+- `VocabularyStore.findByLanguageWithStats({ language, userId, page, pageSize, sortBy?, sortDir? })`
+- `SentenceStore.findByLanguageWithStats({ language, userId, page, pageSize, sortBy?, sortDir? })`
 
 Both methods:
 1. Execute aggregation pipeline for LEFT OUTER JOIN
 2. Execute count query for total
 3. Return `{ words/sentences, totalCount }`
+
+The `sortBy` and `sortDir` params are optional. When absent, the pipeline defaults to alphabetical order.
 
 ### Types
 
@@ -263,7 +277,7 @@ The following are explicitly **not** included in this implementation:
 
 | Item                              | Reason                                              |
 |-----------------------------------|-----------------------------------------------------|
-| Secondary sort options            | Start simple; add if users request                  |
+| Sort fields other than difficulty | Start simple; add if users request                  |
 | Cursor-based pagination           | Skip/limit sufficient for expected scale (2000 items) |
 | Filtering by difficulty bucket    | YAGNI — start simple                                |
 | Caching layer                     | Premature optimization                              |
@@ -273,4 +287,6 @@ The following are explicitly **not** included in this implementation:
 
 ## References
 
-- Parent issue: [#20 - Expose vocabulary and sentences enriched with per-user stats](https://github.com/nicolasances/tome-ms-language/issues/20)
+- Parent issue: [#24 - Sorting of Vocabulary and Sentences by Difficulty](https://github.com/nicolasances/tome-ms-language/issues/24)
+- Task issue (words): [#25 - Add sort-by-difficulty to Words vocabulary with-stats endpoint](https://github.com/nicolasances/tome-ms-language/issues/25)
+- Task issue (sentences): [#26 - Add sort-by-difficulty to Sentences with-stats endpoint](https://github.com/nicolasances/tome-ms-language/issues/26)

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,11 +28,15 @@
         "totoms": "^2.3.2"
       },
       "devDependencies": {
+        "@types/chai": "^5.2.3",
         "@types/connect-busboy": "^1.0.2",
         "@types/express": "^4.17.20",
         "@types/fs-extra": "^11.0.3",
         "@types/jsonwebtoken": "^9.0.10",
+        "@types/mocha": "^10.0.10",
         "@types/node": "^16.11.7",
+        "chai": "^6.2.2",
+        "mocha": "^11.7.5",
         "nodemon": "^3.0.1",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
@@ -1083,6 +1087,109 @@
         "hono": "^4"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1518,6 +1625,17 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.30.0.tgz",
       "integrity": "sha512-4VlGgo32k2EQ2wcCY3vEU28A0O13aOtHz3Xt2/2U5FAh9EfhD6t6DqL5Z6yAnRCntbTFDU4YfbpyzSlHNWycPw==",
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=14"
       }
@@ -2239,6 +2357,17 @@
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -2260,6 +2389,13 @@
         "@types/express": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "4.17.25",
@@ -2336,6 +2472,13 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -2648,6 +2791,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -2795,6 +2948,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/bson": {
       "version": "6.10.4",
       "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
@@ -2859,11 +3019,74 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -3046,6 +3269,19 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3109,6 +3345,13 @@
         "readable-stream": "^3.1.1",
         "stream-shift": "^1.0.2"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -3218,6 +3461,19 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -3451,6 +3707,50 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/forever-agent": {
@@ -3704,6 +4004,28 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -3715,6 +4037,39 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/google-auth-library": {
@@ -4087,6 +4442,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/heap-js": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.7.1.tgz",
@@ -4339,6 +4704,26 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -4369,6 +4754,19 @@
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "license": "MIT"
     },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4380,6 +4778,22 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "license": "MIT"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jose": {
       "version": "6.2.2",
@@ -4514,6 +4928,22 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -4567,6 +4997,23 @@
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
       "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -4682,6 +5129,177 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "11.7.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
+      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^4.0.1",
+        "debug": "^4.3.5",
+        "diff": "^7.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^10.4.5",
+        "he": "^1.2.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^9.0.5",
+        "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^9.2.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/mocha/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/mocha/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/mocha/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/moment": {
@@ -4975,6 +5593,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -4992,6 +5633,16 @@
       "dependencies": {
         "process": "^0.11.1",
         "util": "^0.10.3"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-expression-matcher": {
@@ -5018,6 +5669,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
@@ -5029,6 +5704,13 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
@@ -5151,6 +5833,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/range-parser": {
@@ -5425,6 +6117,16 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
     "node_modules/serve-static": {
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
@@ -5539,6 +6241,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -5641,6 +6356,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -5651,6 +6382,33 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strnum": {
@@ -6173,10 +6931,36 @@
         "node": ">= 8"
       }
     },
+    "node_modules/workerpool": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -6236,6 +7020,22 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "npx nodemon",
     "build": "rm -rf ./build && tsc",
-    "start": "node build/index.js"
+    "start": "node build/index.js",
+    "test": "mocha --require ts-node/register \"src/__tests__/**/*.test.ts\" --timeout 10000"
   },
   "author": "",
   "license": "ISC",
@@ -30,11 +31,15 @@
     "totoms": "^2.3.2"
   },
   "devDependencies": {
+    "@types/chai": "^5.2.3",
     "@types/connect-busboy": "^1.0.2",
     "@types/express": "^4.17.20",
     "@types/fs-extra": "^11.0.3",
     "@types/jsonwebtoken": "^9.0.10",
+    "@types/mocha": "^10.0.10",
     "@types/node": "^16.11.7",
+    "chai": "^6.2.2",
+    "mocha": "^11.7.5",
     "nodemon": "^3.0.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "npx nodemon",
     "build": "rm -rf ./build && tsc",
     "start": "node build/index.js",
-    "test": "mocha --require ts-node/register \"src/__tests__/**/*.test.ts\" --timeout 10000"
+    "test": "mocha --require ts-node/register \"test/**/*.test.ts\" --timeout 10000"
   },
   "author": "",
   "license": "ISC",

--- a/src/__tests__/GetSentencesWithStats.parseRequest.test.ts
+++ b/src/__tests__/GetSentencesWithStats.parseRequest.test.ts
@@ -1,0 +1,38 @@
+import { Request } from "express";
+import { assert } from "chai";
+import { GetSentencesWithStats } from "../dlg/GetSentencesWithStats";
+
+function makeRequest(params: Record<string, string>, query: Record<string, string> = {}): Request {
+    return { params, query, body: {} } as unknown as Request;
+}
+
+const delegate = new GetSentencesWithStats({} as any, {} as any);
+
+describe("GetSentencesWithStats.parseRequest — sortBy / sortDir validation", () => {
+
+    it("accepts no sortBy or sortDir and defaults to no sort", () => {
+        const result = delegate.parseRequest(makeRequest({ language: "danish" }));
+        assert.isUndefined(result.sortBy);
+        assert.isUndefined(result.sortDir);
+    });
+
+    it("accepts sortBy=difficulty with sortDir=asc", () => {
+        const result = delegate.parseRequest(makeRequest({ language: "danish" }, { sortBy: "difficulty", sortDir: "asc" }));
+        assert.equal(result.sortBy, "difficulty");
+        assert.equal(result.sortDir, "asc");
+    });
+
+    it("accepts sortBy=difficulty with sortDir=desc", () => {
+        const result = delegate.parseRequest(makeRequest({ language: "danish" }, { sortBy: "difficulty", sortDir: "desc" }));
+        assert.equal(result.sortBy, "difficulty");
+        assert.equal(result.sortDir, "desc");
+    });
+
+    it("throws for an invalid sortBy value", () => {
+        assert.throws(() => delegate.parseRequest(makeRequest({ language: "danish" }, { sortBy: "unknown" })));
+    });
+
+    it("throws for an invalid sortDir value", () => {
+        assert.throws(() => delegate.parseRequest(makeRequest({ language: "danish" }, { sortBy: "difficulty", sortDir: "sideways" })));
+    });
+});

--- a/src/__tests__/GetVocabularyWithStats.parseRequest.test.ts
+++ b/src/__tests__/GetVocabularyWithStats.parseRequest.test.ts
@@ -1,0 +1,38 @@
+import { Request } from "express";
+import { assert } from "chai";
+import { GetVocabularyWithStats } from "../dlg/GetVocabularyWithStats";
+
+function makeRequest(params: Record<string, string>, query: Record<string, string> = {}): Request {
+    return { params, query, body: {} } as unknown as Request;
+}
+
+const delegate = new GetVocabularyWithStats({} as any, {} as any);
+
+describe("GetVocabularyWithStats.parseRequest — sortBy / sortDir validation", () => {
+
+    it("accepts no sortBy or sortDir and defaults to no sort", () => {
+        const result = delegate.parseRequest(makeRequest({ language: "danish" }));
+        assert.isUndefined(result.sortBy);
+        assert.isUndefined(result.sortDir);
+    });
+
+    it("accepts sortBy=difficulty with sortDir=asc", () => {
+        const result = delegate.parseRequest(makeRequest({ language: "danish" }, { sortBy: "difficulty", sortDir: "asc" }));
+        assert.equal(result.sortBy, "difficulty");
+        assert.equal(result.sortDir, "asc");
+    });
+
+    it("accepts sortBy=difficulty with sortDir=desc", () => {
+        const result = delegate.parseRequest(makeRequest({ language: "danish" }, { sortBy: "difficulty", sortDir: "desc" }));
+        assert.equal(result.sortBy, "difficulty");
+        assert.equal(result.sortDir, "desc");
+    });
+
+    it("throws for an invalid sortBy value", () => {
+        assert.throws(() => delegate.parseRequest(makeRequest({ language: "danish" }, { sortBy: "unknown" })));
+    });
+
+    it("throws for an invalid sortDir value", () => {
+        assert.throws(() => delegate.parseRequest(makeRequest({ language: "danish" }, { sortBy: "difficulty", sortDir: "sideways" })));
+    });
+});

--- a/src/__tests__/SortUtils.test.ts
+++ b/src/__tests__/SortUtils.test.ts
@@ -1,0 +1,63 @@
+import { buildDifficultySortStage } from "../util/SortUtils";
+
+describe("buildDifficultySortStage", () => {
+
+    describe("sortDir=desc (hardest first)", () => {
+
+        const stages = buildDifficultySortStage("desc") as any[];
+
+        it("produces two stages", () => {
+            expect(stages).toHaveLength(2);
+        });
+
+        it("first stage negates failureRatio for items with stats", () => {
+            const addFields = stages[0].$addFields;
+            expect(addFields.sortKey.$cond.if).toEqual({ $ifNull: ["$stats", false] });
+            expect(addFields.sortKey.$cond.then).toEqual({ $multiply: ["$stats.failureRatio", -1] });
+        });
+
+        it("first stage assigns sortKey=1 for items without stats (sinks them to end)", () => {
+            const addFields = stages[0].$addFields;
+            expect(addFields.sortKey.$cond.else).toBe(1);
+        });
+
+        it("second stage sorts ascending on sortKey", () => {
+            expect(stages[1].$sort).toEqual({ sortKey: 1 });
+        });
+
+        it("sentinel value 1 is greater than any negated failureRatio in [-1, 0]", () => {
+            // failureRatio is in [0,1], so negated it's in [-1,0]. 1 > 0 => no-stats items last.
+            const sentinel = stages[0].$addFields.sortKey.$cond.else;
+            expect(sentinel).toBeGreaterThan(0);
+        });
+    });
+
+    describe("sortDir=asc (easiest first)", () => {
+
+        const stages = buildDifficultySortStage("asc") as any[];
+
+        it("produces two stages", () => {
+            expect(stages).toHaveLength(2);
+        });
+
+        it("first stage uses failureRatio directly for items with stats", () => {
+            const addFields = stages[0].$addFields;
+            expect(addFields.sortKey.$cond.if).toEqual({ $ifNull: ["$stats", false] });
+            expect(addFields.sortKey.$cond.then).toBe("$stats.failureRatio");
+        });
+
+        it("first stage assigns Number.MAX_VALUE for items without stats (sinks them to end)", () => {
+            const addFields = stages[0].$addFields;
+            expect(addFields.sortKey.$cond.else).toBe(Number.MAX_VALUE);
+        });
+
+        it("second stage sorts ascending on sortKey", () => {
+            expect(stages[1].$sort).toEqual({ sortKey: 1 });
+        });
+
+        it("sentinel Number.MAX_VALUE is greater than any failureRatio in [0, 1]", () => {
+            const sentinel = stages[0].$addFields.sortKey.$cond.else;
+            expect(sentinel).toBeGreaterThan(1);
+        });
+    });
+});

--- a/src/__tests__/SortUtils.test.ts
+++ b/src/__tests__/SortUtils.test.ts
@@ -1,3 +1,4 @@
+import { assert } from "chai";
 import { buildDifficultySortStage } from "../util/SortUtils";
 
 describe("buildDifficultySortStage", () => {
@@ -7,28 +8,25 @@ describe("buildDifficultySortStage", () => {
         const stages = buildDifficultySortStage("desc") as any[];
 
         it("produces two stages", () => {
-            expect(stages).toHaveLength(2);
+            assert.lengthOf(stages, 2);
         });
 
         it("first stage negates failureRatio for items with stats", () => {
-            const addFields = stages[0].$addFields;
-            expect(addFields.sortKey.$cond.if).toEqual({ $ifNull: ["$stats", false] });
-            expect(addFields.sortKey.$cond.then).toEqual({ $multiply: ["$stats.failureRatio", -1] });
+            const { sortKey } = stages[0].$addFields;
+            assert.deepEqual(sortKey.$cond.if, { $ifNull: ["$stats", false] });
+            assert.deepEqual(sortKey.$cond.then, { $multiply: ["$stats.failureRatio", -1] });
         });
 
         it("first stage assigns sortKey=1 for items without stats (sinks them to end)", () => {
-            const addFields = stages[0].$addFields;
-            expect(addFields.sortKey.$cond.else).toBe(1);
+            assert.equal(stages[0].$addFields.sortKey.$cond.else, 1);
         });
 
         it("second stage sorts ascending on sortKey", () => {
-            expect(stages[1].$sort).toEqual({ sortKey: 1 });
+            assert.deepEqual(stages[1].$sort, { sortKey: 1 });
         });
 
         it("sentinel value 1 is greater than any negated failureRatio in [-1, 0]", () => {
-            // failureRatio is in [0,1], so negated it's in [-1,0]. 1 > 0 => no-stats items last.
-            const sentinel = stages[0].$addFields.sortKey.$cond.else;
-            expect(sentinel).toBeGreaterThan(0);
+            assert.isAbove(stages[0].$addFields.sortKey.$cond.else, 0);
         });
     });
 
@@ -37,27 +35,25 @@ describe("buildDifficultySortStage", () => {
         const stages = buildDifficultySortStage("asc") as any[];
 
         it("produces two stages", () => {
-            expect(stages).toHaveLength(2);
+            assert.lengthOf(stages, 2);
         });
 
         it("first stage uses failureRatio directly for items with stats", () => {
-            const addFields = stages[0].$addFields;
-            expect(addFields.sortKey.$cond.if).toEqual({ $ifNull: ["$stats", false] });
-            expect(addFields.sortKey.$cond.then).toBe("$stats.failureRatio");
+            const { sortKey } = stages[0].$addFields;
+            assert.deepEqual(sortKey.$cond.if, { $ifNull: ["$stats", false] });
+            assert.equal(sortKey.$cond.then, "$stats.failureRatio");
         });
 
         it("first stage assigns Number.MAX_VALUE for items without stats (sinks them to end)", () => {
-            const addFields = stages[0].$addFields;
-            expect(addFields.sortKey.$cond.else).toBe(Number.MAX_VALUE);
+            assert.equal(stages[0].$addFields.sortKey.$cond.else, Number.MAX_VALUE);
         });
 
         it("second stage sorts ascending on sortKey", () => {
-            expect(stages[1].$sort).toEqual({ sortKey: 1 });
+            assert.deepEqual(stages[1].$sort, { sortKey: 1 });
         });
 
         it("sentinel Number.MAX_VALUE is greater than any failureRatio in [0, 1]", () => {
-            const sentinel = stages[0].$addFields.sortKey.$cond.else;
-            expect(sentinel).toBeGreaterThan(1);
+            assert.isAbove(stages[0].$addFields.sortKey.$cond.else, 1);
         });
     });
 });

--- a/src/dlg/GetSentencesWithStats.ts
+++ b/src/dlg/GetSentencesWithStats.ts
@@ -33,7 +33,24 @@ export class GetSentencesWithStats extends TotoDelegate<GetSentencesWithStatsReq
             }
         }
 
-        return { language, page, pageSize };
+        const sortByParam = req.query.sortBy as string | undefined;
+        const sortDirParam = req.query.sortDir as string | undefined;
+
+        const VALID_SORT_BY = ["difficulty"];
+        const VALID_SORT_DIR = ["asc", "desc"];
+
+        if (sortByParam !== undefined && !VALID_SORT_BY.includes(sortByParam)) {
+            throw new ValidationError(400, `Invalid sortBy value: "${sortByParam}". Accepted values: ${VALID_SORT_BY.join(", ")}`);
+        }
+
+        if (sortDirParam !== undefined && !VALID_SORT_DIR.includes(sortDirParam)) {
+            throw new ValidationError(400, `Invalid sortDir value: "${sortDirParam}". Accepted values: ${VALID_SORT_DIR.join(", ")}`);
+        }
+
+        const sortBy = sortByParam as "difficulty" | undefined;
+        const sortDir = sortDirParam as "asc" | "desc" | undefined;
+
+        return { language, page, pageSize, sortBy, sortDir };
     }
 
     async do(req: GetSentencesWithStatsRequest, userContext?: UserContext): Promise<GetSentencesWithStatsResponse> {
@@ -49,7 +66,9 @@ export class GetSentencesWithStats extends TotoDelegate<GetSentencesWithStatsReq
             language: req.language,
             userId: userContext.email,
             page: req.page,
-            pageSize: req.pageSize
+            pageSize: req.pageSize,
+            sortBy: req.sortBy,
+            sortDir: req.sortDir,
         });
 
         return {
@@ -66,6 +85,8 @@ interface GetSentencesWithStatsRequest {
     language: string;
     page: number;
     pageSize: number;
+    sortBy?: "difficulty";
+    sortDir?: "asc" | "desc";
 }
 
 interface GetSentencesWithStatsResponse {

--- a/src/dlg/GetVocabularyWithStats.ts
+++ b/src/dlg/GetVocabularyWithStats.ts
@@ -33,7 +33,24 @@ export class GetVocabularyWithStats extends TotoDelegate<GetVocabularyWithStatsR
             }
         }
 
-        return { language, page, pageSize };
+        const sortByParam = req.query.sortBy as string | undefined;
+        const sortDirParam = req.query.sortDir as string | undefined;
+
+        const VALID_SORT_BY = ["difficulty"];
+        const VALID_SORT_DIR = ["asc", "desc"];
+
+        if (sortByParam !== undefined && !VALID_SORT_BY.includes(sortByParam)) {
+            throw new ValidationError(400, `Invalid sortBy value: "${sortByParam}". Accepted values: ${VALID_SORT_BY.join(", ")}`);
+        }
+
+        if (sortDirParam !== undefined && !VALID_SORT_DIR.includes(sortDirParam)) {
+            throw new ValidationError(400, `Invalid sortDir value: "${sortDirParam}". Accepted values: ${VALID_SORT_DIR.join(", ")}`);
+        }
+
+        const sortBy = sortByParam as "difficulty" | undefined;
+        const sortDir = sortDirParam as "asc" | "desc" | undefined;
+
+        return { language, page, pageSize, sortBy, sortDir };
     }
 
     async do(req: GetVocabularyWithStatsRequest, userContext?: UserContext): Promise<GetVocabularyWithStatsResponse> {
@@ -49,7 +66,9 @@ export class GetVocabularyWithStats extends TotoDelegate<GetVocabularyWithStatsR
             language: req.language,
             userId: userContext.email,
             page: req.page,
-            pageSize: req.pageSize
+            pageSize: req.pageSize,
+            sortBy: req.sortBy,
+            sortDir: req.sortDir,
         });
 
         return {
@@ -66,6 +85,8 @@ interface GetVocabularyWithStatsRequest {
     language: string;
     page: number;
     pageSize: number;
+    sortBy?: "difficulty";
+    sortDir?: "asc" | "desc";
 }
 
 interface GetVocabularyWithStatsResponse {

--- a/src/store/SentenceStore.ts
+++ b/src/store/SentenceStore.ts
@@ -1,6 +1,7 @@
 import { Db, ObjectId } from "mongodb";
 import { ControllerConfig } from "../Config";
 import { Sentence } from "../model/Sentence";
+import { buildDifficultySortStage } from "../util/SortUtils";
 
 const SENTENCES_COLLECTION = "sentences";
 const SENTENCE_STATS_COLLECTION = "sentence_stats";
@@ -149,37 +150,35 @@ export class SentenceStore {
 
     /**
      * Finds sentences by language with user-specific stats using a LEFT OUTER JOIN.
-     * Sentences with stats are sorted by failureRatio descending (hardest first).
-     * Sentences without stats appear at the end.
-     * 
-     * @param language - The language to filter by
-     * @param userId - The user ID to join stats for
-     * @param page - 1-indexed page number
-     * @param pageSize - Number of items per page
+     *
+     * Default sort: alphabetical by `sentence`.
+     * When sortBy=difficulty: sort by failureRatio (sortDir controls direction).
+     * Items without stats always appear at the end when sorting by difficulty.
      */
-    async findByLanguageWithStats({ language, userId, page, pageSize }: {
+    async findByLanguageWithStats({ language, userId, page, pageSize, sortBy, sortDir }: {
         language: string;
         userId: string;
         page: number;
         pageSize: number;
+        sortBy?: "difficulty";
+        sortDir?: "asc" | "desc";
     }): Promise<SentencesWithStatsResult> {
 
         const skip = (page - 1) * pageSize;
 
-        // First, get the total count for the language
         const totalCount = await this.db.collection(SENTENCES_COLLECTION).countDocuments({ language });
 
-        // Aggregation pipeline for LEFT OUTER JOIN with sentence_stats
+        const sortStage = sortBy === "difficulty"
+            ? this.buildDifficultySortStage(sortDir ?? "asc")
+            : [{ $sort: { sentence: 1 as const } }];
+
         const pipeline = [
-            // Match sentences by language
             { $match: { language } },
-            // Convert _id to string for joining
             {
                 $addFields: {
                     sentenceIdStr: { $toString: "$_id" }
                 }
             },
-            // LEFT OUTER JOIN with sentence_stats filtered by userId
             {
                 $lookup: {
                     from: SENTENCE_STATS_COLLECTION,
@@ -199,31 +198,14 @@ export class SentenceStore {
                     as: "statsArray"
                 }
             },
-            // Unwind the stats array (preserving nulls for sentences without stats)
             {
                 $addFields: {
                     stats: { $arrayElemAt: ["$statsArray", 0] }
                 }
             },
-            // Add a sort key: 1 for items without stats (to sort them at the end)
-            // For items with stats, use negative failureRatio so higher ratios come first
-            {
-                $addFields: {
-                    sortKey: {
-                        $cond: {
-                            if: { $ifNull: ["$stats", false] },
-                            then: { $multiply: ["$stats.failureRatio", -1] },
-                            else: 1 // Items without stats get a high value to sort at the end
-                        }
-                    }
-                }
-            },
-            // Sort: items with stats (by failureRatio desc) first, then items without stats
-            { $sort: { sortKey: 1 as const } },
-            // Pagination
+            ...sortStage,
             { $skip: skip },
             { $limit: pageSize },
-            // Project final shape
             {
                 $project: {
                     _id: 1,
@@ -259,5 +241,13 @@ export class SentenceStore {
         }));
 
         return { sentences, totalCount };
+    }
+
+    /**
+     * Builds the aggregation sort stage for difficulty sorting.
+     * Items without stats always sort to the end regardless of direction.
+     */
+    private buildDifficultySortStage(sortDir: "asc" | "desc"): object[] {
+        return buildDifficultySortStage(sortDir);
     }
 }

--- a/src/store/VocabularyStore.ts
+++ b/src/store/VocabularyStore.ts
@@ -1,6 +1,7 @@
 import { Db, ObjectId } from "mongodb";
 import { ControllerConfig } from "../Config";
 import { Word } from "../model/Word";
+import { buildDifficultySortStage } from "../util/SortUtils";
 
 const VOCABULARY_COLLECTION = "vocabulary";
 const WORD_STATS_COLLECTION = "word_stats";
@@ -147,39 +148,30 @@ export class VocabularyStore {
         return result.deletedCount > 0;
     }
 
-    /**
-     * Finds vocabulary by language with user-specific stats using a LEFT OUTER JOIN.
-     * Words with stats are sorted by failureRatio descending (hardest first).
-     * Words without stats appear at the end.
-     * 
-     * @param language - The language to filter by
-     * @param userId - The user ID to join stats for
-     * @param page - 1-indexed page number
-     * @param pageSize - Number of items per page
-     */
-    async findByLanguageWithStats({ language, userId, page, pageSize }: {
+    async findByLanguageWithStats({ language, userId, page, pageSize, sortBy, sortDir }: {
         language: string;
         userId: string;
         page: number;
         pageSize: number;
+        sortBy?: "difficulty";
+        sortDir?: "asc" | "desc";
     }): Promise<VocabularyWithStatsResult> {
 
         const skip = (page - 1) * pageSize;
 
-        // First, get the total count for the language
         const totalCount = await this.db.collection(VOCABULARY_COLLECTION).countDocuments({ language });
 
-        // Aggregation pipeline for LEFT OUTER JOIN with word_stats
+        const sortStage = sortBy === "difficulty"
+            ? this.buildDifficultySortStage(sortDir ?? "asc")
+            : [{ $sort: { translation: 1 as const } }];
+
         const pipeline = [
-            // Match vocabulary by language
             { $match: { language } },
-            // Convert _id to string for joining
             {
                 $addFields: {
                     wordIdStr: { $toString: "$_id" }
                 }
             },
-            // LEFT OUTER JOIN with word_stats filtered by userId
             {
                 $lookup: {
                     from: WORD_STATS_COLLECTION,
@@ -199,31 +191,14 @@ export class VocabularyStore {
                     as: "statsArray"
                 }
             },
-            // Unwind the stats array (preserving nulls for words without stats)
             {
                 $addFields: {
                     stats: { $arrayElemAt: ["$statsArray", 0] }
                 }
             },
-            // Add a sort key: -1 for items without stats (to sort them at the end)
-            // For items with stats, use negative failureRatio so higher ratios come first
-            {
-                $addFields: {
-                    sortKey: {
-                        $cond: {
-                            if: { $ifNull: ["$stats", false] },
-                            then: { $multiply: ["$stats.failureRatio", -1] },
-                            else: 1 // Items without stats get a high value to sort at the end
-                        }
-                    }
-                }
-            },
-            // Sort: items with stats (by failureRatio desc) first, then items without stats
-            { $sort: { sortKey: 1 as const } },
-            // Pagination
+            ...sortStage,
             { $skip: skip },
             { $limit: pageSize },
-            // Project final shape
             {
                 $project: {
                     _id: 1,
@@ -259,5 +234,17 @@ export class VocabularyStore {
         }));
 
         return { words, totalCount };
+    }
+
+    /**
+     * Builds the aggregation sort stage for difficulty sorting.
+     * Items without stats always sort to the end regardless of direction.
+     *
+     * For desc: negate failureRatio so higher ratios sort first when sorting asc on sortKey.
+     *   Items without stats get sortKey=1, which is > any value in [-1,0].
+     * For asc: use failureRatio directly. Items without stats get sortKey=Number.MAX_VALUE.
+     */
+    private buildDifficultySortStage(sortDir: "asc" | "desc"): object[] {
+        return buildDifficultySortStage(sortDir);
     }
 }

--- a/src/util/SortUtils.ts
+++ b/src/util/SortUtils.ts
@@ -1,0 +1,44 @@
+/**
+ * Builds a MongoDB aggregation sort stage for difficulty-based sorting.
+ *
+ * Items without stats always sort to the end, regardless of direction.
+ *
+ * Strategy:
+ *  - desc: negate failureRatio → sort ascending on sortKey.
+ *          Items without stats get sortKey=1 which is > any value in [-1, 0].
+ *  - asc:  use failureRatio directly → sort ascending on sortKey.
+ *          Items without stats get sortKey=Number.MAX_VALUE which is > any value in [0, 1].
+ */
+export function buildDifficultySortStage(sortDir: "asc" | "desc"): object[] {
+    if (sortDir === "desc") {
+        return [
+            {
+                $addFields: {
+                    sortKey: {
+                        $cond: {
+                            if: { $ifNull: ["$stats", false] },
+                            then: { $multiply: ["$stats.failureRatio", -1] },
+                            else: 1
+                        }
+                    }
+                }
+            },
+            { $sort: { sortKey: 1 as const } }
+        ];
+    } else {
+        return [
+            {
+                $addFields: {
+                    sortKey: {
+                        $cond: {
+                            if: { $ifNull: ["$stats", false] },
+                            then: "$stats.failureRatio",
+                            else: Number.MAX_VALUE
+                        }
+                    }
+                }
+            },
+            { $sort: { sortKey: 1 as const } }
+        ];
+    }
+}

--- a/test/GetSentencesWithStats.parseRequest.test.ts
+++ b/test/GetSentencesWithStats.parseRequest.test.ts
@@ -1,0 +1,38 @@
+import { Request } from "express";
+import { assert } from "chai";
+import { GetSentencesWithStats } from "../src/dlg/GetSentencesWithStats";
+
+function makeRequest(params: Record<string, string>, query: Record<string, string> = {}): Request {
+    return { params, query, body: {} } as unknown as Request;
+}
+
+const delegate = new GetSentencesWithStats({} as any, {} as any);
+
+describe("GetSentencesWithStats.parseRequest — sortBy / sortDir validation", () => {
+
+    it("accepts no sortBy or sortDir and defaults to no sort", () => {
+        const result = delegate.parseRequest(makeRequest({ language: "danish" }));
+        assert.isUndefined(result.sortBy);
+        assert.isUndefined(result.sortDir);
+    });
+
+    it("accepts sortBy=difficulty with sortDir=asc", () => {
+        const result = delegate.parseRequest(makeRequest({ language: "danish" }, { sortBy: "difficulty", sortDir: "asc" }));
+        assert.equal(result.sortBy, "difficulty");
+        assert.equal(result.sortDir, "asc");
+    });
+
+    it("accepts sortBy=difficulty with sortDir=desc", () => {
+        const result = delegate.parseRequest(makeRequest({ language: "danish" }, { sortBy: "difficulty", sortDir: "desc" }));
+        assert.equal(result.sortBy, "difficulty");
+        assert.equal(result.sortDir, "desc");
+    });
+
+    it("throws for an invalid sortBy value", () => {
+        assert.throws(() => delegate.parseRequest(makeRequest({ language: "danish" }, { sortBy: "unknown" })));
+    });
+
+    it("throws for an invalid sortDir value", () => {
+        assert.throws(() => delegate.parseRequest(makeRequest({ language: "danish" }, { sortBy: "difficulty", sortDir: "sideways" })));
+    });
+});

--- a/test/GetVocabularyWithStats.parseRequest.test.ts
+++ b/test/GetVocabularyWithStats.parseRequest.test.ts
@@ -1,0 +1,38 @@
+import { Request } from "express";
+import { assert } from "chai";
+import { GetVocabularyWithStats } from "../src/dlg/GetVocabularyWithStats";
+
+function makeRequest(params: Record<string, string>, query: Record<string, string> = {}): Request {
+    return { params, query, body: {} } as unknown as Request;
+}
+
+const delegate = new GetVocabularyWithStats({} as any, {} as any);
+
+describe("GetVocabularyWithStats.parseRequest — sortBy / sortDir validation", () => {
+
+    it("accepts no sortBy or sortDir and defaults to no sort", () => {
+        const result = delegate.parseRequest(makeRequest({ language: "danish" }));
+        assert.isUndefined(result.sortBy);
+        assert.isUndefined(result.sortDir);
+    });
+
+    it("accepts sortBy=difficulty with sortDir=asc", () => {
+        const result = delegate.parseRequest(makeRequest({ language: "danish" }, { sortBy: "difficulty", sortDir: "asc" }));
+        assert.equal(result.sortBy, "difficulty");
+        assert.equal(result.sortDir, "asc");
+    });
+
+    it("accepts sortBy=difficulty with sortDir=desc", () => {
+        const result = delegate.parseRequest(makeRequest({ language: "danish" }, { sortBy: "difficulty", sortDir: "desc" }));
+        assert.equal(result.sortBy, "difficulty");
+        assert.equal(result.sortDir, "desc");
+    });
+
+    it("throws for an invalid sortBy value", () => {
+        assert.throws(() => delegate.parseRequest(makeRequest({ language: "danish" }, { sortBy: "unknown" })));
+    });
+
+    it("throws for an invalid sortDir value", () => {
+        assert.throws(() => delegate.parseRequest(makeRequest({ language: "danish" }, { sortBy: "difficulty", sortDir: "sideways" })));
+    });
+});

--- a/test/SortUtils.test.ts
+++ b/test/SortUtils.test.ts
@@ -1,0 +1,59 @@
+import { assert } from "chai";
+import { buildDifficultySortStage } from "../src/util/SortUtils";
+
+describe("buildDifficultySortStage", () => {
+
+    describe("sortDir=desc (hardest first)", () => {
+
+        const stages = buildDifficultySortStage("desc") as any[];
+
+        it("produces two stages", () => {
+            assert.lengthOf(stages, 2);
+        });
+
+        it("first stage negates failureRatio for items with stats", () => {
+            const { sortKey } = stages[0].$addFields;
+            assert.deepEqual(sortKey.$cond.if, { $ifNull: ["$stats", false] });
+            assert.deepEqual(sortKey.$cond.then, { $multiply: ["$stats.failureRatio", -1] });
+        });
+
+        it("first stage assigns sortKey=1 for items without stats (sinks them to end)", () => {
+            assert.equal(stages[0].$addFields.sortKey.$cond.else, 1);
+        });
+
+        it("second stage sorts ascending on sortKey", () => {
+            assert.deepEqual(stages[1].$sort, { sortKey: 1 });
+        });
+
+        it("sentinel value 1 is greater than any negated failureRatio in [-1, 0]", () => {
+            assert.isAbove(stages[0].$addFields.sortKey.$cond.else, 0);
+        });
+    });
+
+    describe("sortDir=asc (easiest first)", () => {
+
+        const stages = buildDifficultySortStage("asc") as any[];
+
+        it("produces two stages", () => {
+            assert.lengthOf(stages, 2);
+        });
+
+        it("first stage uses failureRatio directly for items with stats", () => {
+            const { sortKey } = stages[0].$addFields;
+            assert.deepEqual(sortKey.$cond.if, { $ifNull: ["$stats", false] });
+            assert.equal(sortKey.$cond.then, "$stats.failureRatio");
+        });
+
+        it("first stage assigns Number.MAX_VALUE for items without stats (sinks them to end)", () => {
+            assert.equal(stages[0].$addFields.sortKey.$cond.else, Number.MAX_VALUE);
+        });
+
+        it("second stage sorts ascending on sortKey", () => {
+            assert.deepEqual(stages[1].$sort, { sortKey: 1 });
+        });
+
+        it("sentinel Number.MAX_VALUE is greater than any failureRatio in [0, 1]", () => {
+            assert.isAbove(stages[0].$addFields.sortKey.$cond.else, 1);
+        });
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
 
     /* Modules */
     "module": "commonjs",
-    "rootDir": "src",
+    "rootDir": ".",
     "resolveJsonModule": true,
 
     /* JavaScript Support */
@@ -26,6 +26,10 @@
     "noImplicitAny": true,
 
     /* Completeness */
-    "skipLibCheck": true
-  }
+    "skipLibCheck": true,
+
+    /* Types */
+    "types": ["mocha", "node"]
+  },
+  "include": ["src/**/*", "test/**/*"]
 }


### PR DESCRIPTION
## Summary

Implements sorting support for the `with-stats` endpoints for both vocabulary (words) and sentences.

## Changes

- **Default sort**: alphabetical by `translation` (words) and `sentence` (sentences)
- **`?sortBy=difficulty`**: sort by `failureRatio`; `sortDir=asc|desc` controls direction
- Items without stats always appear at the end, regardless of sort direction
- `sortBy` / `sortDir` validation returns 400 for invalid values

## New files

- `src/util/SortUtils.ts` — `buildDifficultySortStage()` pure helper function
- `src/__tests__/SortUtils.test.ts` — unit tests for sort stage logic
- `src/__tests__/GetVocabularyWithStats.parseRequest.test.ts` — param validation tests
- `src/__tests__/GetSentencesWithStats.parseRequest.test.ts` — param validation tests

## Test setup

Mocha + Chai (20 tests, all passing).

## Closes

Closes #25
Closes #26