### PR TITLE
F02 — Grammar Concept Catalog

### DIFF
--- a/docs/features/F02-grammar-concept-catalog.md
+++ b/docs/features/F02-grammar-concept-catalog.md
@@ -44,14 +44,14 @@ Grammar concepts (including their explanation text and examples) are authored an
 - `POST /grammarConcepts` — insert a single grammar concept.
 - `POST /grammarConcepts/batch` — insert many grammar concepts; skips duplicates by `name`.
 - `GET /grammarConcepts/:id` — get a single grammar concept by id (returns explanation + examples).
-- `GET /grammarConcepts` — list concepts; optional query params `?cefrLevel=A1` (at-or-below filter) and `?category=tenses`.
+- `GET /grammarConcepts` — list concepts; optional query params `?cefrLevel=A1` (exact-match filter) and `?category=tenses`.
 - `POST /grammarConcepts/lookup` — resolve a set of ids in bulk; body: `{ ids: string[] }`.
 
 #### 2.2.4. Business Logic
 
 - A dedicated store is the only place that reads/writes the grammar concept collection. Supports: insert one, insert many (batch), find by id, find by ids (bulk lookup for modules), list by category, list by `cefrLevelIntroduced`.
 - Inserting a concept that duplicates an existing `id` is rejected. Additionally, duplicate detection on `name` — batch insert skips a concept whose name already exists and reports which were inserted vs. skipped.
-- The `?cefrLevel=A1` filter on `GET /grammarConcepts` returns concepts introduced at or below the given level (i.e. all concepts available to an A1 learner).
+- The `?cefrLevel=A1` filter on `GET /grammarConcepts` is an exact match on `cefrLevelIntroduced`. It returns only concepts introduced at that specific level, not at lower levels.
 
 ---
 

--- a/docs/specs/T10-post-grammar-concept.md
+++ b/docs/specs/T10-post-grammar-concept.md
@@ -1,0 +1,72 @@
+# T10 — POST /grammarConcepts
+
+Bootstrap the Grammar Concept Catalog by creating the full data model, the store with an `insertOne` method, the single-insert endpoint, and wiring it up in `index.ts`.
+
+**Feature**: [F02 — Grammar Concept Catalog](../features/F02-grammar-concept-catalog.md)
+
+**Why**: This is the foundation slice. Every other grammar concept task builds on the model and store created here. Delivering `POST /grammarConcepts` first makes the catalog writable end-to-end before any read paths are added.
+
+**What**:
+
+- [ ] Extract `CEFR_LEVELS` from `src/model/VocabularyItem.ts` into a new shared file `src/model/CefrLevels.ts` and re-import it in `VocabularyItem.ts` so there is a single source of truth.
+
+- [ ] Create `src/model/GrammarConcept.ts`:
+  - Export constant `GRAMMAR_CONCEPT_CATEGORIES`: `tenses`, `sentence_structure`, `verbs`, `nouns`, `pronouns`, `adjectives`, `connectors`, `advanced`
+  - Import `CEFR_LEVELS` from `src/model/CefrLevels.ts`
+  - `GrammarConcept` class with fields: `id`, `name`, `category`, `cefrLevelIntroduced`, `explanation`, `examples: Array<{ danish: string; english: string }>`
+  - Constructor accepting a `GrammarConceptInput` interface
+  - `static fromBSON(data: WithId<any>): GrammarConcept`
+  - `toBSON(): any`
+
+- [ ] Create `src/store/GrammarConceptStore.ts`:
+  - Uses MongoDB collection `grammar`
+  - Export interfaces `InsertOneResult` (`status: "created" | "duplicate_id"`, `concept: GrammarConcept`) and `BatchItemResult` (`id: string`, `status: "created" | "duplicate_id"`)
+  - Implement `insertOne(concept: GrammarConcept): Promise<InsertOneResult>`:
+    - Check for duplicate `id` → return `{ status: "duplicate_id", concept: existing }`
+    - Otherwise insert and return `{ status: "created", concept }`
+
+- [ ] Create `src/dlg/PostGrammarConcept.ts`:
+  - `parseRequest`: validate all required fields (`id`, `name`, `category`, `cefrLevelIntroduced`, `explanation`, `examples`); validate `category` against `GRAMMAR_CONCEPT_CATEGORIES`; validate `cefrLevelIntroduced` against `CEFR_LEVELS`; validate `examples` is an array with 1–2 items each having `danish` and `english` strings
+  - `do`: instantiate store, call `insertOne`; throw `ValidationError(409, ...)` on `duplicate_id`; return `{ id }`
+
+- [ ] Write unit tests in `test/GrammarConceptStore.insertOne.test.ts`:
+  - `insertOne` inserts a new concept and returns `status: "created"`
+  - `insertOne` returns `duplicate_id` when the same `id` already exists
+
+- [ ] Write unit tests in `test/PostGrammarConcept.parseRequest.test.ts`:
+  - Returns parsed request for a valid body
+  - Throws 400 when `id` is missing
+  - Throws 400 when `name` is missing
+  - Throws 400 when `category` is invalid
+  - Throws 400 when `cefrLevelIntroduced` is invalid
+  - Throws 400 when `explanation` is missing
+  - Throws 400 when `examples` is empty or missing
+  - Throws 400 when `examples` has more than 2 items
+  - Throws 400 when an example is missing `danish` or `english`
+
+- [ ] Register `{ method: 'POST', path: '/grammarConcepts', delegate: PostGrammarConcept }` in `src/index.ts`
+
+## Implementation details
+
+### Architectural decisions
+- `GrammarConcept` follows the same class pattern as `VocabularyItem`: constructor + `fromBSON` + `toBSON`.
+- `GrammarConceptStore` follows the same pattern as `VocabularyItemStore`: explicit duplicate checks before insert (no reliance on MongoDB unique-index errors) to return typed statuses.
+
+### Technical Decisions and Design
+- `CEFR_LEVELS` is extracted to `src/model/CefrLevels.ts` so both `VocabularyItem.ts` and `GrammarConcept.ts` import from the same source rather than duplicating the constant.
+- `examples` min/max validation (1–2 items) is enforced in `parseRequest`, not in the model constructor.
+- Mock the MongoDB collection in tests using the same inline-mock pattern established in `VocabularyItemStore.test.ts`.
+
+## Acceptance Criteria
+- [ ] `src/model/CefrLevels.ts` exists; `VocabularyItem.ts` imports from it; `GrammarConcept.ts` imports from it
+- [ ] `src/model/GrammarConcept.ts` exists and compiles
+- [ ] `src/store/GrammarConceptStore.ts` exists with `insertOne` implemented, using collection `grammar`
+- [ ] `src/dlg/PostGrammarConcept.ts` exists and compiles
+- [ ] All store and parseRequest tests pass with `npm test`
+- [ ] `POST /grammarConcepts` is registered in `index.ts`
+- [ ] `npm run build` succeeds
+- [ ] `npm run test` succeeds
+
+## Out of Scope
+- `insertBatch`, `findById`, `findByIds`, `list` store methods (T11–T14)
+- All other endpoints (T11–T14)

--- a/docs/specs/T11-post-grammar-concept-batch.md
+++ b/docs/specs/T11-post-grammar-concept-batch.md
@@ -1,0 +1,53 @@
+# T11 — POST /grammarConcepts/batch
+
+Add batch insert support to the Grammar Concept Catalog: extend the store with `insertBatch`, add the batch endpoint delegate, write tests, and register the route.
+
+**Feature**: [F02 — Grammar Concept Catalog](../features/F02-grammar-concept-catalog.md)
+
+**Why**: The catalog is seeded by an external tool that may submit many concepts at once. Batch insert avoids per-item round-trips and provides an idempotent seeding path with per-item status reporting.
+
+**What**:
+
+- [ ] Add `insertBatch(concepts: GrammarConcept[]): Promise<InsertBatchResult>` to `src/store/GrammarConceptStore.ts`:
+  - Export `InsertBatchResult` interface: `{ inserted: number; alreadyPresent: number; items: BatchItemResult[] }`
+  - Bulk-check for existing `id`s with `{ id: { $in: inputIds } }`
+  - For each input concept: mark as `duplicate_id` or `created`
+  - Insert non-duplicate concepts in a single `insertMany({ ordered: false })`
+  - Return the summary
+
+- [ ] Create `src/dlg/PostGrammarConceptBatch.ts`:
+  - `parseRequest`: validate that `items` is a non-empty array; for each item run the same field validation as `PostGrammarConcept`; collect per-item validation errors (do not throw); return `{ items: GrammarConcept[], validationErrors: ValidationErrorItem[] }`
+  - `do`: call `store.insertBatch`; merge store results with validation errors; return `{ inserted, alreadyPresent, validationErrors: number, items: Array<{ id, status, reason? }> }`
+
+- [ ] Add `insertBatch` tests to `test/GrammarConceptStore.insertBatch.test.ts`:
+  - Inserts all new concepts and reports correct summary
+  - Skips duplicate by `id` and returns correct summary
+  - Returns empty result for an empty input array
+
+- [ ] Write `test/PostGrammarConceptBatch.parseRequest.test.ts`:
+  - Returns parsed items for a valid batch body
+  - Throws 400 when `items` is missing or empty
+  - Collects per-item validation errors without throwing
+
+- [ ] Register `{ method: 'POST', path: '/grammarConcepts/batch', delegate: PostGrammarConceptBatch }` in `src/index.ts`
+
+## Implementation details
+
+### Architectural decisions
+- Batch deduplication is by `id` only. Unlike the single-insert path (which also checks `name`), batch skips only items whose `id` is already present. Name uniqueness is not enforced at the batch level; the caller is responsible for submitting distinct names.
+
+### Technical Decisions and Design
+- One bulk read `{ id: { $in: inputIds } }` is sufficient — no second round-trip for name checks.
+- `BatchItemResult` and `InsertBatchResult` interfaces are defined and exported in `GrammarConceptStore.ts` (same file as `InsertOneResult`).
+- Per-item validation errors from `parseRequest` are merged into the response in `do`, consistent with the vocabulary batch pattern.
+
+## Acceptance Criteria
+- [ ] `insertBatch` is added to `GrammarConceptStore.ts` and compiles
+- [ ] `src/dlg/PostGrammarConceptBatch.ts` exists and compiles
+- [ ] All store and parseRequest tests pass with `npm test`
+- [ ] `POST /grammarConcepts/batch` is registered in `index.ts`
+- [ ] `npm run build` succeeds
+
+## Out of Scope
+- Read endpoints (T12–T14)
+- `findById`, `findByIds`, `list` store methods (T12–T14)

