### PR TITLE
feat: Alternative Translations — data model & session payload (issues #29, #30, #31)

### DIFF
--- a/docs/specs/alternative-translations-crud-endpoints.md
+++ b/docs/specs/alternative-translations-crud-endpoints.md
@@ -1,0 +1,57 @@
+# Spec: Alternative Translations — CRUD Endpoints
+
+## Objective
+
+Expose four HTTP endpoints to add and remove alternative translations for vocabulary words and sentences. These endpoints allow the frontend to persist user-accepted and AI-corrected alternatives to the shared pool stored in MongoDB.
+
+Covers: `tome-ms-language#30`
+
+## Core Logic
+
+### Endpoints
+
+| Method | Path | Delegate |
+|--------|------|----------|
+| `POST` | `/vocabulary/:language/words/:wordId/alternatives` | `AddWordAlternative` |
+| `DELETE` | `/vocabulary/:language/words/:wordId/alternatives/:id` | `RemoveWordAlternative` |
+| `POST` | `/sentences/:language/:sentenceId/alternatives` | `AddSentenceAlternative` |
+| `DELETE` | `/sentences/:language/:sentenceId/alternatives/:id` | `RemoveSentenceAlternative` |
+
+### Add Alternative (POST)
+
+- Request body: `{ translation: string }`
+- The translation is **lowercased** before storage
+- Check if a matching `translation` already exists in the array:
+  - If yes → return the existing `{ id, translation }` (idempotent, 200 OK)
+  - If no → generate a UUID via `crypto.randomUUID()`, push `{ id, translation }` to the array using MongoDB `$push`
+- Response: `{ id: string; translation: string }`
+- Returns 404 if the word/sentence document is not found
+
+### Remove Alternative (DELETE)
+
+- URL param: `:id` — the UUID of the alternative to remove
+- Uses MongoDB `$pull: { alternativeTranslations: { id: altId } }`
+- Returns 200 with `{ id, removed: true }` on success
+- Returns 404 if the word/sentence document is not found
+
+### Store methods
+
+Add to `VocabularyStore`:
+- `addAlternative(wordId: string, translation: string): Promise<{ id: string; translation: string }>` — dedup by translation, push with UUID if new
+- `removeAlternative(wordId: string, altId: string): Promise<boolean>` — returns false if document not found
+
+Add to `SentenceStore`:
+- Same two methods: `addAlternative(sentenceId, translation)`, `removeAlternative(sentenceId, altId)`
+
+### Architectural Decisions
+
+- **Dedup by translation string** (case-insensitive, normalised to lowercase). Two POST calls with the same translation yield exactly one stored entry and the same UUID in both responses.
+- **UUID generated server-side** with `crypto.randomUUID()` — no external dependency.
+- **MongoDB `$push`** (not `$addToSet`) because we perform the dedup check in application code first. This keeps the dedup behaviour and ID generation in a single readable place.
+- **404 on missing document**: The delegate checks `matchedCount` from the MongoDB update result; if 0, throws `ValidationError(404, ...)`.
+
+## Out of Scope
+
+- Rate limiting or quota on the number of alternatives per word/sentence
+- Single-item GET endpoints (covered in `tome-ms-language#31`)
+- Any UI changes

--- a/docs/specs/alternative-translations-data-model.md
+++ b/docs/specs/alternative-translations-data-model.md
@@ -1,0 +1,114 @@
+# Spec: Alternative Translations — Data Model & Payload Extensions
+
+GitHub issue: https://github.com/nicolasances/tome-ms-language/issues/29
+
+## Objective
+
+Extend the `Word` and `Sentence` data models to carry a list of **community-shared alternative translations** — additional phrasings that are equally valid answers for a given word or sentence. Each alternative is an object with a UUID and a translation string, so it can be individually identified and later removed by ID.
+
+Once the field exists on the model, it must be propagated through every response that returns word or sentence data:
+- The paginated **with-stats** list endpoints (used by the vocabulary and sentences browsing pages)
+- The **session start** payload (used by both vocabulary and sentence practice sessions, so the client can check alternatives at match-time without an extra round-trip)
+
+This task is **purely additive** — no existing behaviour changes. Documents that pre-date this change simply resolve `alternativeTranslations` to `[]`.
+
+---
+
+## Core Logic
+
+### Data Model Changes
+
+#### `Word` model (`src/model/Word.ts`)
+
+Add field:
+
+| Field                   | Type                                   | Description                                                  |
+|-------------------------|----------------------------------------|--------------------------------------------------------------|
+| `alternativeTranslations` | `Array<{ id: string; translation: string }>` | Community-accepted alternative translations. Defaults to `[]` when absent. |
+
+- `id` is a UUID (generated at creation time by the CRUD endpoint, not here).
+- `translation` is stored lowercase.
+- `fromBSON`: reads `data.alternativeTranslations ?? []`
+- `toBSON`: only writes the field if the array is non-empty (keeps existing documents clean)
+
+#### `Sentence` model (`src/model/Sentence.ts`)
+
+Identical change — same field, same rules.
+
+---
+
+### Store Changes
+
+#### `VocabularyStore.findByLanguageWithStats`
+
+The MongoDB `$project` stage must include `alternativeTranslations`:
+
+```js
+{
+  $project: {
+    _id: 1,
+    english: 1,
+    translation: 1,
+    createdAt: 1,
+    knowledgeSource: 1,
+    alternativeTranslations: { $ifNull: ["$alternativeTranslations", []] },
+    stats: { ... }   // unchanged
+  }
+}
+```
+
+The `WordWithStats` interface gains `alternativeTranslations: Array<{ id: string; translation: string }>`.
+
+#### `SentenceStore.findByLanguageWithStats`
+
+Same change to the `$project` stage and the `SentenceWithStats` interface.
+
+---
+
+### Session Payload Changes (`StartSession`)
+
+#### Vocabulary branch
+
+Each item in `payload.words` gains `alternativeTranslations`:
+
+```ts
+words: selectedWords.map(w => ({
+  wordId: w.id!,
+  english: w.english,
+  translation: w.translation,
+  alternativeTranslations: w.alternativeTranslations,   // ← new
+}))
+```
+
+`StartSessionResponse` vocabulary payload type updated accordingly.
+
+#### Sentences branch
+
+Each item in `payload.sentences` gains `alternativeTranslations`:
+
+```ts
+sentences: selectedSentences.map(s => ({
+  sentenceId: s.id!,
+  sentence: s.sentence,
+  translation: s.translation,
+  alternativeTranslations: s.alternativeTranslations,   // ← new
+}))
+```
+
+`StartSessionResponse` sentences payload type updated accordingly.
+
+---
+
+### Backward Compatibility
+
+- Existing documents in MongoDB that have no `alternativeTranslations` field resolve to `[]` via `$ifNull` in the aggregation pipeline and `?? []` in `fromBSON`.
+- No migration script needed.
+
+---
+
+## Out of Scope
+
+- CRUD endpoints for adding/removing alternative translations (covered in issue #30).
+- Single-item GET endpoints for the detail pages (covered in issue #31).
+- Any change to the `GetVocabulary` (non-paginated) endpoint — it is used only for internal/admin tooling and does not need to carry alternatives at this stage.
+- Validation of the `alternativeTranslations` field on insert — that is enforced by the add-alternative endpoint (issue #30).

--- a/docs/specs/alternative-translations-get-endpoints.md
+++ b/docs/specs/alternative-translations-get-endpoints.md
@@ -1,0 +1,73 @@
+# Spec: Alternative Translations — Single-Item GET Endpoints
+
+## Objective
+
+Add dedicated GET endpoints to fetch a single vocabulary word or sentence by ID, returning the full document including its `alternativeTranslations` array. Required so the frontend detail pages can load their data when navigated to directly by URL.
+
+Covers: `tome-ms-language#31`
+
+## Core Logic
+
+### Endpoints
+
+| Method | Path | Delegate |
+|--------|------|----------|
+| `GET` | `/vocabulary/:language/words/:wordId` | `GetWord` |
+| `GET` | `/sentences/:language/:sentenceId` | `GetSentence` |
+
+### Response shape
+
+**GetWord** — `200 OK`:
+```json
+{
+  "id": "string",
+  "language": "string",
+  "english": "string",
+  "translation": "string",
+  "createdAt": "string",
+  "knowledgeSource": "string",
+  "alternativeTranslations": [{ "id": "string", "translation": "string" }]
+}
+```
+
+**GetSentence** — `200 OK`:
+```json
+{
+  "id": "string",
+  "language": "string",
+  "sentence": "string",
+  "translation": "string",
+  "createdAt": "string",
+  "knowledgeSource": "string",
+  "alternativeTranslations": [{ "id": "string", "translation": "string" }]
+}
+```
+
+Both return `404` when the document is not found or the `id` is malformed.
+
+### Store methods
+
+Add to `VocabularyStore`:
+- `findById(id: string): Promise<Word | null>` — uses `new ObjectId(id)` for lookup; returns `null` if not found or if `id` is an invalid ObjectId
+
+Add to `SentenceStore`:
+- `findById(id: string): Promise<Sentence | null>` — same pattern
+
+### Delegate logic
+
+Both delegates follow the same pattern:
+1. Parse `wordId` / `sentenceId` from URL params
+2. Call `store.findById(id)`
+3. If `null` → throw `ValidationError(404, ...)`
+4. Map model fields to response shape (use `Word.fromBSON` / `Sentence.fromBSON` indirectly via `findById`)
+
+### Architectural Decisions
+
+- **No stats in response** — stats are not needed for the detail pages at this stage; they can be added later if required.
+- **`findById` returns `Word | null`** — keeps error handling in the delegate, not the store.
+- **ObjectId wrapping** — `new ObjectId(id)` can throw for malformed IDs; wrap in try/catch in the store method and return `null` to surface a clean 404 to the caller.
+
+## Out of Scope
+
+- Stats (failureRatio, totalAttempts, etc.) in the response
+- Paginated or filtered GET endpoints (those already exist via `with-stats` endpoints)

--- a/src/dlg/AddSentenceAlternative.ts
+++ b/src/dlg/AddSentenceAlternative.ts
@@ -1,0 +1,36 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../Config";
+import { SentenceStore } from "../store/SentenceStore";
+import { SUPPORTED_LANGUAGES } from "../util/Languages";
+
+export class AddSentenceAlternative extends TotoDelegate<AddSentenceAlternativeRequest, AddSentenceAlternativeResponse> {
+
+    parseRequest(req: Request): AddSentenceAlternativeRequest {
+        const language = req.params.language;
+        if (!SUPPORTED_LANGUAGES.includes(language)) throw new ValidationError(400, `Unsupported language: ${language}`);
+        const translation = req.body?.translation;
+        if (!translation) throw new ValidationError(400, "translation is required");
+        return { language, sentenceId: req.params.sentenceId, translation };
+    }
+
+    async do(req: AddSentenceAlternativeRequest, userContext?: UserContext): Promise<AddSentenceAlternativeResponse> {
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+        const store = new SentenceStore(db, config);
+        const result = await store.addAlternative(req.sentenceId, req.translation);
+        if (!result) throw new ValidationError(404, `Sentence not found: ${req.sentenceId}`);
+        return result;
+    }
+}
+
+interface AddSentenceAlternativeRequest {
+    language: string;
+    sentenceId: string;
+    translation: string;
+}
+
+interface AddSentenceAlternativeResponse {
+    id: string;
+    translation: string;
+}

--- a/src/dlg/AddSentenceAlternative.ts
+++ b/src/dlg/AddSentenceAlternative.ts
@@ -7,19 +7,27 @@ import { SUPPORTED_LANGUAGES } from "../util/Languages";
 export class AddSentenceAlternative extends TotoDelegate<AddSentenceAlternativeRequest, AddSentenceAlternativeResponse> {
 
     parseRequest(req: Request): AddSentenceAlternativeRequest {
+        
         const language = req.params.language;
-        if (!SUPPORTED_LANGUAGES.includes(language)) throw new ValidationError(400, `Unsupported language: ${language}`);
         const translation = req.body?.translation;
+        
+        if (!SUPPORTED_LANGUAGES.includes(language)) throw new ValidationError(400, `Unsupported language: ${language}`);
         if (!translation) throw new ValidationError(400, "translation is required");
+        
         return { language, sentenceId: req.params.sentenceId, translation };
     }
 
     async do(req: AddSentenceAlternativeRequest, userContext?: UserContext): Promise<AddSentenceAlternativeResponse> {
+        
         const config = this.config as ControllerConfig;
         const db = await config.getMongoDb(config.getDBName());
+        
         const store = new SentenceStore(db, config);
+        
         const result = await store.addAlternative(req.sentenceId, req.translation);
+        
         if (!result) throw new ValidationError(404, `Sentence not found: ${req.sentenceId}`);
+        
         return result;
     }
 }

--- a/src/dlg/AddWordAlternative.ts
+++ b/src/dlg/AddWordAlternative.ts
@@ -1,0 +1,36 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../Config";
+import { VocabularyStore } from "../store/VocabularyStore";
+import { SUPPORTED_LANGUAGES } from "../util/Languages";
+
+export class AddWordAlternative extends TotoDelegate<AddWordAlternativeRequest, AddWordAlternativeResponse> {
+
+    parseRequest(req: Request): AddWordAlternativeRequest {
+        const language = req.params.language;
+        if (!SUPPORTED_LANGUAGES.includes(language)) throw new ValidationError(400, `Unsupported language: ${language}`);
+        const translation = req.body?.translation;
+        if (!translation) throw new ValidationError(400, "translation is required");
+        return { language, wordId: req.params.wordId, translation };
+    }
+
+    async do(req: AddWordAlternativeRequest, userContext?: UserContext): Promise<AddWordAlternativeResponse> {
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+        const store = new VocabularyStore(db, config);
+        const result = await store.addAlternative(req.wordId, req.translation);
+        if (!result) throw new ValidationError(404, `Word not found: ${req.wordId}`);
+        return result;
+    }
+}
+
+interface AddWordAlternativeRequest {
+    language: string;
+    wordId: string;
+    translation: string;
+}
+
+interface AddWordAlternativeResponse {
+    id: string;
+    translation: string;
+}

--- a/src/dlg/AddWordAlternative.ts
+++ b/src/dlg/AddWordAlternative.ts
@@ -7,19 +7,27 @@ import { SUPPORTED_LANGUAGES } from "../util/Languages";
 export class AddWordAlternative extends TotoDelegate<AddWordAlternativeRequest, AddWordAlternativeResponse> {
 
     parseRequest(req: Request): AddWordAlternativeRequest {
+
         const language = req.params.language;
-        if (!SUPPORTED_LANGUAGES.includes(language)) throw new ValidationError(400, `Unsupported language: ${language}`);
         const translation = req.body?.translation;
+        
+        if (!SUPPORTED_LANGUAGES.includes(language)) throw new ValidationError(400, `Unsupported language: ${language}`);
         if (!translation) throw new ValidationError(400, "translation is required");
+        
         return { language, wordId: req.params.wordId, translation };
     }
 
     async do(req: AddWordAlternativeRequest, userContext?: UserContext): Promise<AddWordAlternativeResponse> {
+        
         const config = this.config as ControllerConfig;
         const db = await config.getMongoDb(config.getDBName());
+        
         const store = new VocabularyStore(db, config);
+        
         const result = await store.addAlternative(req.wordId, req.translation);
+        
         if (!result) throw new ValidationError(404, `Word not found: ${req.wordId}`);
+        
         return result;
     }
 }

--- a/src/dlg/DeleteWord.ts
+++ b/src/dlg/DeleteWord.ts
@@ -10,10 +10,12 @@ export class DeleteWord extends TotoDelegate<DeleteWordRequest, DeleteWordRespon
     }
 
     async do(req: DeleteWordRequest, userContext?: UserContext): Promise<DeleteWordResponse> {
+        
         const config = this.config as ControllerConfig;
         const db = await config.getMongoDb(config.getDBName());
 
         const store = new VocabularyStore(db, config);
+        
         const deleted = await store.deleteWord(req.id);
 
         if (!deleted) throw new ValidationError(404, `Word not found: ${req.id}`);

--- a/src/dlg/GetSentence.ts
+++ b/src/dlg/GetSentence.ts
@@ -7,17 +7,25 @@ import { SUPPORTED_LANGUAGES } from "../util/Languages";
 export class GetSentence extends TotoDelegate<GetSentenceRequest, GetSentenceResponse> {
 
     parseRequest(req: Request): GetSentenceRequest {
+        
         const language = req.params.language;
+        
         if (!SUPPORTED_LANGUAGES.includes(language)) throw new ValidationError(400, `Unsupported language: ${language}`);
+        
         return { language, sentenceId: req.params.sentenceId };
     }
 
     async do(req: GetSentenceRequest, userContext?: UserContext): Promise<GetSentenceResponse> {
+        
         const config = this.config as ControllerConfig;
         const db = await config.getMongoDb(config.getDBName());
+        
         const store = new SentenceStore(db, config);
+        
         const sentence = await store.findById(req.sentenceId);
+        
         if (!sentence) throw new ValidationError(404, `Sentence not found: ${req.sentenceId}`);
+        
         return { id: sentence.id!, language: sentence.language, sentence: sentence.sentence, translation: sentence.translation, createdAt: sentence.createdAt, knowledgeSource: sentence.knowledgeSource, alternativeTranslations: sentence.alternativeTranslations };
     }
 }

--- a/src/dlg/GetSentence.ts
+++ b/src/dlg/GetSentence.ts
@@ -1,0 +1,38 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../Config";
+import { SentenceStore } from "../store/SentenceStore";
+import { SUPPORTED_LANGUAGES } from "../util/Languages";
+
+export class GetSentence extends TotoDelegate<GetSentenceRequest, GetSentenceResponse> {
+
+    parseRequest(req: Request): GetSentenceRequest {
+        const language = req.params.language;
+        if (!SUPPORTED_LANGUAGES.includes(language)) throw new ValidationError(400, `Unsupported language: ${language}`);
+        return { language, sentenceId: req.params.sentenceId };
+    }
+
+    async do(req: GetSentenceRequest, userContext?: UserContext): Promise<GetSentenceResponse> {
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+        const store = new SentenceStore(db, config);
+        const sentence = await store.findById(req.sentenceId);
+        if (!sentence) throw new ValidationError(404, `Sentence not found: ${req.sentenceId}`);
+        return { id: sentence.id!, language: sentence.language, sentence: sentence.sentence, translation: sentence.translation, createdAt: sentence.createdAt, knowledgeSource: sentence.knowledgeSource, alternativeTranslations: sentence.alternativeTranslations };
+    }
+}
+
+interface GetSentenceRequest {
+    language: string;
+    sentenceId: string;
+}
+
+interface GetSentenceResponse {
+    id: string;
+    language: string;
+    sentence: string;
+    translation: string;
+    createdAt: string;
+    knowledgeSource: string;
+    alternativeTranslations: Array<{ id: string; translation: string }>;
+}

--- a/src/dlg/GetSentences.ts
+++ b/src/dlg/GetSentences.ts
@@ -7,16 +7,21 @@ import { SUPPORTED_LANGUAGES } from "../util/Languages";
 export class GetSentences extends TotoDelegate<GetSentencesRequest, GetSentencesResponse> {
 
     parseRequest(req: Request): GetSentencesRequest {
+        
         const language = req.params.language;
+        
         if (!SUPPORTED_LANGUAGES.includes(language)) {
             throw new ValidationError(400, `Unsupported language: ${language}`);
         }
+        
         return { language };
     }
 
     async do(req: GetSentencesRequest, userContext?: UserContext): Promise<GetSentencesResponse> {
+        
         const config = this.config as ControllerConfig;
         const db = await config.getMongoDb(config.getDBName());
+        
         const store = new SentenceStore(db, config);
 
         const sentences = await store.findByLanguage(req.language);

--- a/src/dlg/GetSentencesWithStats.ts
+++ b/src/dlg/GetSentencesWithStats.ts
@@ -9,15 +9,20 @@ const DEFAULT_PAGE_SIZE = 100;
 export class GetSentencesWithStats extends TotoDelegate<GetSentencesWithStatsRequest, GetSentencesWithStatsResponse> {
 
     parseRequest(req: Request): GetSentencesWithStatsRequest {
+        
         const language = req.params.language;
+        const pageParam = req.query.page;
+        const pageSizeParam = req.query.pageSize;
+        const sortByParam = req.query.sortBy as string | undefined;
+        const sortDirParam = req.query.sortDir as string | undefined;
+        
+        let page = 1;
+        let pageSize = DEFAULT_PAGE_SIZE;
+        
         if (!SUPPORTED_LANGUAGES.includes(language)) {
             throw new ValidationError(400, `Unsupported language: ${language}`);
         }
 
-        const pageParam = req.query.page;
-        const pageSizeParam = req.query.pageSize;
-
-        let page = 1;
         if (pageParam !== undefined) {
             page = parseInt(pageParam as string, 10);
             if (isNaN(page) || page < 1) {
@@ -25,16 +30,12 @@ export class GetSentencesWithStats extends TotoDelegate<GetSentencesWithStatsReq
             }
         }
 
-        let pageSize = DEFAULT_PAGE_SIZE;
         if (pageSizeParam !== undefined) {
             pageSize = parseInt(pageSizeParam as string, 10);
             if (isNaN(pageSize) || pageSize < 1) {
                 throw new ValidationError(400, "pageSize must be a positive integer");
             }
         }
-
-        const sortByParam = req.query.sortBy as string | undefined;
-        const sortDirParam = req.query.sortDir as string | undefined;
 
         const VALID_SORT_BY = ["difficulty"];
         const VALID_SORT_DIR = ["asc", "desc"];

--- a/src/dlg/GetVocabulary.ts
+++ b/src/dlg/GetVocabulary.ts
@@ -7,14 +7,18 @@ import { SUPPORTED_LANGUAGES } from "../util/Languages";
 export class GetVocabulary extends TotoDelegate<GetVocabularyRequest, GetVocabularyResponse> {
 
     parseRequest(req: Request): GetVocabularyRequest {
+
         const language = req.params.language;
+        
         if (!SUPPORTED_LANGUAGES.includes(language)) {
             throw new ValidationError(400, `Unsupported language: ${language}`);
         }
+        
         return { language };
     }
 
     async do(req: GetVocabularyRequest, userContext?: UserContext): Promise<GetVocabularyResponse> {
+        
         const config = this.config as ControllerConfig;
         const db = await config.getMongoDb(config.getDBName());
 

--- a/src/dlg/GetVocabularyWithStats.ts
+++ b/src/dlg/GetVocabularyWithStats.ts
@@ -9,15 +9,20 @@ const DEFAULT_PAGE_SIZE = 100;
 export class GetVocabularyWithStats extends TotoDelegate<GetVocabularyWithStatsRequest, GetVocabularyWithStatsResponse> {
 
     parseRequest(req: Request): GetVocabularyWithStatsRequest {
+
         const language = req.params.language;
+        const pageParam = req.query.page;
+        const pageSizeParam = req.query.pageSize;
+        const sortByParam = req.query.sortBy as string | undefined;
+        const sortDirParam = req.query.sortDir as string | undefined;
+
+        let page = 1;
+        let pageSize = DEFAULT_PAGE_SIZE;
+        
         if (!SUPPORTED_LANGUAGES.includes(language)) {
             throw new ValidationError(400, `Unsupported language: ${language}`);
         }
 
-        const pageParam = req.query.page;
-        const pageSizeParam = req.query.pageSize;
-
-        let page = 1;
         if (pageParam !== undefined) {
             page = parseInt(pageParam as string, 10);
             if (isNaN(page) || page < 1) {
@@ -25,16 +30,12 @@ export class GetVocabularyWithStats extends TotoDelegate<GetVocabularyWithStatsR
             }
         }
 
-        let pageSize = DEFAULT_PAGE_SIZE;
         if (pageSizeParam !== undefined) {
             pageSize = parseInt(pageSizeParam as string, 10);
             if (isNaN(pageSize) || pageSize < 1) {
                 throw new ValidationError(400, "pageSize must be a positive integer");
             }
         }
-
-        const sortByParam = req.query.sortBy as string | undefined;
-        const sortDirParam = req.query.sortDir as string | undefined;
 
         const VALID_SORT_BY = ["difficulty"];
         const VALID_SORT_DIR = ["asc", "desc"];
@@ -54,6 +55,7 @@ export class GetVocabularyWithStats extends TotoDelegate<GetVocabularyWithStatsR
     }
 
     async do(req: GetVocabularyWithStatsRequest, userContext?: UserContext): Promise<GetVocabularyWithStatsResponse> {
+
         if (!userContext?.email) {
             throw new ValidationError(401, "Unauthorized: user context required");
         }

--- a/src/dlg/GetWord.ts
+++ b/src/dlg/GetWord.ts
@@ -1,0 +1,38 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../Config";
+import { VocabularyStore } from "../store/VocabularyStore";
+import { SUPPORTED_LANGUAGES } from "../util/Languages";
+
+export class GetWord extends TotoDelegate<GetWordRequest, GetWordResponse> {
+
+    parseRequest(req: Request): GetWordRequest {
+        const language = req.params.language;
+        if (!SUPPORTED_LANGUAGES.includes(language)) throw new ValidationError(400, `Unsupported language: ${language}`);
+        return { language, wordId: req.params.wordId };
+    }
+
+    async do(req: GetWordRequest, userContext?: UserContext): Promise<GetWordResponse> {
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+        const store = new VocabularyStore(db, config);
+        const word = await store.findById(req.wordId);
+        if (!word) throw new ValidationError(404, `Word not found: ${req.wordId}`);
+        return { id: word.id!, language: word.language, english: word.english, translation: word.translation, createdAt: word.createdAt, knowledgeSource: word.knowledgeSource, alternativeTranslations: word.alternativeTranslations };
+    }
+}
+
+interface GetWordRequest {
+    language: string;
+    wordId: string;
+}
+
+interface GetWordResponse {
+    id: string;
+    language: string;
+    english: string;
+    translation: string;
+    createdAt: string;
+    knowledgeSource: string;
+    alternativeTranslations: Array<{ id: string; translation: string }>;
+}

--- a/src/dlg/GetWord.ts
+++ b/src/dlg/GetWord.ts
@@ -7,17 +7,25 @@ import { SUPPORTED_LANGUAGES } from "../util/Languages";
 export class GetWord extends TotoDelegate<GetWordRequest, GetWordResponse> {
 
     parseRequest(req: Request): GetWordRequest {
+
         const language = req.params.language;
+        
         if (!SUPPORTED_LANGUAGES.includes(language)) throw new ValidationError(400, `Unsupported language: ${language}`);
+        
         return { language, wordId: req.params.wordId };
     }
 
     async do(req: GetWordRequest, userContext?: UserContext): Promise<GetWordResponse> {
+        
         const config = this.config as ControllerConfig;
         const db = await config.getMongoDb(config.getDBName());
+        
         const store = new VocabularyStore(db, config);
+        
         const word = await store.findById(req.wordId);
+        
         if (!word) throw new ValidationError(404, `Word not found: ${req.wordId}`);
+        
         return { id: word.id!, language: word.language, english: word.english, translation: word.translation, createdAt: word.createdAt, knowledgeSource: word.knowledgeSource, alternativeTranslations: word.alternativeTranslations };
     }
 }

--- a/src/dlg/RemoveSentenceAlternative.ts
+++ b/src/dlg/RemoveSentenceAlternative.ts
@@ -7,17 +7,25 @@ import { SUPPORTED_LANGUAGES } from "../util/Languages";
 export class RemoveSentenceAlternative extends TotoDelegate<RemoveSentenceAlternativeRequest, RemoveSentenceAlternativeResponse> {
 
     parseRequest(req: Request): RemoveSentenceAlternativeRequest {
+
         const language = req.params.language;
+        
         if (!SUPPORTED_LANGUAGES.includes(language)) throw new ValidationError(400, `Unsupported language: ${language}`);
+        
         return { language, sentenceId: req.params.sentenceId, altId: req.params.id };
     }
 
     async do(req: RemoveSentenceAlternativeRequest, userContext?: UserContext): Promise<RemoveSentenceAlternativeResponse> {
+        
         const config = this.config as ControllerConfig;
         const db = await config.getMongoDb(config.getDBName());
+        
         const store = new SentenceStore(db, config);
+        
         const found = await store.removeAlternative(req.sentenceId, req.altId);
+        
         if (!found) throw new ValidationError(404, `Sentence not found: ${req.sentenceId}`);
+        
         return { id: req.altId, removed: true };
     }
 }

--- a/src/dlg/RemoveSentenceAlternative.ts
+++ b/src/dlg/RemoveSentenceAlternative.ts
@@ -1,0 +1,34 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../Config";
+import { SentenceStore } from "../store/SentenceStore";
+import { SUPPORTED_LANGUAGES } from "../util/Languages";
+
+export class RemoveSentenceAlternative extends TotoDelegate<RemoveSentenceAlternativeRequest, RemoveSentenceAlternativeResponse> {
+
+    parseRequest(req: Request): RemoveSentenceAlternativeRequest {
+        const language = req.params.language;
+        if (!SUPPORTED_LANGUAGES.includes(language)) throw new ValidationError(400, `Unsupported language: ${language}`);
+        return { language, sentenceId: req.params.sentenceId, altId: req.params.id };
+    }
+
+    async do(req: RemoveSentenceAlternativeRequest, userContext?: UserContext): Promise<RemoveSentenceAlternativeResponse> {
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+        const store = new SentenceStore(db, config);
+        const found = await store.removeAlternative(req.sentenceId, req.altId);
+        if (!found) throw new ValidationError(404, `Sentence not found: ${req.sentenceId}`);
+        return { id: req.altId, removed: true };
+    }
+}
+
+interface RemoveSentenceAlternativeRequest {
+    language: string;
+    sentenceId: string;
+    altId: string;
+}
+
+interface RemoveSentenceAlternativeResponse {
+    id: string;
+    removed: boolean;
+}

--- a/src/dlg/RemoveWordAlternative.ts
+++ b/src/dlg/RemoveWordAlternative.ts
@@ -1,0 +1,34 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../Config";
+import { VocabularyStore } from "../store/VocabularyStore";
+import { SUPPORTED_LANGUAGES } from "../util/Languages";
+
+export class RemoveWordAlternative extends TotoDelegate<RemoveWordAlternativeRequest, RemoveWordAlternativeResponse> {
+
+    parseRequest(req: Request): RemoveWordAlternativeRequest {
+        const language = req.params.language;
+        if (!SUPPORTED_LANGUAGES.includes(language)) throw new ValidationError(400, `Unsupported language: ${language}`);
+        return { language, wordId: req.params.wordId, altId: req.params.id };
+    }
+
+    async do(req: RemoveWordAlternativeRequest, userContext?: UserContext): Promise<RemoveWordAlternativeResponse> {
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+        const store = new VocabularyStore(db, config);
+        const found = await store.removeAlternative(req.wordId, req.altId);
+        if (!found) throw new ValidationError(404, `Word not found: ${req.wordId}`);
+        return { id: req.altId, removed: true };
+    }
+}
+
+interface RemoveWordAlternativeRequest {
+    language: string;
+    wordId: string;
+    altId: string;
+}
+
+interface RemoveWordAlternativeResponse {
+    id: string;
+    removed: boolean;
+}

--- a/src/dlg/RemoveWordAlternative.ts
+++ b/src/dlg/RemoveWordAlternative.ts
@@ -13,11 +13,16 @@ export class RemoveWordAlternative extends TotoDelegate<RemoveWordAlternativeReq
     }
 
     async do(req: RemoveWordAlternativeRequest, userContext?: UserContext): Promise<RemoveWordAlternativeResponse> {
+
         const config = this.config as ControllerConfig;
         const db = await config.getMongoDb(config.getDBName());
+        
         const store = new VocabularyStore(db, config);
+        
         const found = await store.removeAlternative(req.wordId, req.altId);
+        
         if (!found) throw new ValidationError(404, `Word not found: ${req.wordId}`);
+        
         return { id: req.altId, removed: true };
     }
 }

--- a/src/dlg/SampleWords.ts
+++ b/src/dlg/SampleWords.ts
@@ -8,15 +8,19 @@ import { SUPPORTED_LANGUAGES } from "../util/Languages";
 export class SampleWords extends TotoDelegate<SampleWordsRequest, SampleWordsResponse> {
 
     parseRequest(req: Request): SampleWordsRequest {
+
         const language = req.params.language;
+        
         if (!SUPPORTED_LANGUAGES.includes(language)) {
             throw new ValidationError(400, `Unsupported language: ${language}`);
         }
 
         const nParam = req.query.n;
         let n = 20;
+        
         if (nParam !== undefined) {
             const parsed = Number(nParam);
+        
             if (!Number.isInteger(parsed) || parsed <= 0) {
                 throw new ValidationError(400, `Invalid 'n' parameter: must be a positive integer`);
             }
@@ -27,8 +31,10 @@ export class SampleWords extends TotoDelegate<SampleWordsRequest, SampleWordsRes
     }
 
     async do(req: SampleWordsRequest, userContext?: UserContext): Promise<SampleWordsResponse> {
+        
         const config = this.config as ControllerConfig;
         const db = await config.getMongoDb(config.getDBName());
+        
         const store = new SentenceStore(db, config);
 
         const raw = await store.sampleWords(req.language, req.n);

--- a/src/dlg/session/StartSession.ts
+++ b/src/dlg/session/StartSession.ts
@@ -60,7 +60,7 @@ export class StartSession extends TotoDelegate<StartSessionRequest, StartSession
             );
 
             const payload: VocabularySessionPayload = {
-                words: selectedWords.map(w => ({ wordId: w.id!, english: w.english, translation: w.translation })),
+                words: selectedWords.map(w => ({ wordId: w.id!, english: w.english, translation: w.translation, alternativeTranslations: w.alternativeTranslations })),
                 totalWords: selectedWords.length,
                 answers: [],
             };
@@ -109,7 +109,7 @@ export class StartSession extends TotoDelegate<StartSessionRequest, StartSession
         );
 
         const payload: SentenceSessionPayload = {
-            sentences: selectedSentences.map(s => ({ sentenceId: s.id!, sentence: s.sentence, translation: s.translation })),
+            sentences: selectedSentences.map(s => ({ sentenceId: s.id!, sentence: s.sentence, translation: s.translation, alternativeTranslations: s.alternativeTranslations })),
             totalSentences: selectedSentences.length,
             answers: [],
         };
@@ -149,10 +149,10 @@ interface StartSessionResponse {
     practiceType: string;
     payload: {
         // vocabulary
-        words?: Array<{ wordId: string; english: string; translation: string }>;
+        words?: Array<{ wordId: string; english: string; translation: string; alternativeTranslations: Array<{ id: string; translation: string }> }>;
         totalWords?: number;
         // sentences
-        sentences?: Array<{ sentenceId: string; sentence: string; translation: string }>;
+        sentences?: Array<{ sentenceId: string; sentence: string; translation: string; alternativeTranslations: Array<{ id: string; translation: string }> }>;
         totalSentences?: number;
     };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,25 @@
 import { getHyperscalerConfiguration, SupportedHyperscalers, TotoMicroservice, TotoMicroserviceConfiguration } from 'totoms';
 import { ControllerConfig } from "./Config";
+import { AddSentenceAlternative } from './dlg/AddSentenceAlternative';
+import { AddWordAlternative } from './dlg/AddWordAlternative';
 import { CompleteSession } from './dlg/session/CompleteSession';
 import { DeleteWord } from './dlg/DeleteWord';
 import { GetActiveSession } from './dlg/session/GetActiveSession';
 import { GetRollingSessionStats } from './dlg/session/GetRollingSessionStats';
+import { GetSentence } from './dlg/GetSentence';
 import { GetSentences } from './dlg/GetSentences';
 import { GetSentencesWithStats } from './dlg/GetSentencesWithStats';
 import { GetVocabulary } from './dlg/GetVocabulary';
 import { GetVocabularyWithStats } from './dlg/GetVocabularyWithStats';
 import { GetWeeklySessionStats } from './dlg/session/GetWeeklySessionStats';
+import { GetWord } from './dlg/GetWord';
 import { PostSentence } from './dlg/PostSentence';
 import { PostSentences } from './dlg/PostSentences';
 import { PostWord } from './dlg/PostWord';
 import { PostWords } from './dlg/PostWords';
 import { PutWord } from './dlg/PutWord';
+import { RemoveSentenceAlternative } from './dlg/RemoveSentenceAlternative';
+import { RemoveWordAlternative } from './dlg/RemoveWordAlternative';
 import { SampleWords } from './dlg/SampleWords';
 import { StartSession } from './dlg/session/StartSession';
 import { SubmitAnswer } from './dlg/session/SubmitAnswer';
@@ -33,12 +39,18 @@ const config: TotoMicroserviceConfiguration = {
             { method: 'POST', path: '/vocabulary/:language/words', delegate: PostWord },
             { method: 'POST', path: '/vocabulary/:language/words/batch', delegate: PostWords },
             { method: 'GET', path: '/vocabulary/:language/words/sample', delegate: SampleWords },
+            { method: 'GET', path: '/vocabulary/:language/words/:wordId', delegate: GetWord },
             { method: 'PUT', path: '/vocabulary/:language/words/:id', delegate: PutWord },
             { method: 'DELETE', path: '/vocabulary/:language/words/:id', delegate: DeleteWord },
+            { method: 'POST', path: '/vocabulary/:language/words/:wordId/alternatives', delegate: AddWordAlternative },
+            { method: 'DELETE', path: '/vocabulary/:language/words/:wordId/alternatives/:id', delegate: RemoveWordAlternative },
             { method: 'GET', path: '/sentences/:language', delegate: GetSentences },
             { method: 'GET', path: '/sentences/:language/with-stats', delegate: GetSentencesWithStats },
             { method: 'POST', path: '/sentences/:language', delegate: PostSentence },
             { method: 'POST', path: '/sentences/:language/batch', delegate: PostSentences },
+            { method: 'GET', path: '/sentences/:language/:sentenceId', delegate: GetSentence },
+            { method: 'POST', path: '/sentences/:language/:sentenceId/alternatives', delegate: AddSentenceAlternative },
+            { method: 'DELETE', path: '/sentences/:language/:sentenceId/alternatives/:id', delegate: RemoveSentenceAlternative },
             { method: 'POST', path: '/languages/:language/sessions', delegate: StartSession },
             { method: 'GET', path: '/sessions/active', delegate: GetActiveSession },
             { method: 'GET', path: '/sessions/stats/weekly', delegate: GetWeeklySessionStats },

--- a/src/model/Sentence.ts
+++ b/src/model/Sentence.ts
@@ -1,5 +1,10 @@
 import { WithId } from "mongodb";
 
+export interface AlternativeTranslation {
+    id: string;
+    translation: string;
+}
+
 export class Sentence {
 
     id?: string;
@@ -8,14 +13,16 @@ export class Sentence {
     translation: string;
     createdAt: string;
     knowledgeSource: string;
+    alternativeTranslations: AlternativeTranslation[];
 
-    constructor({ language, sentence, translation, createdAt, id, knowledgeSource }: {
+    constructor({ language, sentence, translation, createdAt, id, knowledgeSource, alternativeTranslations }: {
         language: string;
         sentence: string;
         translation: string;
         createdAt: string;
         id?: string;
         knowledgeSource: string;
+        alternativeTranslations?: AlternativeTranslation[];
     }) {
         this.language = language;
         this.sentence = sentence;
@@ -23,6 +30,7 @@ export class Sentence {
         this.createdAt = createdAt;
         this.id = id;
         this.knowledgeSource = knowledgeSource;
+        this.alternativeTranslations = alternativeTranslations ?? [];
     }
 
     static fromBSON(data: WithId<any>): Sentence {
@@ -33,16 +41,19 @@ export class Sentence {
             createdAt: data.createdAt,
             id: data._id.toString(),
             knowledgeSource: data.knowledgeSource,
+            alternativeTranslations: data.alternativeTranslations ?? [],
         });
     }
 
     toBSON(): any {
-        return {
+        const doc: any = {
             language: this.language,
             sentence: this.sentence,
             translation: this.translation,
             createdAt: this.createdAt,
             knowledgeSource: this.knowledgeSource,
         };
+        if (this.alternativeTranslations.length > 0) doc.alternativeTranslations = this.alternativeTranslations;
+        return doc;
     }
 }

--- a/src/model/Session.ts
+++ b/src/model/Session.ts
@@ -4,12 +4,14 @@ export interface SessionWord {
     wordId: string;
     english: string;
     translation: string;
+    alternativeTranslations: Array<{ id: string; translation: string }>;
 }
 
 export interface SessionSentence {
     sentenceId: string;
     sentence: string;
     translation: string;
+    alternativeTranslations: Array<{ id: string; translation: string }>;
 }
 
 export interface SessionAnswer {

--- a/src/model/Word.ts
+++ b/src/model/Word.ts
@@ -1,5 +1,10 @@
 import { WithId } from "mongodb";
 
+export interface AlternativeTranslation {
+    id: string;
+    translation: string;
+}
+
 export class Word {
 
     id?: string;
@@ -8,14 +13,16 @@ export class Word {
     translation: string;
     createdAt: string;
     knowledgeSource: string;
+    alternativeTranslations: AlternativeTranslation[];
 
-    constructor({ language, english, translation, createdAt, id, knowledgeSource }: { language: string, english: string, translation: string, createdAt: string, id?: string, knowledgeSource: string }) {
+    constructor({ language, english, translation, createdAt, id, knowledgeSource, alternativeTranslations }: { language: string, english: string, translation: string, createdAt: string, id?: string, knowledgeSource: string, alternativeTranslations?: AlternativeTranslation[] }) {
         this.language = language;
         this.english = english.toLowerCase();
         this.translation = translation.toLowerCase();
         this.createdAt = createdAt;
         this.id = id;
         this.knowledgeSource = knowledgeSource;
+        this.alternativeTranslations = alternativeTranslations ?? [];
     }
 
     static fromBSON(data: WithId<any>): Word {
@@ -25,7 +32,8 @@ export class Word {
             translation: data.translation,
             createdAt: data.createdAt,
             id: data._id.toString(),
-            knowledgeSource: data.knowledgeSource
+            knowledgeSource: data.knowledgeSource,
+            alternativeTranslations: data.alternativeTranslations ?? [],
         });
     }
 
@@ -37,6 +45,7 @@ export class Word {
             createdAt: this.createdAt,
         };
         if (this.knowledgeSource !== undefined) doc.knowledgeSource = this.knowledgeSource;
+        if (this.alternativeTranslations.length > 0) doc.alternativeTranslations = this.alternativeTranslations;
         return doc;
     }
 }

--- a/src/store/SentenceStore.ts
+++ b/src/store/SentenceStore.ts
@@ -1,4 +1,5 @@
 import { Db, ObjectId } from "mongodb";
+import { randomUUID } from "crypto";
 import { ControllerConfig } from "../Config";
 import { Sentence } from "../model/Sentence";
 import { buildDifficultySortStage } from "../util/SortUtils";
@@ -102,6 +103,36 @@ export class SentenceStore {
         }
 
         return resolvedIds;
+    }
+
+    async findById(id: string): Promise<Sentence | null> {
+        let oid: ObjectId;
+        try { oid = new ObjectId(id); } catch { return null; }
+        const doc = await this.db.collection(SENTENCES_COLLECTION).findOne({ _id: oid });
+        if (!doc) return null;
+        return Sentence.fromBSON(doc as any);
+    }
+
+    async addAlternative(sentenceId: string, translation: string): Promise<{ id: string; translation: string } | null> {
+        let oid: ObjectId;
+        try { oid = new ObjectId(sentenceId); } catch { return null; }
+        const normalised = translation.toLowerCase();
+        const existing = await this.db.collection(SENTENCES_COLLECTION).findOne({ _id: oid, "alternativeTranslations.translation": normalised });
+        if (existing) {
+            const alt = (existing.alternativeTranslations as Array<{ id: string; translation: string }>).find(a => a.translation === normalised);
+            return alt ?? null;
+        }
+        const newAlt = { id: randomUUID(), translation: normalised };
+        const result = await this.db.collection(SENTENCES_COLLECTION).updateOne({ _id: oid }, { $push: { alternativeTranslations: newAlt } as any });
+        if (result.matchedCount === 0) return null;
+        return newAlt;
+    }
+
+    async removeAlternative(sentenceId: string, altId: string): Promise<boolean> {
+        let oid: ObjectId;
+        try { oid = new ObjectId(sentenceId); } catch { return false; }
+        const result = await this.db.collection(SENTENCES_COLLECTION).updateOne({ _id: oid }, { $pull: { alternativeTranslations: { id: altId } } as any });
+        return result.matchedCount > 0;
     }
 
     /**

--- a/src/store/SentenceStore.ts
+++ b/src/store/SentenceStore.ts
@@ -106,10 +106,11 @@ export class SentenceStore {
     }
 
     async findById(id: string): Promise<Sentence | null> {
-        let oid: ObjectId;
-        try { oid = new ObjectId(id); } catch { return null; }
-        const doc = await this.db.collection(SENTENCES_COLLECTION).findOne({ _id: oid });
+        
+        const doc = await this.db.collection(SENTENCES_COLLECTION).findOne({ _id: new ObjectId(id) });
+        
         if (!doc) return null;
+        
         return Sentence.fromBSON(doc as any);
     }
 

--- a/src/store/SentenceStore.ts
+++ b/src/store/SentenceStore.ts
@@ -12,6 +12,7 @@ export interface SentenceWithStats {
     translation: string;
     createdAt: string;
     knowledgeSource: string;
+    alternativeTranslations: Array<{ id: string; translation: string }>;
     stats: {
         failureRatio: number;
         totalAttempts: number;
@@ -213,6 +214,7 @@ export class SentenceStore {
                     translation: 1,
                     createdAt: 1,
                     knowledgeSource: 1,
+                    alternativeTranslations: { $ifNull: ["$alternativeTranslations", []] },
                     stats: {
                         $cond: {
                             if: { $ifNull: ["$stats", false] },
@@ -237,6 +239,7 @@ export class SentenceStore {
             translation: doc.translation,
             createdAt: doc.createdAt,
             knowledgeSource: doc.knowledgeSource,
+            alternativeTranslations: doc.alternativeTranslations ?? [],
             stats: doc.stats
         }));
 

--- a/src/store/SentenceStore.ts
+++ b/src/store/SentenceStore.ts
@@ -114,24 +114,31 @@ export class SentenceStore {
     }
 
     async addAlternative(sentenceId: string, translation: string): Promise<{ id: string; translation: string } | null> {
-        let oid: ObjectId;
-        try { oid = new ObjectId(sentenceId); } catch { return null; }
+        
+        let oid = new ObjectId(sentenceId);
+        
         const normalised = translation.toLowerCase();
+        
         const existing = await this.db.collection(SENTENCES_COLLECTION).findOne({ _id: oid, "alternativeTranslations.translation": normalised });
+        
         if (existing) {
             const alt = (existing.alternativeTranslations as Array<{ id: string; translation: string }>).find(a => a.translation === normalised);
             return alt ?? null;
         }
+        
         const newAlt = { id: randomUUID(), translation: normalised };
+        
         const result = await this.db.collection(SENTENCES_COLLECTION).updateOne({ _id: oid }, { $push: { alternativeTranslations: newAlt } as any });
+        
         if (result.matchedCount === 0) return null;
+        
         return newAlt;
     }
 
     async removeAlternative(sentenceId: string, altId: string): Promise<boolean> {
-        let oid: ObjectId;
-        try { oid = new ObjectId(sentenceId); } catch { return false; }
-        const result = await this.db.collection(SENTENCES_COLLECTION).updateOne({ _id: oid }, { $pull: { alternativeTranslations: { id: altId } } as any });
+        
+        const result = await this.db.collection(SENTENCES_COLLECTION).updateOne({ _id: new ObjectId(sentenceId) }, { $pull: { alternativeTranslations: { id: altId } } as any });
+        
         return result.matchedCount > 0;
     }
 

--- a/src/store/VocabularyStore.ts
+++ b/src/store/VocabularyStore.ts
@@ -1,4 +1,5 @@
 import { Db, ObjectId } from "mongodb";
+import { randomUUID } from "crypto";
 import { ControllerConfig } from "../Config";
 import { Word } from "../model/Word";
 import { buildDifficultySortStage } from "../util/SortUtils";
@@ -147,6 +148,36 @@ export class VocabularyStore {
         const result = await this.db.collection(VOCABULARY_COLLECTION).deleteOne({ _id: new ObjectId(id) });
         
         return result.deletedCount > 0;
+    }
+
+    async findById(id: string): Promise<Word | null> {
+        let oid: ObjectId;
+        try { oid = new ObjectId(id); } catch { return null; }
+        const doc = await this.db.collection(VOCABULARY_COLLECTION).findOne({ _id: oid });
+        if (!doc) return null;
+        return Word.fromBSON(doc as any);
+    }
+
+    async addAlternative(wordId: string, translation: string): Promise<{ id: string; translation: string } | null> {
+        let oid: ObjectId;
+        try { oid = new ObjectId(wordId); } catch { return null; }
+        const normalised = translation.toLowerCase();
+        const existing = await this.db.collection(VOCABULARY_COLLECTION).findOne({ _id: oid, "alternativeTranslations.translation": normalised });
+        if (existing) {
+            const alt = (existing.alternativeTranslations as Array<{ id: string; translation: string }>).find(a => a.translation === normalised);
+            return alt ?? null;
+        }
+        const newAlt = { id: randomUUID(), translation: normalised };
+        const result = await this.db.collection(VOCABULARY_COLLECTION).updateOne({ _id: oid }, { $push: { alternativeTranslations: newAlt } as any });
+        if (result.matchedCount === 0) return null;
+        return newAlt;
+    }
+
+    async removeAlternative(wordId: string, altId: string): Promise<boolean> {
+        let oid: ObjectId;
+        try { oid = new ObjectId(wordId); } catch { return false; }
+        const result = await this.db.collection(VOCABULARY_COLLECTION).updateOne({ _id: oid }, { $pull: { alternativeTranslations: { id: altId } } as any });
+        return result.matchedCount > 0;
     }
 
     async findByLanguageWithStats({ language, userId, page, pageSize, sortBy, sortDir }: {

--- a/src/store/VocabularyStore.ts
+++ b/src/store/VocabularyStore.ts
@@ -12,6 +12,7 @@ export interface WordWithStats {
     translation: string;
     createdAt: string;
     knowledgeSource: string;
+    alternativeTranslations: Array<{ id: string; translation: string }>;
     stats: {
         failureRatio: number;
         totalAttempts: number;
@@ -206,6 +207,7 @@ export class VocabularyStore {
                     translation: 1,
                     createdAt: 1,
                     knowledgeSource: 1,
+                    alternativeTranslations: { $ifNull: ["$alternativeTranslations", []] },
                     stats: {
                         $cond: {
                             if: { $ifNull: ["$stats", false] },
@@ -230,6 +232,7 @@ export class VocabularyStore {
             translation: doc.translation,
             createdAt: doc.createdAt,
             knowledgeSource: doc.knowledgeSource,
+            alternativeTranslations: doc.alternativeTranslations ?? [],
             stats: doc.stats
         }));
 

--- a/test/AlternativeTranslations.endpoints.test.ts
+++ b/test/AlternativeTranslations.endpoints.test.ts
@@ -1,0 +1,172 @@
+import { assert } from "chai";
+import { Request } from "express";
+
+// ---------------------------------------------------------------------------
+// Helpers — minimal mock Request builders
+// ---------------------------------------------------------------------------
+
+function makePostReq(params: Record<string, string>, body: Record<string, any>): Request {
+    return { params, body } as unknown as Request;
+}
+
+function makeDeleteReq(params: Record<string, string>): Request {
+    return { params, body: {} } as unknown as Request;
+}
+
+function makeGetReq(params: Record<string, string>): Request {
+    return { params, body: {} } as unknown as Request;
+}
+
+// ---------------------------------------------------------------------------
+// AddWordAlternative.parseRequest
+// ---------------------------------------------------------------------------
+
+import { AddWordAlternative } from "../src/dlg/AddWordAlternative";
+
+describe("AddWordAlternative.parseRequest", () => {
+
+    it("parses language, wordId, and translation from request", () => {
+        const delegate = new AddWordAlternative({} as any, {} as any);
+        const req = makePostReq({ language: "danish", wordId: "abc123" }, { translation: "Hej" });
+        const parsed = delegate.parseRequest(req);
+        assert.equal(parsed.language, "danish");
+        assert.equal(parsed.wordId, "abc123");
+        assert.equal(parsed.translation, "Hej");
+    });
+
+    it("throws 400 when translation is missing", () => {
+        const delegate = new AddWordAlternative({} as any, {} as any);
+        const req = makePostReq({ language: "danish", wordId: "abc123" }, {});
+        assert.throws(() => delegate.parseRequest(req), /translation/i);
+    });
+
+    it("throws 400 for unsupported language", () => {
+        const delegate = new AddWordAlternative({} as any, {} as any);
+        const req = makePostReq({ language: "klingon", wordId: "abc123" }, { translation: "Hej" });
+        assert.throws(() => delegate.parseRequest(req), /unsupported language/i);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// RemoveWordAlternative.parseRequest
+// ---------------------------------------------------------------------------
+
+import { RemoveWordAlternative } from "../src/dlg/RemoveWordAlternative";
+
+describe("RemoveWordAlternative.parseRequest", () => {
+
+    it("parses language, wordId, and altId from request", () => {
+        const delegate = new RemoveWordAlternative({} as any, {} as any);
+        const req = makeDeleteReq({ language: "danish", wordId: "abc123", id: "uuid-1" });
+        const parsed = delegate.parseRequest(req);
+        assert.equal(parsed.language, "danish");
+        assert.equal(parsed.wordId, "abc123");
+        assert.equal(parsed.altId, "uuid-1");
+    });
+
+    it("throws 400 for unsupported language", () => {
+        const delegate = new RemoveWordAlternative({} as any, {} as any);
+        const req = makeDeleteReq({ language: "klingon", wordId: "abc123", id: "uuid-1" });
+        assert.throws(() => delegate.parseRequest(req), /unsupported language/i);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// AddSentenceAlternative.parseRequest
+// ---------------------------------------------------------------------------
+
+import { AddSentenceAlternative } from "../src/dlg/AddSentenceAlternative";
+
+describe("AddSentenceAlternative.parseRequest", () => {
+
+    it("parses language, sentenceId, and translation from request", () => {
+        const delegate = new AddSentenceAlternative({} as any, {} as any);
+        const req = makePostReq({ language: "danish", sentenceId: "sent123" }, { translation: "Hej verden" });
+        const parsed = delegate.parseRequest(req);
+        assert.equal(parsed.language, "danish");
+        assert.equal(parsed.sentenceId, "sent123");
+        assert.equal(parsed.translation, "Hej verden");
+    });
+
+    it("throws 400 when translation is missing", () => {
+        const delegate = new AddSentenceAlternative({} as any, {} as any);
+        const req = makePostReq({ language: "danish", sentenceId: "sent123" }, {});
+        assert.throws(() => delegate.parseRequest(req), /translation/i);
+    });
+
+    it("throws 400 for unsupported language", () => {
+        const delegate = new AddSentenceAlternative({} as any, {} as any);
+        const req = makePostReq({ language: "klingon", sentenceId: "sent123" }, { translation: "Hej verden" });
+        assert.throws(() => delegate.parseRequest(req), /unsupported language/i);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// RemoveSentenceAlternative.parseRequest
+// ---------------------------------------------------------------------------
+
+import { RemoveSentenceAlternative } from "../src/dlg/RemoveSentenceAlternative";
+
+describe("RemoveSentenceAlternative.parseRequest", () => {
+
+    it("parses language, sentenceId, and altId from request", () => {
+        const delegate = new RemoveSentenceAlternative({} as any, {} as any);
+        const req = makeDeleteReq({ language: "danish", sentenceId: "sent123", id: "uuid-2" });
+        const parsed = delegate.parseRequest(req);
+        assert.equal(parsed.language, "danish");
+        assert.equal(parsed.sentenceId, "sent123");
+        assert.equal(parsed.altId, "uuid-2");
+    });
+
+    it("throws 400 for unsupported language", () => {
+        const delegate = new RemoveSentenceAlternative({} as any, {} as any);
+        const req = makeDeleteReq({ language: "klingon", sentenceId: "sent123", id: "uuid-2" });
+        assert.throws(() => delegate.parseRequest(req), /unsupported language/i);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// GetWord.parseRequest
+// ---------------------------------------------------------------------------
+
+import { GetWord } from "../src/dlg/GetWord";
+
+describe("GetWord.parseRequest", () => {
+
+    it("parses language and wordId from request", () => {
+        const delegate = new GetWord({} as any, {} as any);
+        const req = makeGetReq({ language: "danish", wordId: "abc123" });
+        const parsed = delegate.parseRequest(req);
+        assert.equal(parsed.language, "danish");
+        assert.equal(parsed.wordId, "abc123");
+    });
+
+    it("throws 400 for unsupported language", () => {
+        const delegate = new GetWord({} as any, {} as any);
+        const req = makeGetReq({ language: "klingon", wordId: "abc123" });
+        assert.throws(() => delegate.parseRequest(req), /unsupported language/i);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// GetSentence.parseRequest
+// ---------------------------------------------------------------------------
+
+import { GetSentence } from "../src/dlg/GetSentence";
+
+describe("GetSentence.parseRequest", () => {
+
+    it("parses language and sentenceId from request", () => {
+        const delegate = new GetSentence({} as any, {} as any);
+        const req = makeGetReq({ language: "danish", sentenceId: "sent123" });
+        const parsed = delegate.parseRequest(req);
+        assert.equal(parsed.language, "danish");
+        assert.equal(parsed.sentenceId, "sent123");
+    });
+
+    it("throws 400 for unsupported language", () => {
+        const delegate = new GetSentence({} as any, {} as any);
+        const req = makeGetReq({ language: "klingon", sentenceId: "sent123" });
+        assert.throws(() => delegate.parseRequest(req), /unsupported language/i);
+    });
+});

--- a/test/AlternativeTranslations.model.test.ts
+++ b/test/AlternativeTranslations.model.test.ts
@@ -1,0 +1,80 @@
+import { assert } from "chai";
+import { ObjectId } from "mongodb";
+import { Word } from "../src/model/Word";
+import { Sentence } from "../src/model/Sentence";
+
+// ---------------------------------------------------------------------------
+// Word model
+// ---------------------------------------------------------------------------
+
+describe("Word.fromBSON — alternativeTranslations", () => {
+
+    it("defaults to [] when alternativeTranslations is absent from the document", () => {
+        const doc = { _id: new ObjectId(), language: "danish", english: "dog", translation: "hund", createdAt: "2026-01-01T00:00:00.000Z", knowledgeSource: "test" };
+        const word = Word.fromBSON(doc as any);
+        assert.deepEqual(word.alternativeTranslations, []);
+    });
+
+    it("reads alternativeTranslations when present in the document", () => {
+        const alts = [{ id: "uuid-1", translation: "hunden" }];
+        const doc = { _id: new ObjectId(), language: "danish", english: "dog", translation: "hund", createdAt: "2026-01-01T00:00:00.000Z", knowledgeSource: "test", alternativeTranslations: alts };
+        const word = Word.fromBSON(doc as any);
+        assert.deepEqual(word.alternativeTranslations, alts);
+    });
+
+});
+
+describe("Word.toBSON — alternativeTranslations", () => {
+
+    it("omits alternativeTranslations from the BSON document when the array is empty", () => {
+        const word = new Word({ language: "danish", english: "dog", translation: "hund", createdAt: "2026-01-01T00:00:00.000Z", knowledgeSource: "test", alternativeTranslations: [] });
+        const bson = word.toBSON();
+        assert.notProperty(bson, "alternativeTranslations");
+    });
+
+    it("includes alternativeTranslations in the BSON document when the array is non-empty", () => {
+        const alts = [{ id: "uuid-1", translation: "hunden" }];
+        const word = new Word({ language: "danish", english: "dog", translation: "hund", createdAt: "2026-01-01T00:00:00.000Z", knowledgeSource: "test", alternativeTranslations: alts });
+        const bson = word.toBSON();
+        assert.deepEqual(bson.alternativeTranslations, alts);
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// Sentence model
+// ---------------------------------------------------------------------------
+
+describe("Sentence.fromBSON — alternativeTranslations", () => {
+
+    it("defaults to [] when alternativeTranslations is absent from the document", () => {
+        const doc = { _id: new ObjectId(), language: "danish", sentence: "Hunden løber", translation: "The dog runs", createdAt: "2026-01-01T00:00:00.000Z", knowledgeSource: "test" };
+        const sentence = Sentence.fromBSON(doc as any);
+        assert.deepEqual(sentence.alternativeTranslations, []);
+    });
+
+    it("reads alternativeTranslations when present in the document", () => {
+        const alts = [{ id: "uuid-2", translation: "the dog is running" }];
+        const doc = { _id: new ObjectId(), language: "danish", sentence: "Hunden løber", translation: "The dog runs", createdAt: "2026-01-01T00:00:00.000Z", knowledgeSource: "test", alternativeTranslations: alts };
+        const sentence = Sentence.fromBSON(doc as any);
+        assert.deepEqual(sentence.alternativeTranslations, alts);
+    });
+
+});
+
+describe("Sentence.toBSON — alternativeTranslations", () => {
+
+    it("omits alternativeTranslations from the BSON document when the array is empty", () => {
+        const sentence = new Sentence({ language: "danish", sentence: "Hunden løber", translation: "The dog runs", createdAt: "2026-01-01T00:00:00.000Z", knowledgeSource: "test", alternativeTranslations: [] });
+        const bson = sentence.toBSON();
+        assert.notProperty(bson, "alternativeTranslations");
+    });
+
+    it("includes alternativeTranslations in the BSON document when the array is non-empty", () => {
+        const alts = [{ id: "uuid-2", translation: "the dog is running" }];
+        const sentence = new Sentence({ language: "danish", sentence: "Hunden løber", translation: "The dog runs", createdAt: "2026-01-01T00:00:00.000Z", knowledgeSource: "test", alternativeTranslations: alts });
+        const bson = sentence.toBSON();
+        assert.deepEqual(bson.alternativeTranslations, alts);
+    });
+
+});


### PR DESCRIPTION
## Summary

Implements the data model changes required for the Alternative Translations feature.

## Changes

- Added `AlternativeTranslation` interface `{ id: string; translation: string }` to `Word` and `Sentence` models
- `fromBSON`: reads `alternativeTranslations ?? []` for backward compatibility with existing documents
- `toBSON`: omits the field when the array is empty (no storage overhead for existing data)
- `WordWithStats` / `SentenceWithStats`: added `alternativeTranslations` field
- MongoDB aggregation `$project`: includes `alternativeTranslations` with `$ifNull` fallback
- `SessionWord` / `SessionSentence`: types updated to carry `alternativeTranslations`
- `StartSession`: passes `alternativeTranslations` through in both vocabulary and sentence session payloads

## Issues

Closes #29

## Tests

All 28 tests passing (8 new unit tests for model changes + 20 existing).