### PR TITLE
fix: stable pagination sort — add _id tiebreaker to difficulty sort stage

### DIFF
--- a/src/util/SortUtils.ts
+++ b/src/util/SortUtils.ts
@@ -23,7 +23,7 @@ export function buildDifficultySortStage(sortDir: "asc" | "desc"): object[] {
                     }
                 }
             },
-            { $sort: { sortKey: 1 as const } }
+            { $sort: { sortKey: 1 as const, _id: 1 as const } }
         ];
     } else {
         return [
@@ -38,7 +38,7 @@ export function buildDifficultySortStage(sortDir: "asc" | "desc"): object[] {
                     }
                 }
             },
-            { $sort: { sortKey: 1 as const } }
+            { $sort: { sortKey: 1 as const, _id: 1 as const } }
         ];
     }
 }

--- a/test/SortUtils.test.ts
+++ b/test/SortUtils.test.ts
@@ -21,8 +21,8 @@ describe("buildDifficultySortStage", () => {
             assert.equal(stages[0].$addFields.sortKey.$cond.else, 1);
         });
 
-        it("second stage sorts ascending on sortKey", () => {
-            assert.deepEqual(stages[1].$sort, { sortKey: 1 });
+        it("second stage sorts ascending on sortKey with _id tiebreaker", () => {
+            assert.deepEqual(stages[1].$sort, { sortKey: 1, _id: 1 });
         });
 
         it("sentinel value 1 is greater than any negated failureRatio in [-1, 0]", () => {
@@ -48,8 +48,8 @@ describe("buildDifficultySortStage", () => {
             assert.equal(stages[0].$addFields.sortKey.$cond.else, Number.MAX_VALUE);
         });
 
-        it("second stage sorts ascending on sortKey", () => {
-            assert.deepEqual(stages[1].$sort, { sortKey: 1 });
+        it("second stage sorts ascending on sortKey with _id tiebreaker", () => {
+            assert.deepEqual(stages[1].$sort, { sortKey: 1, _id: 1 });
         });
 
         it("sentinel Number.MAX_VALUE is greater than any failureRatio in [0, 1]", () => {


### PR DESCRIPTION
## Problem

When paginating vocabulary or sentences sorted by difficulty, duplicate items appeared across page boundaries. Root cause: the `buildDifficultySortStage` in `SortUtils.ts` only sorted by `sortKey` (derived from `failureRatio`). MongoDB gives no stable ordering guarantee for documents with equal sort keys, so the same document could land on both page 1 and page 2.

This manifested as a React `Encountered two children with the same key` warning in the frontend.

## Fix

Add `_id: 1` as a secondary sort key in both `asc` and `desc` branches of `buildDifficultySortStage`. `_id` is always unique, making pagination fully deterministic.

## Tests

Updated the two assertions in `SortUtils.test.ts` that checked the sort stage shape to expect `{ sortKey: 1, _id: 1 }`. All 20 tests pass.

Related: nicolasances/tome#249