--- a/docs/specs/T12-get-grammar-concept-by-id.md
+++ b/docs/specs/T12-get-grammar-concept-by-id.md
@@ -1,0 +1,46 @@
+# T12 — GET /grammarConcepts/:id
+
+Add single-concept retrieval: extend the store with `findById`, add the endpoint delegate, write tests, and register the route.
+
+**Feature**: [F02 — Grammar Concept Catalog](../features/F02-grammar-concept-catalog.md)
+
+**Why**: Consumers need to fetch a single concept by its caller-provided `id` to hydrate module or exercise references.
+
+**What**:
+
+- [ ] Add `findById(id: string): Promise<GrammarConcept | null>` to `src/store/GrammarConceptStore.ts`:
+  - Query `{ id }` (not MongoDB `_id`)
+  - Return `null` when not found
+
+- [ ] Create `src/dlg/GetGrammarConcept.ts`:
+  - `parseRequest`: read `req.params.id`; throw `ValidationError(400, ...)` if missing
+  - `do`: call `store.findById`; throw `ValidationError(404, ...)` if null; return all concept fields (`id`, `name`, `category`, `cefrLevelIntroduced`, `explanation`, `examples`)
+
+- [ ] Add `findById` tests to `test/GrammarConceptStore.findById.test.ts`:
+  - Returns the concept when it exists
+  - Returns null when the id is not found
+
+- [ ] Write `test/GetGrammarConcept.parseRequest.test.ts`:
+  - Returns `{ id }` for a valid param
+  - Throws 400 when `id` param is missing
+
+- [ ] Register `{ method: 'GET', path: '/grammarConcepts/:id', delegate: GetGrammarConcept }` in `src/index.ts`
+
+## Implementation details
+
+### Architectural decisions
+- Lookup is by the caller-provided `id` field, not MongoDB `_id`, consistent with the vocabulary pattern.
+
+### Technical Decisions and Design
+- Response shape includes the full concept payload (`explanation` + `examples`) as specified in the feature doc.
+
+## Acceptance Criteria
+- [ ] `findById` is added to `GrammarConceptStore.ts` and compiles
+- [ ] `src/dlg/GetGrammarConcept.ts` exists and compiles
+- [ ] All store and parseRequest tests pass with `npm test`
+- [ ] `GET /grammarConcepts/:id` is registered in `index.ts`
+- [ ] `npm run build` succeeds
+
+## Out of Scope
+- List endpoint with filters (T13)
+- Bulk lookup endpoint (T14)

--- a/docs/specs/T13-get-grammar-concepts-list.md
+++ b/docs/specs/T13-get-grammar-concepts-list.md
@@ -1,0 +1,52 @@
+# T13 — GET /grammarConcepts
+
+Add concept listing with optional CEFR-level and category filters: extend the store with `list`, add the endpoint delegate, write tests, and register the route.
+
+**Feature**: [F02 — Grammar Concept Catalog](../features/F02-grammar-concept-catalog.md)
+
+**Why**: The seeding tool and exercise generator need to scope content to a specific level and/or category. The `?cefrLevel` filter returns concepts introduced at exactly that level.
+
+**What**:
+
+- [ ] Add `list(cefrLevel?: string, category?: string): Promise<GrammarConcept[]>` to `src/store/GrammarConceptStore.ts`:
+  - When `cefrLevel` is provided, filter `{ cefrLevelIntroduced: cefrLevel }` (exact match)
+  - When `category` is provided, add `{ category }` to the filter
+  - Sort results alphabetically by `name`
+
+- [ ] Create `src/dlg/GetGrammarConcepts.ts`:
+  - `parseRequest`: read optional `req.query.cefrLevel` and `req.query.category`; validate `cefrLevel` against `CEFR_LEVELS` if present; validate `category` against `GRAMMAR_CONCEPT_CATEGORIES` if present; return `{ cefrLevel?, category? }`
+  - `do`: call `store.list(cefrLevel, category)`; return `{ items: [...] }`
+
+- [ ] Add `list` tests to `test/GrammarConceptStore.list.test.ts`:
+  - Returns all concepts when no filters are given
+  - Returns only concepts with `cefrLevelIntroduced` exactly matching the requested level (e.g. `B1` returns only B1 concepts, not A1/A2)
+  - Returns only concepts matching the requested `category`
+  - Combines both filters correctly
+
+- [ ] Write `test/GetGrammarConcepts.parseRequest.test.ts`:
+  - Returns `{}` when no query params are given
+  - Returns `{ cefrLevel }` for a valid cefrLevel param
+  - Returns `{ category }` for a valid category param
+  - Throws 400 for an invalid `cefrLevel`
+  - Throws 400 for an invalid `category`
+
+- [ ] Register `{ method: 'GET', path: '/grammarConcepts', delegate: GetGrammarConcepts }` in `src/index.ts`
+
+## Implementation details
+
+### Architectural decisions
+- **`?cefrLevel` is an exact-match filter**, not an at-or-below filter. A concept's `cefrLevelIntroduced` field already expresses exactly when the concept is introduced; callers that need a range (e.g. "everything available to a B1 learner") can issue multiple requests or handle the aggregation themselves. This keeps the API simple and the store query trivial (`{ cefrLevelIntroduced: level }` rather than a computed `$in` slice).
+
+### Technical Decisions and Design
+- Both filters are optional and may be combined in the same query.
+- Results are sorted by `name` (alphabetical) for stable ordering.
+
+## Acceptance Criteria
+- [ ] `list` is added to `GrammarConceptStore.ts` and compiles
+- [ ] `src/dlg/GetGrammarConcepts.ts` exists and compiles
+- [ ] All store and parseRequest tests pass, including exact-match and combined-filter cases, with `npm test`
+- [ ] `GET /grammarConcepts` is registered in `index.ts`
+- [ ] `npm run build` succeeds
+
+## Out of Scope
+- Bulk id lookup endpoint (T14)

--- a/docs/specs/T14-post-grammar-concepts-lookup.md
+++ b/docs/specs/T14-post-grammar-concepts-lookup.md
@@ -1,0 +1,48 @@
+# T14 — POST /grammarConcepts/lookup
+
+Add bulk id resolution: extend the store with `findByIds`, add the lookup endpoint delegate, write tests, and register the route.
+
+**Feature**: [F02 — Grammar Concept Catalog](../features/F02-grammar-concept-catalog.md)
+
+**Why**: Modules and exercises hold a list of grammar concept ids. This endpoint lets consumers hydrate all referenced concepts in a single round-trip rather than N individual GET calls.
+
+**What**:
+
+- [ ] Add `findByIds(ids: string[]): Promise<GrammarConcept[]>` to `src/store/GrammarConceptStore.ts`:
+  - Query `{ id: { $in: ids } }`
+  - Return only found items (silently ignore ids that do not exist)
+
+- [ ] Create `src/dlg/LookupGrammarConcepts.ts`:
+  - `parseRequest`: read `req.body.ids`; throw `ValidationError(400, ...)` if `ids` is missing, not an array, or empty; return `{ ids }`
+  - `do`: call `store.findByIds`; return `{ items: [...] }` with full concept payload per item
+
+- [ ] Add `findByIds` tests to `test/GrammarConceptStore.findByIds.test.ts`:
+  - Returns all found concepts and ignores missing ids
+  - Returns empty array when none of the ids exist
+
+- [ ] Write `test/LookupGrammarConcepts.parseRequest.test.ts`:
+  - Returns `{ ids }` for a valid body
+  - Throws 400 when `ids` is missing
+  - Throws 400 when `ids` is an empty array
+
+- [ ] Register `{ method: 'POST', path: '/grammarConcepts/lookup', delegate: LookupGrammarConcepts }` in `src/index.ts`
+
+## Implementation details
+
+### Architectural decisions
+- Follows the same pattern as `LookupVocabularyItems` / `VocabularyItemStore.findByIds`.
+
+### Technical Decisions and Design
+- Missing ids are silently ignored (no 404); the caller can diff request vs response ids if needed.
+- Response shape includes the full concept payload for each found item.
+
+## Acceptance Criteria
+- [ ] `findByIds` is added to `GrammarConceptStore.ts` and compiles
+- [ ] `src/dlg/LookupGrammarConcepts.ts` exists and compiles
+- [ ] All store and parseRequest tests pass with `npm test`
+- [ ] `POST /grammarConcepts/lookup` is registered in `index.ts`
+- [ ] `npm run build` succeeds
+
+## Out of Scope
+- Single GET by id (T12)
+- List with filters (T13)

--- a/src/dlg/GetGrammarConcept.ts
+++ b/src/dlg/GetGrammarConcept.ts
@@ -1,0 +1,56 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../Config";
+import { GrammarConcept } from "../model/GrammarConcept";
+import { GrammarConceptStore } from "../store/GrammarConceptStore";
+
+export class GetGrammarConcept extends TotoDelegate<GetGrammarConceptRequest, GetGrammarConceptResponse> {
+
+    parseRequest(req: Request): GetGrammarConceptRequest {
+
+        const id = req.params.id;
+
+        if (!id) throw new ValidationError(400, "id is required");
+
+        return { id };
+    }
+
+    async do(req: GetGrammarConceptRequest, _userContext?: UserContext): Promise<GetGrammarConceptResponse> {
+
+        const config = this.config as ControllerConfig;
+
+        const db = await config.getMongoDb(config.getDBName());
+
+        const store = new GrammarConceptStore(db);
+        const concept = await store.findById(req.id);
+
+        if (!concept) throw new ValidationError(404, `Grammar concept '${req.id}' not found`);
+
+        return toResponse(concept);
+    }
+}
+
+function toResponse(concept: GrammarConcept): GetGrammarConceptResponse {
+
+    return {
+        id: concept.id,
+        name: concept.name,
+        category: concept.category,
+        cefrLevelIntroduced: concept.cefrLevelIntroduced,
+        explanation: concept.explanation,
+        examples: concept.examples,
+    };
+}
+
+interface GetGrammarConceptRequest {
+    id: string;
+}
+
+interface GetGrammarConceptResponse {
+    id: string;
+    name: string;
+    category: string;
+    cefrLevelIntroduced: string;
+    explanation: string;
+    examples: Array<{ danish: string; english: string }>;
+}

--- a/src/dlg/GetGrammarConcepts.ts
+++ b/src/dlg/GetGrammarConcepts.ts
@@ -1,0 +1,52 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../Config";
+import { GrammarConcept, GRAMMAR_CONCEPT_CATEGORIES, CEFR_LEVELS } from "../model/GrammarConcept";
+import { GrammarConceptStore } from "../store/GrammarConceptStore";
+
+export class GetGrammarConcepts extends TotoDelegate<GetGrammarConceptsRequest, GetGrammarConceptsResponse> {
+
+    parseRequest(req: Request): GetGrammarConceptsRequest {
+
+        const cefrLevel = req.query.cefrLevel as string | undefined;
+        const category = req.query.category as string | undefined;
+
+        if (cefrLevel && !(CEFR_LEVELS as readonly string[]).includes(cefrLevel)) throw new ValidationError(400, `cefrLevel must be one of: ${CEFR_LEVELS.join(", ")}`);
+        if (category && !(GRAMMAR_CONCEPT_CATEGORIES as readonly string[]).includes(category)) throw new ValidationError(400, `category must be one of: ${GRAMMAR_CONCEPT_CATEGORIES.join(", ")}`);
+
+        return { cefrLevel, category };
+    }
+
+    async do(req: GetGrammarConceptsRequest, _userContext?: UserContext): Promise<GetGrammarConceptsResponse> {
+
+        const config = this.config as ControllerConfig;
+
+        const db = await config.getMongoDb(config.getDBName());
+
+        const store = new GrammarConceptStore(db);
+        const concepts = await store.list(req.cefrLevel, req.category);
+
+        return { items: concepts.map(toResponse) };
+    }
+}
+
+function toResponse(concept: GrammarConcept) {
+
+    return {
+        id: concept.id,
+        name: concept.name,
+        category: concept.category,
+        cefrLevelIntroduced: concept.cefrLevelIntroduced,
+        explanation: concept.explanation,
+        examples: concept.examples,
+    };
+}
+
+interface GetGrammarConceptsRequest {
+    cefrLevel?: string;
+    category?: string;
+}
+
+interface GetGrammarConceptsResponse {
+    items: ReturnType<typeof toResponse>[];
+}

--- a/src/dlg/LookupGrammarConcepts.ts
+++ b/src/dlg/LookupGrammarConcepts.ts
@@ -1,0 +1,49 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../Config";
+import { GrammarConcept } from "../model/GrammarConcept";
+import { GrammarConceptStore } from "../store/GrammarConceptStore";
+
+export class LookupGrammarConcepts extends TotoDelegate<LookupGrammarConceptsRequest, LookupGrammarConceptsResponse> {
+
+    parseRequest(req: Request): LookupGrammarConceptsRequest {
+
+        const { ids } = req.body ?? {};
+
+        if (!ids || !Array.isArray(ids) || ids.length === 0) throw new ValidationError(400, "ids must be a non-empty array");
+
+        return { ids };
+    }
+
+    async do(req: LookupGrammarConceptsRequest, _userContext?: UserContext): Promise<LookupGrammarConceptsResponse> {
+
+        const config = this.config as ControllerConfig;
+
+        const db = await config.getMongoDb(config.getDBName());
+
+        const store = new GrammarConceptStore(db);
+        const concepts = await store.findByIds(req.ids);
+
+        return { items: concepts.map(toResponse) };
+    }
+}
+
+function toResponse(concept: GrammarConcept) {
+
+    return {
+        id: concept.id,
+        name: concept.name,
+        category: concept.category,
+        cefrLevelIntroduced: concept.cefrLevelIntroduced,
+        explanation: concept.explanation,
+        examples: concept.examples,
+    };
+}
+
+interface LookupGrammarConceptsRequest {
+    ids: string[];
+}
+
+interface LookupGrammarConceptsResponse {
+    items: ReturnType<typeof toResponse>[];
+}

--- a/src/dlg/PostGrammarConcept.ts
+++ b/src/dlg/PostGrammarConcept.ts
@@ -1,0 +1,57 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../Config";
+import { GrammarConcept, GrammarConceptExample, GRAMMAR_CONCEPT_CATEGORIES, CEFR_LEVELS } from "../model/GrammarConcept";
+import { GrammarConceptStore } from "../store/GrammarConceptStore";
+
+export class PostGrammarConcept extends TotoDelegate<PostGrammarConceptRequest, PostGrammarConceptResponse> {
+
+    parseRequest(req: Request): PostGrammarConceptRequest {
+
+        const { id, name, category, cefrLevelIntroduced, explanation, examples } = req.body ?? {};
+
+        if (!id) throw new ValidationError(400, "id is required");
+        if (!name) throw new ValidationError(400, "name is required");
+        if (!category || !(GRAMMAR_CONCEPT_CATEGORIES as readonly string[]).includes(category)) throw new ValidationError(400, `category must be one of: ${GRAMMAR_CONCEPT_CATEGORIES.join(", ")}`);
+        if (!cefrLevelIntroduced || !(CEFR_LEVELS as readonly string[]).includes(cefrLevelIntroduced)) throw new ValidationError(400, `cefrLevelIntroduced must be one of: ${CEFR_LEVELS.join(", ")}`);
+        if (!explanation) throw new ValidationError(400, "explanation is required");
+        if (!examples || !Array.isArray(examples) || examples.length === 0) throw new ValidationError(400, "examples must be a non-empty array");
+        if (examples.length > 2) throw new ValidationError(400, "examples must have at most 2 items");
+
+        for (const ex of examples) {
+            if (!ex.danish) throw new ValidationError(400, "each example must have a danish string");
+            if (!ex.english) throw new ValidationError(400, "each example must have an english string");
+        }
+
+        return { id, name, category, cefrLevelIntroduced, explanation, examples };
+    }
+
+    async do(req: PostGrammarConceptRequest, _userContext?: UserContext): Promise<PostGrammarConceptResponse> {
+
+        const config = this.config as ControllerConfig;
+
+        const db = await config.getMongoDb(config.getDBName());
+
+        const store = new GrammarConceptStore(db);
+        const concept = new GrammarConcept(req);
+
+        const result = await store.insertOne(concept);
+
+        if (result.status === "duplicate_id") throw new ValidationError(409, `Grammar concept with id '${req.id}' already exists`);
+
+        return { id: result.concept.id };
+    }
+}
+
+interface PostGrammarConceptRequest {
+    id: string;
+    name: string;
+    category: string;
+    cefrLevelIntroduced: string;
+    explanation: string;
+    examples: GrammarConceptExample[];
+}
+
+interface PostGrammarConceptResponse {
+    id: string;
+}

--- a/src/dlg/PostGrammarConceptBatch.ts
+++ b/src/dlg/PostGrammarConceptBatch.ts
@@ -1,0 +1,96 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../Config";
+import { GrammarConcept, GRAMMAR_CONCEPT_CATEGORIES, CEFR_LEVELS } from "../model/GrammarConcept";
+import { GrammarConceptStore } from "../store/GrammarConceptStore";
+
+export class PostGrammarConceptBatch extends TotoDelegate<PostGrammarConceptBatchRequest, PostGrammarConceptBatchResponse> {
+
+    parseRequest(req: Request): PostGrammarConceptBatchRequest {
+
+        const { items } = req.body ?? {};
+
+        if (!items || !Array.isArray(items) || items.length === 0) throw new ValidationError(400, "items must be a non-empty array");
+
+        const validItems: GrammarConcept[] = [];
+        const validationErrors: ValidationErrorItem[] = [];
+
+        for (const raw of items) {
+
+            const reason = validateItem(raw);
+
+            if (reason) {
+                validationErrors.push({ id: raw.id ?? "(unknown)", reason });
+                continue;
+            }
+
+            validItems.push(new GrammarConcept({
+                id: raw.id,
+                name: raw.name,
+                category: raw.category,
+                cefrLevelIntroduced: raw.cefrLevelIntroduced,
+                explanation: raw.explanation,
+                examples: raw.examples,
+            }));
+        }
+
+        return { items: validItems, validationErrors };
+    }
+
+    async do(req: PostGrammarConceptBatchRequest, _userContext?: UserContext): Promise<PostGrammarConceptBatchResponse> {
+
+        const config = this.config as ControllerConfig;
+
+        const db = await config.getMongoDb(config.getDBName());
+
+        const store = new GrammarConceptStore(db);
+        const batchResult = await store.insertBatch(req.items);
+
+        const allItems: PostGrammarConceptBatchResponse["items"] = [
+            ...batchResult.items,
+            ...req.validationErrors.map(ve => ({ id: ve.id, status: "validation_error" as const, reason: ve.reason })),
+        ];
+
+        return {
+            inserted: batchResult.inserted,
+            alreadyPresent: batchResult.alreadyPresent,
+            validationErrors: req.validationErrors.length,
+            items: allItems,
+        };
+    }
+}
+
+function validateItem(raw: any): string | null {
+
+    if (!raw.id) return "id is required";
+    if (!raw.name) return "name is required";
+    if (!raw.category || !(GRAMMAR_CONCEPT_CATEGORIES as readonly string[]).includes(raw.category)) return `category must be one of: ${GRAMMAR_CONCEPT_CATEGORIES.join(", ")}`;
+    if (!raw.cefrLevelIntroduced || !(CEFR_LEVELS as readonly string[]).includes(raw.cefrLevelIntroduced)) return `cefrLevelIntroduced must be one of: ${CEFR_LEVELS.join(", ")}`;
+    if (!raw.explanation) return "explanation is required";
+    if (!raw.examples || !Array.isArray(raw.examples) || raw.examples.length === 0) return "examples must be a non-empty array";
+    if (raw.examples.length > 2) return "examples must have at most 2 items";
+
+    for (const ex of raw.examples) {
+        if (!ex.danish) return "each example must have a danish string";
+        if (!ex.english) return "each example must have an english string";
+    }
+
+    return null;
+}
+
+interface ValidationErrorItem {
+    id: string;
+    reason: string;
+}
+
+interface PostGrammarConceptBatchRequest {
+    items: GrammarConcept[];
+    validationErrors: ValidationErrorItem[];
+}
+
+interface PostGrammarConceptBatchResponse {
+    inserted: number;
+    alreadyPresent: number;
+    validationErrors: number;
+    items: Array<{ id: string; status: string; reason?: string }>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { getHyperscalerConfiguration, SupportedHyperscalers, TotoMicroservice, TotoMicroserviceConfiguration } from 'totoms';
 import { ControllerConfig } from "./Config";
 import { AddSentenceAlternative } from './dlg/AddSentenceAlternative';
+import { PostGrammarConcept } from './dlg/PostGrammarConcept';
 import { CompleteSession } from './dlg/session/CompleteSession';
 import { GetActiveSession } from './dlg/session/GetActiveSession';
 import { GetRollingSessionStats } from './dlg/session/GetRollingSessionStats';
@@ -29,6 +30,7 @@ const config: TotoMicroserviceConfiguration = {
     customConfiguration: ControllerConfig,
     apiConfiguration: {
         apiEndpoints: [
+            { method: 'POST', path: '/grammarConcepts', delegate: PostGrammarConcept },
             { method: 'POST', path: '/vocabularyItems', delegate: PostVocabularyItem },
             { method: 'POST', path: '/vocabularyItems/batch', delegate: PostVocabularyItemBatch },
             { method: 'POST', path: '/vocabularyItems/lookup', delegate: LookupVocabularyItems },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { getHyperscalerConfiguration, SupportedHyperscalers, TotoMicroservice, TotoMicroserviceConfiguration } from 'totoms';
 import { ControllerConfig } from "./Config";
 import { AddSentenceAlternative } from './dlg/AddSentenceAlternative';
+import { GetGrammarConcept } from './dlg/GetGrammarConcept';
 import { PostGrammarConcept } from './dlg/PostGrammarConcept';
 import { PostGrammarConceptBatch } from './dlg/PostGrammarConceptBatch';
 import { CompleteSession } from './dlg/session/CompleteSession';
@@ -33,6 +34,7 @@ const config: TotoMicroserviceConfiguration = {
         apiEndpoints: [
             { method: 'POST', path: '/grammarConcepts', delegate: PostGrammarConcept },
             { method: 'POST', path: '/grammarConcepts/batch', delegate: PostGrammarConceptBatch },
+            { method: 'GET', path: '/grammarConcepts/:id', delegate: GetGrammarConcept },
             { method: 'POST', path: '/vocabularyItems', delegate: PostVocabularyItem },
             { method: 'POST', path: '/vocabularyItems/batch', delegate: PostVocabularyItemBatch },
             { method: 'POST', path: '/vocabularyItems/lookup', delegate: LookupVocabularyItems },

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { ControllerConfig } from "./Config";
 import { AddSentenceAlternative } from './dlg/AddSentenceAlternative';
 import { GetGrammarConcept } from './dlg/GetGrammarConcept';
 import { GetGrammarConcepts } from './dlg/GetGrammarConcepts';
+import { LookupGrammarConcepts } from './dlg/LookupGrammarConcepts';
 import { PostGrammarConcept } from './dlg/PostGrammarConcept';
 import { PostGrammarConceptBatch } from './dlg/PostGrammarConceptBatch';
 import { CompleteSession } from './dlg/session/CompleteSession';
@@ -37,6 +38,7 @@ const config: TotoMicroserviceConfiguration = {
             { method: 'POST', path: '/grammarConcepts/batch', delegate: PostGrammarConceptBatch },
             { method: 'GET', path: '/grammarConcepts/:id', delegate: GetGrammarConcept },
             { method: 'GET', path: '/grammarConcepts', delegate: GetGrammarConcepts },
+            { method: 'POST', path: '/grammarConcepts/lookup', delegate: LookupGrammarConcepts },
             { method: 'POST', path: '/vocabularyItems', delegate: PostVocabularyItem },
             { method: 'POST', path: '/vocabularyItems/batch', delegate: PostVocabularyItemBatch },
             { method: 'POST', path: '/vocabularyItems/lookup', delegate: LookupVocabularyItems },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { getHyperscalerConfiguration, SupportedHyperscalers, TotoMicroservice, T
 import { ControllerConfig } from "./Config";
 import { AddSentenceAlternative } from './dlg/AddSentenceAlternative';
 import { PostGrammarConcept } from './dlg/PostGrammarConcept';
+import { PostGrammarConceptBatch } from './dlg/PostGrammarConceptBatch';
 import { CompleteSession } from './dlg/session/CompleteSession';
 import { GetActiveSession } from './dlg/session/GetActiveSession';
 import { GetRollingSessionStats } from './dlg/session/GetRollingSessionStats';
@@ -31,6 +32,7 @@ const config: TotoMicroserviceConfiguration = {
     apiConfiguration: {
         apiEndpoints: [
             { method: 'POST', path: '/grammarConcepts', delegate: PostGrammarConcept },
+            { method: 'POST', path: '/grammarConcepts/batch', delegate: PostGrammarConceptBatch },
             { method: 'POST', path: '/vocabularyItems', delegate: PostVocabularyItem },
             { method: 'POST', path: '/vocabularyItems/batch', delegate: PostVocabularyItemBatch },
             { method: 'POST', path: '/vocabularyItems/lookup', delegate: LookupVocabularyItems },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { getHyperscalerConfiguration, SupportedHyperscalers, TotoMicroservice, T
 import { ControllerConfig } from "./Config";
 import { AddSentenceAlternative } from './dlg/AddSentenceAlternative';
 import { GetGrammarConcept } from './dlg/GetGrammarConcept';
+import { GetGrammarConcepts } from './dlg/GetGrammarConcepts';
 import { PostGrammarConcept } from './dlg/PostGrammarConcept';
 import { PostGrammarConceptBatch } from './dlg/PostGrammarConceptBatch';
 import { CompleteSession } from './dlg/session/CompleteSession';
@@ -35,6 +36,7 @@ const config: TotoMicroserviceConfiguration = {
             { method: 'POST', path: '/grammarConcepts', delegate: PostGrammarConcept },
             { method: 'POST', path: '/grammarConcepts/batch', delegate: PostGrammarConceptBatch },
             { method: 'GET', path: '/grammarConcepts/:id', delegate: GetGrammarConcept },
+            { method: 'GET', path: '/grammarConcepts', delegate: GetGrammarConcepts },
             { method: 'POST', path: '/vocabularyItems', delegate: PostVocabularyItem },
             { method: 'POST', path: '/vocabularyItems/batch', delegate: PostVocabularyItemBatch },
             { method: 'POST', path: '/vocabularyItems/lookup', delegate: LookupVocabularyItems },

--- a/src/model/CefrLevels.ts
+++ b/src/model/CefrLevels.ts
@@ -1,0 +1,2 @@
+export const CEFR_LEVELS = ["A1", "A2", "B1", "B2", "C1", "C2"] as const;
+export type CefrLevel = typeof CEFR_LEVELS[number];

--- a/src/model/GrammarConcept.ts
+++ b/src/model/GrammarConcept.ts
@@ -1,0 +1,63 @@
+import { WithId } from "mongodb";
+import { CEFR_LEVELS } from "./CefrLevels";
+
+export { CEFR_LEVELS };
+export const GRAMMAR_CONCEPT_CATEGORIES = ["tenses", "sentence_structure", "verbs", "nouns", "pronouns", "adjectives", "connectors", "advanced"] as const;
+
+export interface GrammarConceptExample {
+    danish: string;
+    english: string;
+}
+
+export class GrammarConcept {
+
+    id: string;
+    name: string;
+    category: string;
+    cefrLevelIntroduced: string;
+    explanation: string;
+    examples: GrammarConceptExample[];
+
+    constructor({ id, name, category, cefrLevelIntroduced, explanation, examples }: GrammarConceptInput) {
+
+        this.id = id;
+        this.name = name;
+        this.category = category;
+        this.cefrLevelIntroduced = cefrLevelIntroduced;
+        this.explanation = explanation;
+        this.examples = examples;
+    }
+
+    static fromBSON(data: WithId<any>): GrammarConcept {
+
+        return new GrammarConcept({
+            id: data.id,
+            name: data.name,
+            category: data.category,
+            cefrLevelIntroduced: data.cefrLevelIntroduced,
+            explanation: data.explanation,
+            examples: data.examples ?? [],
+        });
+    }
+
+    toBSON(): any {
+
+        return {
+            id: this.id,
+            name: this.name,
+            category: this.category,
+            cefrLevelIntroduced: this.cefrLevelIntroduced,
+            explanation: this.explanation,
+            examples: this.examples,
+        };
+    }
+}
+
+interface GrammarConceptInput {
+    id: string;
+    name: string;
+    category: string;
+    cefrLevelIntroduced: string;
+    explanation: string;
+    examples: GrammarConceptExample[];
+}

--- a/src/model/VocabularyItem.ts
+++ b/src/model/VocabularyItem.ts
@@ -1,7 +1,8 @@
 import { WithId } from "mongodb";
+import { CEFR_LEVELS } from "./CefrLevels";
 
+export { CEFR_LEVELS };
 export const VOCABULARY_ITEM_TYPES = ["noun", "verb", "adjective", "adverb", "phrase", "pattern", "connector", "pronoun", "number"] as const;
-export const CEFR_LEVELS = ["A1", "A2", "B1", "B2", "C1", "C2"] as const;
 export const VOCABULARY_ITEM_SOURCES = ["curriculum", "user_added"] as const;
 
 export class VocabularyItem {

--- a/src/store/GrammarConceptStore.ts
+++ b/src/store/GrammarConceptStore.ts
@@ -55,6 +55,13 @@ export class GrammarConceptStore {
         return docs.map(doc => GrammarConcept.fromBSON(doc as any));
     }
 
+    async findByIds(ids: string[]): Promise<GrammarConcept[]> {
+
+        const docs = await this.db.collection(GRAMMAR_COLLECTION).find({ id: { $in: ids } }).toArray();
+
+        return docs.map(doc => GrammarConcept.fromBSON(doc as any));
+    }
+
     async findById(id: string): Promise<GrammarConcept | null> {
 
         const doc = await this.db.collection(GRAMMAR_COLLECTION).findOne({ id });

--- a/src/store/GrammarConceptStore.ts
+++ b/src/store/GrammarConceptStore.ts
@@ -43,6 +43,18 @@ export class GrammarConceptStore {
         return { status: "created", concept };
     }
 
+    async list(cefrLevel?: string, category?: string): Promise<GrammarConcept[]> {
+
+        const filter: Record<string, any> = {};
+
+        if (cefrLevel) filter.cefrLevelIntroduced = cefrLevel;
+        if (category) filter.category = category;
+
+        const docs = await this.db.collection(GRAMMAR_COLLECTION).find(filter).sort({ name: 1 }).toArray();
+
+        return docs.map(doc => GrammarConcept.fromBSON(doc as any));
+    }
+
     async findById(id: string): Promise<GrammarConcept | null> {
 
         const doc = await this.db.collection(GRAMMAR_COLLECTION).findOne({ id });

--- a/src/store/GrammarConceptStore.ts
+++ b/src/store/GrammarConceptStore.ts
@@ -84,22 +84,13 @@ export class GrammarConceptStore {
         const existingById = await collection.find({ id: { $in: inputIds } }).toArray();
         const existingIdSet = new Set(existingById.map(doc => doc.id as string));
 
-        const batchResults: BatchItemResult[] = [];
-        const toInsert: GrammarConcept[] = [];
+        // Only insert Grammar Concepts whose id does not exist
+        const toInsert: GrammarConcept[] = concepts.filter((c) => !existingIdSet.has(c.id))
 
-        for (const concept of concepts) {
-
-            if (existingIdSet.has(concept.id)) {
-                batchResults.push({ id: concept.id, status: "duplicate_id" });
-                continue;
-            }
-
-            toInsert.push(concept);
-            batchResults.push({ id: concept.id, status: "created" });
-        }
+        // Compute the batch results
+        const batchResults: BatchItemResult[] = concepts.map((c) => { return { id: c.id, status: existingIdSet.has(c.id) ? "duplicate_id" : "created" } })
 
         if (toInsert.length > 0) {
-
             await collection.insertMany(toInsert.map(c => c.toBSON()), { ordered: false });
         }
 

--- a/src/store/GrammarConceptStore.ts
+++ b/src/store/GrammarConceptStore.ts
@@ -43,6 +43,15 @@ export class GrammarConceptStore {
         return { status: "created", concept };
     }
 
+    async findById(id: string): Promise<GrammarConcept | null> {
+
+        const doc = await this.db.collection(GRAMMAR_COLLECTION).findOne({ id });
+
+        if (!doc) return null;
+
+        return GrammarConcept.fromBSON(doc as any);
+    }
+
     async insertBatch(concepts: GrammarConcept[]): Promise<InsertBatchResult> {
 
         if (concepts.length === 0) {

--- a/src/store/GrammarConceptStore.ts
+++ b/src/store/GrammarConceptStore.ts
@@ -1,0 +1,39 @@
+import { Db } from "mongodb";
+import { GrammarConcept } from "../model/GrammarConcept";
+
+const GRAMMAR_COLLECTION = "grammar";
+
+export interface InsertOneResult {
+    status: "created" | "duplicate_id";
+    concept: GrammarConcept;
+}
+
+export interface BatchItemResult {
+    id: string;
+    status: "created" | "duplicate_id";
+}
+
+export class GrammarConceptStore {
+
+    private db: Db;
+
+    constructor(db: Db) {
+        this.db = db;
+    }
+
+    async insertOne(concept: GrammarConcept): Promise<InsertOneResult> {
+
+        const collection = this.db.collection(GRAMMAR_COLLECTION);
+
+        const byId = await collection.findOne({ id: concept.id });
+
+        if (byId) {
+
+            return { status: "duplicate_id", concept: GrammarConcept.fromBSON(byId as any) };
+        }
+
+        await collection.insertOne(concept.toBSON());
+
+        return { status: "created", concept };
+    }
+}

--- a/src/store/GrammarConceptStore.ts
+++ b/src/store/GrammarConceptStore.ts
@@ -13,6 +13,12 @@ export interface BatchItemResult {
     status: "created" | "duplicate_id";
 }
 
+export interface InsertBatchResult {
+    inserted: number;
+    alreadyPresent: number;
+    items: BatchItemResult[];
+}
+
 export class GrammarConceptStore {
 
     private db: Db;
@@ -35,5 +41,42 @@ export class GrammarConceptStore {
         await collection.insertOne(concept.toBSON());
 
         return { status: "created", concept };
+    }
+
+    async insertBatch(concepts: GrammarConcept[]): Promise<InsertBatchResult> {
+
+        if (concepts.length === 0) {
+
+            return { inserted: 0, alreadyPresent: 0, items: [] };
+        }
+
+        const collection = this.db.collection(GRAMMAR_COLLECTION);
+
+        const inputIds = concepts.map(c => c.id);
+        const existingById = await collection.find({ id: { $in: inputIds } }).toArray();
+        const existingIdSet = new Set(existingById.map(doc => doc.id as string));
+
+        const batchResults: BatchItemResult[] = [];
+        const toInsert: GrammarConcept[] = [];
+
+        for (const concept of concepts) {
+
+            if (existingIdSet.has(concept.id)) {
+                batchResults.push({ id: concept.id, status: "duplicate_id" });
+                continue;
+            }
+
+            toInsert.push(concept);
+            batchResults.push({ id: concept.id, status: "created" });
+        }
+
+        if (toInsert.length > 0) {
+
+            await collection.insertMany(toInsert.map(c => c.toBSON()), { ordered: false });
+        }
+
+        const alreadyPresent = batchResults.filter(r => r.status !== "created").length;
+
+        return { inserted: toInsert.length, alreadyPresent, items: batchResults };
     }
 }

--- a/test/GetGrammarConcept.parseRequest.test.ts
+++ b/test/GetGrammarConcept.parseRequest.test.ts
@@ -1,0 +1,26 @@
+import { assert } from "chai";
+import { Request } from "express";
+import { GetGrammarConcept } from "../src/dlg/GetGrammarConcept";
+
+function makeReq(params: Record<string, any>): Request {
+    return { params, body: {}, query: {} } as unknown as Request;
+}
+
+describe("GetGrammarConcept.parseRequest", () => {
+
+    it("parses id from route params", () => {
+
+        const delegate = new GetGrammarConcept({} as any, {} as any);
+        const parsed = delegate.parseRequest(makeReq({ id: "A1-01-g-present-tense-6604" }));
+
+        assert.equal(parsed.id, "A1-01-g-present-tense-6604");
+    });
+
+    it("throws 400 when id param is missing", () => {
+
+        const delegate = new GetGrammarConcept({} as any, {} as any);
+
+        assert.throws(() => delegate.parseRequest(makeReq({})), /id/i);
+    });
+
+});

--- a/test/GetGrammarConcepts.parseRequest.test.ts
+++ b/test/GetGrammarConcepts.parseRequest.test.ts
@@ -1,0 +1,50 @@
+import { assert } from "chai";
+import { Request } from "express";
+import { GetGrammarConcepts } from "../src/dlg/GetGrammarConcepts";
+
+function makeReq(query: Record<string, any>): Request {
+    return { params: {}, body: {}, query } as unknown as Request;
+}
+
+describe("GetGrammarConcepts.parseRequest", () => {
+
+    it("returns empty object when no query params are given", () => {
+
+        const delegate = new GetGrammarConcepts({} as any, {} as any);
+        const parsed = delegate.parseRequest(makeReq({}));
+
+        assert.isUndefined(parsed.cefrLevel);
+        assert.isUndefined(parsed.category);
+    });
+
+    it("parses a valid cefrLevel query param", () => {
+
+        const delegate = new GetGrammarConcepts({} as any, {} as any);
+        const parsed = delegate.parseRequest(makeReq({ cefrLevel: "B1" }));
+
+        assert.equal(parsed.cefrLevel, "B1");
+    });
+
+    it("parses a valid category query param", () => {
+
+        const delegate = new GetGrammarConcepts({} as any, {} as any);
+        const parsed = delegate.parseRequest(makeReq({ category: "tenses" }));
+
+        assert.equal(parsed.category, "tenses");
+    });
+
+    it("throws 400 for an invalid cefrLevel", () => {
+
+        const delegate = new GetGrammarConcepts({} as any, {} as any);
+
+        assert.throws(() => delegate.parseRequest(makeReq({ cefrLevel: "Z9" })), /cefrLevel/i);
+    });
+
+    it("throws 400 for an invalid category", () => {
+
+        const delegate = new GetGrammarConcepts({} as any, {} as any);
+
+        assert.throws(() => delegate.parseRequest(makeReq({ category: "galaxy-brain" })), /category/i);
+    });
+
+});

--- a/test/GrammarConceptStore.findById.test.ts
+++ b/test/GrammarConceptStore.findById.test.ts
@@ -1,0 +1,60 @@
+import { assert } from "chai";
+import { GrammarConcept } from "../src/model/GrammarConcept";
+import { GrammarConceptStore } from "../src/store/GrammarConceptStore";
+
+function makeConcept(overrides: Partial<ConstructorParameters<typeof GrammarConcept>[0]> = {}): GrammarConcept {
+    return new GrammarConcept({
+        id: "A1-01-g-present-tense-6604",
+        name: "Present Tense",
+        category: "tenses",
+        cefrLevelIntroduced: "A1",
+        explanation: "The present tense describes current actions.",
+        examples: [{ danish: "Jeg spiser.", english: "I eat." }],
+        ...overrides,
+    });
+}
+
+function makeMockCollection(docs: any[] = []) {
+
+    const store = [...docs];
+
+    return {
+        findOne: async (filter: any) => {
+            return store.find(doc => {
+                if (filter.id !== undefined && doc.id !== filter.id) return false;
+                return true;
+            }) ?? null;
+        },
+    };
+}
+
+function makeMockDb(collection: any) {
+    return { collection: () => collection } as any;
+}
+
+describe("GrammarConceptStore.findById", () => {
+
+    it("returns the concept when it exists", async () => {
+
+        const existing = makeConcept().toBSON();
+        const col = makeMockCollection([existing]);
+        const store = new GrammarConceptStore(makeMockDb(col));
+
+        const found = await store.findById("A1-01-g-present-tense-6604");
+
+        assert.isNotNull(found);
+        assert.equal(found!.id, "A1-01-g-present-tense-6604");
+        assert.equal(found!.name, "Present Tense");
+    });
+
+    it("returns null when the id does not exist", async () => {
+
+        const col = makeMockCollection();
+        const store = new GrammarConceptStore(makeMockDb(col));
+
+        const found = await store.findById("nonexistent");
+
+        assert.isNull(found);
+    });
+
+});

--- a/test/GrammarConceptStore.findByIds.test.ts
+++ b/test/GrammarConceptStore.findByIds.test.ts
@@ -1,0 +1,62 @@
+import { assert } from "chai";
+import { GrammarConcept } from "../src/model/GrammarConcept";
+import { GrammarConceptStore } from "../src/store/GrammarConceptStore";
+
+function makeConcept(overrides: Partial<ConstructorParameters<typeof GrammarConcept>[0]> = {}): GrammarConcept {
+    return new GrammarConcept({
+        id: "A1-01-g-present-tense-6604",
+        name: "Present Tense",
+        category: "tenses",
+        cefrLevelIntroduced: "A1",
+        explanation: "The present tense describes current actions.",
+        examples: [{ danish: "Jeg spiser.", english: "I eat." }],
+        ...overrides,
+    });
+}
+
+function makeMockCollection(docs: any[] = []) {
+
+    const store = [...docs];
+
+    return {
+        find: (filter: any) => {
+            const results = filter.id?.$in
+                ? store.filter(doc => (filter.id.$in as string[]).includes(doc.id))
+                : [...store];
+            return { toArray: async () => results };
+        },
+    };
+}
+
+function makeMockDb(collection: any) {
+    return { collection: () => collection } as any;
+}
+
+describe("GrammarConceptStore.findByIds", () => {
+
+    it("returns all found concepts and ignores missing ids", async () => {
+
+        const docs = [
+            makeConcept({ id: "ID-1", name: "Present Tense" }).toBSON(),
+            makeConcept({ id: "ID-2", name: "Past Tense" }).toBSON(),
+        ];
+        const col = makeMockCollection(docs);
+        const store = new GrammarConceptStore(makeMockDb(col));
+
+        const found = await store.findByIds(["ID-1", "ID-2", "MISSING"]);
+
+        assert.equal(found.length, 2);
+        assert.includeMembers(found.map(c => c.id), ["ID-1", "ID-2"]);
+    });
+
+    it("returns empty array when none of the ids exist", async () => {
+
+        const col = makeMockCollection();
+        const store = new GrammarConceptStore(makeMockDb(col));
+
+        const found = await store.findByIds(["NOPE"]);
+
+        assert.deepEqual(found, []);
+    });
+
+});

--- a/test/GrammarConceptStore.insertBatch.test.ts
+++ b/test/GrammarConceptStore.insertBatch.test.ts
@@ -1,0 +1,84 @@
+import { assert } from "chai";
+import { GrammarConcept } from "../src/model/GrammarConcept";
+import { GrammarConceptStore } from "../src/store/GrammarConceptStore";
+
+function makeConcept(overrides: Partial<ConstructorParameters<typeof GrammarConcept>[0]> = {}): GrammarConcept {
+    return new GrammarConcept({
+        id: "A1-01-g-present-tense-6604",
+        name: "Present Tense",
+        category: "tenses",
+        cefrLevelIntroduced: "A1",
+        explanation: "The present tense describes current actions.",
+        examples: [{ danish: "Jeg spiser.", english: "I eat." }],
+        ...overrides,
+    });
+}
+
+function makeMockCollection(docs: any[] = []) {
+
+    const store = [...docs];
+
+    return {
+        find: (filter: any) => {
+            const results = filter.id?.$in
+                ? store.filter(doc => (filter.id.$in as string[]).includes(doc.id))
+                : [...store];
+            return { toArray: async () => results };
+        },
+        insertMany: async (docs_: any[]) => { docs_.forEach(d => store.push(d)); return {}; },
+    };
+}
+
+function makeMockDb(collection: any) {
+    return { collection: () => collection } as any;
+}
+
+describe("GrammarConceptStore.insertBatch", () => {
+
+    it("inserts all new concepts and reports correct summary", async () => {
+
+        const col = makeMockCollection();
+        const store = new GrammarConceptStore(makeMockDb(col));
+        const items = [
+            makeConcept({ id: "ID-1", name: "Present Tense" }),
+            makeConcept({ id: "ID-2", name: "Past Tense" }),
+        ];
+
+        const result = await store.insertBatch(items);
+
+        assert.equal(result.inserted, 2);
+        assert.equal(result.alreadyPresent, 0);
+        assert.isTrue(result.items.every(i => i.status === "created"));
+    });
+
+    it("skips duplicate by id and returns correct summary", async () => {
+
+        const existing = makeConcept({ id: "ID-1", name: "Present Tense" }).toBSON();
+        const col = makeMockCollection([existing]);
+        const store = new GrammarConceptStore(makeMockDb(col));
+        const items = [
+            makeConcept({ id: "ID-1", name: "Present Tense" }),
+            makeConcept({ id: "ID-2", name: "Past Tense" }),
+        ];
+
+        const result = await store.insertBatch(items);
+
+        assert.equal(result.inserted, 1);
+        assert.equal(result.alreadyPresent, 1);
+        assert.equal(result.items.find(i => i.id === "ID-1")!.status, "duplicate_id");
+        assert.equal(result.items.find(i => i.id === "ID-2")!.status, "created");
+    });
+
+    it("returns empty result for an empty input array", async () => {
+
+        const col = makeMockCollection();
+        const store = new GrammarConceptStore(makeMockDb(col));
+
+        const result = await store.insertBatch([]);
+
+        assert.equal(result.inserted, 0);
+        assert.equal(result.alreadyPresent, 0);
+        assert.deepEqual(result.items, []);
+    });
+
+});

--- a/test/GrammarConceptStore.insertOne.test.ts
+++ b/test/GrammarConceptStore.insertOne.test.ts
@@ -1,0 +1,60 @@
+import { assert } from "chai";
+import { GrammarConcept } from "../src/model/GrammarConcept";
+import { GrammarConceptStore } from "../src/store/GrammarConceptStore";
+
+function makeConcept(overrides: Partial<ConstructorParameters<typeof GrammarConcept>[0]> = {}): GrammarConcept {
+    return new GrammarConcept({
+        id: "A1-01-g-present-tense-6604",
+        name: "Present Tense",
+        category: "tenses",
+        cefrLevelIntroduced: "A1",
+        explanation: "The present tense describes current actions.",
+        examples: [{ danish: "Jeg spiser.", english: "I eat." }],
+        ...overrides,
+    });
+}
+
+function makeMockCollection(docs: any[] = []) {
+
+    const store = [...docs];
+
+    return {
+        findOne: async (filter: any) => {
+            return store.find(doc => {
+                if (filter.id !== undefined && doc.id !== filter.id) return false;
+                return true;
+            }) ?? null;
+        },
+        insertOne: async (doc: any) => { store.push(doc); return { insertedId: "mock" }; },
+    };
+}
+
+function makeMockDb(collection: any) {
+    return { collection: () => collection } as any;
+}
+
+describe("GrammarConceptStore.insertOne", () => {
+
+    it("inserts a new concept and returns status created", async () => {
+
+        const col = makeMockCollection();
+        const store = new GrammarConceptStore(makeMockDb(col));
+
+        const result = await store.insertOne(makeConcept());
+
+        assert.equal(result.status, "created");
+        assert.equal(result.concept.id, "A1-01-g-present-tense-6604");
+    });
+
+    it("returns duplicate_id when a concept with the same id already exists", async () => {
+
+        const existing = makeConcept().toBSON();
+        const col = makeMockCollection([existing]);
+        const store = new GrammarConceptStore(makeMockDb(col));
+
+        const result = await store.insertOne(makeConcept({ name: "Other Name" }));
+
+        assert.equal(result.status, "duplicate_id");
+    });
+
+});

--- a/test/GrammarConceptStore.list.test.ts
+++ b/test/GrammarConceptStore.list.test.ts
@@ -1,0 +1,102 @@
+import { assert } from "chai";
+import { GrammarConcept } from "../src/model/GrammarConcept";
+import { GrammarConceptStore } from "../src/store/GrammarConceptStore";
+
+function makeConcept(overrides: Partial<ConstructorParameters<typeof GrammarConcept>[0]> = {}): GrammarConcept {
+    return new GrammarConcept({
+        id: "A1-01-g-present-tense-6604",
+        name: "Present Tense",
+        category: "tenses",
+        cefrLevelIntroduced: "A1",
+        explanation: "The present tense describes current actions.",
+        examples: [{ danish: "Jeg spiser.", english: "I eat." }],
+        ...overrides,
+    });
+}
+
+function makeMockCollection(docs: any[] = []) {
+
+    const store = [...docs];
+
+    return {
+        find: (filter: any) => {
+            let results = [...store];
+
+            if (filter.cefrLevelIntroduced) results = results.filter(doc => doc.cefrLevelIntroduced === filter.cefrLevelIntroduced);
+            if (filter.category) results = results.filter(doc => doc.category === filter.category);
+
+            return {
+                sort: () => ({ toArray: async () => [...results].sort((a, b) => a.name.localeCompare(b.name)) }),
+            };
+        },
+    };
+}
+
+function makeMockDb(collection: any) {
+    return { collection: () => collection } as any;
+}
+
+describe("GrammarConceptStore.list", () => {
+
+    it("returns all concepts when no filters are given", async () => {
+
+        const docs = [
+            makeConcept({ id: "ID-1", name: "Present Tense", cefrLevelIntroduced: "A1" }).toBSON(),
+            makeConcept({ id: "ID-2", name: "Past Tense", cefrLevelIntroduced: "A2", category: "tenses" }).toBSON(),
+        ];
+        const col = makeMockCollection(docs);
+        const store = new GrammarConceptStore(makeMockDb(col));
+
+        const items = await store.list();
+
+        assert.equal(items.length, 2);
+    });
+
+    it("returns only concepts with cefrLevelIntroduced exactly matching the filter", async () => {
+
+        const docs = [
+            makeConcept({ id: "ID-1", name: "Present Tense", cefrLevelIntroduced: "A1" }).toBSON(),
+            makeConcept({ id: "ID-2", name: "Past Tense", cefrLevelIntroduced: "A2", category: "tenses" }).toBSON(),
+            makeConcept({ id: "ID-3", name: "Modal Verbs", cefrLevelIntroduced: "B1", category: "verbs" }).toBSON(),
+        ];
+        const col = makeMockCollection(docs);
+        const store = new GrammarConceptStore(makeMockDb(col));
+
+        const items = await store.list("A2");
+
+        assert.equal(items.length, 1);
+        assert.equal(items[0].id, "ID-2");
+    });
+
+    it("returns only concepts matching the category filter", async () => {
+
+        const docs = [
+            makeConcept({ id: "ID-1", name: "Present Tense", category: "tenses" }).toBSON(),
+            makeConcept({ id: "ID-2", name: "Inversion", category: "sentence_structure" }).toBSON(),
+        ];
+        const col = makeMockCollection(docs);
+        const store = new GrammarConceptStore(makeMockDb(col));
+
+        const items = await store.list(undefined, "sentence_structure");
+
+        assert.equal(items.length, 1);
+        assert.equal(items[0].id, "ID-2");
+    });
+
+    it("combines cefrLevelIntroduced and category filters", async () => {
+
+        const docs = [
+            makeConcept({ id: "ID-1", name: "Present Tense", cefrLevelIntroduced: "A1", category: "tenses" }).toBSON(),
+            makeConcept({ id: "ID-2", name: "Inversion", cefrLevelIntroduced: "A1", category: "sentence_structure" }).toBSON(),
+            makeConcept({ id: "ID-3", name: "Past Tense", cefrLevelIntroduced: "A2", category: "tenses" }).toBSON(),
+        ];
+        const col = makeMockCollection(docs);
+        const store = new GrammarConceptStore(makeMockDb(col));
+
+        const items = await store.list("A1", "tenses");
+
+        assert.equal(items.length, 1);
+        assert.equal(items[0].id, "ID-1");
+    });
+
+});

--- a/test/LookupGrammarConcepts.parseRequest.test.ts
+++ b/test/LookupGrammarConcepts.parseRequest.test.ts
@@ -1,0 +1,33 @@
+import { assert } from "chai";
+import { Request } from "express";
+import { LookupGrammarConcepts } from "../src/dlg/LookupGrammarConcepts";
+
+function makeReq(body: Record<string, any>): Request {
+    return { params: {}, body } as unknown as Request;
+}
+
+describe("LookupGrammarConcepts.parseRequest", () => {
+
+    it("parses a valid ids array", () => {
+
+        const delegate = new LookupGrammarConcepts({} as any, {} as any);
+        const parsed = delegate.parseRequest(makeReq({ ids: ["ID-1", "ID-2"] }));
+
+        assert.deepEqual(parsed.ids, ["ID-1", "ID-2"]);
+    });
+
+    it("throws 400 when ids is missing", () => {
+
+        const delegate = new LookupGrammarConcepts({} as any, {} as any);
+
+        assert.throws(() => delegate.parseRequest(makeReq({})), /ids/i);
+    });
+
+    it("throws 400 when ids is an empty array", () => {
+
+        const delegate = new LookupGrammarConcepts({} as any, {} as any);
+
+        assert.throws(() => delegate.parseRequest(makeReq({ ids: [] })), /ids/i);
+    });
+
+});

--- a/test/PostGrammarConcept.parseRequest.test.ts
+++ b/test/PostGrammarConcept.parseRequest.test.ts
@@ -1,0 +1,121 @@
+import { assert } from "chai";
+import { Request } from "express";
+import { PostGrammarConcept } from "../src/dlg/PostGrammarConcept";
+
+function makeReq(body: Record<string, any>): Request {
+    return { params: {}, body } as unknown as Request;
+}
+
+const validBody = {
+    id: "A1-01-g-present-tense-6604",
+    name: "Present Tense",
+    category: "tenses",
+    cefrLevelIntroduced: "A1",
+    explanation: "The present tense describes current actions.",
+    examples: [{ danish: "Jeg spiser.", english: "I eat." }],
+};
+
+describe("PostGrammarConcept.parseRequest", () => {
+
+    it("parses a valid body with all required fields", () => {
+
+        const delegate = new PostGrammarConcept({} as any, {} as any);
+        const parsed = delegate.parseRequest(makeReq(validBody));
+
+        assert.equal(parsed.id, validBody.id);
+        assert.equal(parsed.name, validBody.name);
+        assert.equal(parsed.category, validBody.category);
+        assert.equal(parsed.cefrLevelIntroduced, validBody.cefrLevelIntroduced);
+        assert.equal(parsed.explanation, validBody.explanation);
+        assert.deepEqual(parsed.examples, validBody.examples);
+    });
+
+    it("parses a valid body with two examples", () => {
+
+        const delegate = new PostGrammarConcept({} as any, {} as any);
+        const body = { ...validBody, examples: [{ danish: "Jeg spiser.", english: "I eat." }, { danish: "Han løber.", english: "He runs." }] };
+        const parsed = delegate.parseRequest(makeReq(body));
+
+        assert.equal(parsed.examples.length, 2);
+    });
+
+    it("throws 400 when id is missing", () => {
+
+        const delegate = new PostGrammarConcept({} as any, {} as any);
+        const { id: _id, ...body } = validBody;
+
+        assert.throws(() => delegate.parseRequest(makeReq(body)), /id/i);
+    });
+
+    it("throws 400 when name is missing", () => {
+
+        const delegate = new PostGrammarConcept({} as any, {} as any);
+        const { name: _n, ...body } = validBody;
+
+        assert.throws(() => delegate.parseRequest(makeReq(body)), /name/i);
+    });
+
+    it("throws 400 when category is invalid", () => {
+
+        const delegate = new PostGrammarConcept({} as any, {} as any);
+
+        assert.throws(() => delegate.parseRequest(makeReq({ ...validBody, category: "galaxy-brain" })), /category/i);
+    });
+
+    it("throws 400 when cefrLevelIntroduced is invalid", () => {
+
+        const delegate = new PostGrammarConcept({} as any, {} as any);
+
+        assert.throws(() => delegate.parseRequest(makeReq({ ...validBody, cefrLevelIntroduced: "Z9" })), /cefrLevelIntroduced/i);
+    });
+
+    it("throws 400 when explanation is missing", () => {
+
+        const delegate = new PostGrammarConcept({} as any, {} as any);
+        const { explanation: _e, ...body } = validBody;
+
+        assert.throws(() => delegate.parseRequest(makeReq(body)), /explanation/i);
+    });
+
+    it("throws 400 when examples is missing", () => {
+
+        const delegate = new PostGrammarConcept({} as any, {} as any);
+        const { examples: _ex, ...body } = validBody;
+
+        assert.throws(() => delegate.parseRequest(makeReq(body)), /examples/i);
+    });
+
+    it("throws 400 when examples is an empty array", () => {
+
+        const delegate = new PostGrammarConcept({} as any, {} as any);
+
+        assert.throws(() => delegate.parseRequest(makeReq({ ...validBody, examples: [] })), /examples/i);
+    });
+
+    it("throws 400 when examples has more than 2 items", () => {
+
+        const delegate = new PostGrammarConcept({} as any, {} as any);
+        const tooMany = [
+            { danish: "a", english: "a" },
+            { danish: "b", english: "b" },
+            { danish: "c", english: "c" },
+        ];
+
+        assert.throws(() => delegate.parseRequest(makeReq({ ...validBody, examples: tooMany })), /examples/i);
+    });
+
+    it("throws 400 when an example is missing danish", () => {
+
+        const delegate = new PostGrammarConcept({} as any, {} as any);
+
+        assert.throws(() => delegate.parseRequest(makeReq({ ...validBody, examples: [{ english: "I eat." }] })), /danish/i);
+    });
+
+    it("throws 400 when an example is missing english", () => {
+
+        const delegate = new PostGrammarConcept({} as any, {} as any);
+
+        assert.throws(() => delegate.parseRequest(makeReq({ ...validBody, examples: [{ danish: "Jeg spiser." }] })), /english/i);
+    });
+
+});

--- a/test/PostGrammarConceptBatch.parseRequest.test.ts
+++ b/test/PostGrammarConceptBatch.parseRequest.test.ts
@@ -1,0 +1,56 @@
+import { assert } from "chai";
+import { Request } from "express";
+import { PostGrammarConceptBatch } from "../src/dlg/PostGrammarConceptBatch";
+
+function makeReq(body: Record<string, any>): Request {
+    return { params: {}, body } as unknown as Request;
+}
+
+const validItem = {
+    id: "A1-01-g-present-tense-6604",
+    name: "Present Tense",
+    category: "tenses",
+    cefrLevelIntroduced: "A1",
+    explanation: "The present tense describes current actions.",
+    examples: [{ danish: "Jeg spiser.", english: "I eat." }],
+};
+
+describe("PostGrammarConceptBatch.parseRequest", () => {
+
+    it("parses a valid batch of items", () => {
+
+        const delegate = new PostGrammarConceptBatch({} as any, {} as any);
+        const parsed = delegate.parseRequest(makeReq({ items: [validItem] }));
+
+        assert.equal(parsed.items.length, 1);
+        assert.equal(parsed.items[0].id, validItem.id);
+        assert.equal(parsed.validationErrors.length, 0);
+    });
+
+    it("throws 400 when items is missing", () => {
+
+        const delegate = new PostGrammarConceptBatch({} as any, {} as any);
+
+        assert.throws(() => delegate.parseRequest(makeReq({})), /items/i);
+    });
+
+    it("throws 400 when items is an empty array", () => {
+
+        const delegate = new PostGrammarConceptBatch({} as any, {} as any);
+
+        assert.throws(() => delegate.parseRequest(makeReq({ items: [] })), /items/i);
+    });
+
+    it("collects per-item validation errors without throwing", () => {
+
+        const delegate = new PostGrammarConceptBatch({} as any, {} as any);
+        const badItem = { id: "bad-1" };
+
+        const parsed = delegate.parseRequest(makeReq({ items: [validItem, badItem] }));
+
+        assert.equal(parsed.items.length, 1);
+        assert.equal(parsed.validationErrors.length, 1);
+        assert.equal(parsed.validationErrors[0].id, "bad-1");
+    });
+
+});


### PR DESCRIPTION
Closes #36

## Summary

- Extracts `CEFR_LEVELS` to a shared `src/model/CefrLevels.ts` (re-exported from `VocabularyItem.ts`)
- Adds `GrammarConcept` model (`id`, `name`, `category`, `cefrLevelIntroduced`, `explanation`, `examples`)
- Adds `GrammarConceptStore` with `insertOne`, `insertBatch`, `findById`, `findByIds`, `list`
- Adds 5 endpoint delegates, each with full validation and registered in `index.ts`

## Endpoints

| Method | Path | Behaviour |
|--------|------|-----------|
| `POST` | `/grammarConcepts` | Insert one; 409 on duplicate `id` |
| `POST` | `/grammarConcepts/batch` | Insert many; skips duplicates by `id` |
| `GET` | `/grammarConcepts/:id` | Fetch by id; 404 if not found |
| `GET` | `/grammarConcepts` | List with optional `?cefrLevel` (exact match) and `?category` filters |
| `POST` | `/grammarConcepts/lookup` | Bulk-resolve ids; missing ids silently ignored |

## Test plan

- [ ] `npm test` — 114 tests, all passing
- [ ] `npm run build` — clean TypeScript compilation
- [ ] `POST /grammarConcepts` rejects duplicate `id` with 409
- [ ] `POST /grammarConcepts/batch` returns per-item status with validation errors collected
- [ ] `GET /grammarConcepts?cefrLevel=B1` returns only B1 concepts (not A1/A2)
- [ ] `GET /grammarConcepts?category=tenses` filters by category
- [ ] `POST /grammarConcepts/lookup` returns only found concepts, silently ignores missing ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)