### PR TITLE
Exercise deduplication on POST /exercises

### DIFF
--- a/docs/features/F04-exercise-bank.md
+++ b/docs/features/F04-exercise-bank.md
@@ -26,6 +26,7 @@ Selection logic lives in [F08](./F08-mastery-aware-exercise-selection.md).
 | Exercise | One interactive task of a given type, testing one vocab item or one grammar concept |
 | Exercise type | translation_active, multiple_choice, fill_blank, sentence_reorder, error_correction, conjugation_drill |
 | Exercise pool | The set of all exercises for a module — queried from the exercises collection by `moduleId`; not a stored entity |
+| Duplicate exercise | An exercise with the same `(moduleId, type, prompt)` as one already in the collection |
 | Alternative answers | Additional accepted answers stored alongside the canonical answer |
 | User-contributed answers | Answers validated on-demand by AI at answer time (translation_active only) |
 
@@ -53,7 +54,7 @@ Selection logic lives in [F08](./F08-mastery-aware-exercise-selection.md).
 
 #### 2.2.2. Endpoints
 
-- `POST /exercises` — batch-insert exercises for a module (body: `{ moduleId, exercises[] }`). Can be called multiple times to grow the pool. Returns `{ exerciseIds: string[] }`.
+- `POST /exercises` — batch-insert exercises for a module (body: `{ moduleId, exercises[] }`). Can be called multiple times to grow the pool. Duplicate exercises (same `moduleId`, `type`, `prompt`) are silently skipped — not rejected. Returns `{ inserted: string[], duplicatesSkipped: number }`.
 - `GET /exercises` — list all exercises for a module; query param `?moduleId=<id>` required. This is the pool retrieval used by sessions and the selection engine.
 - `GET /exercises/:id` — get a single exercise by id.
 - `PUT /exercises/:id/timesShown` — increment `timesShown` by 1 (called after each exercise is shown in a session).
@@ -61,10 +62,10 @@ Selection logic lives in [F08](./F08-mastery-aware-exercise-selection.md).
 
 #### 2.2.4. Business Logic
 
-- A dedicated store is the sole DB accessor for exercises. Supports: batch-insert exercises, list exercises by moduleId, find exercise by id, increment `timesShown`, append a string to `userContributedAnswers`.
+- A dedicated store is the sole DB accessor for exercises. Supports: batch-insert exercises with duplicate detection, list exercises by moduleId, find exercise by id, increment `timesShown`, append a string to `userContributedAnswers`.
 - Per-type linkage rule: `vocabularyItemId` is set for multiple_choice, fill_blank, conjugation_drill, translation_active; `grammarConceptId` is set for sentence_reorder, error_correction. Exactly one of the two must be set per exercise; the other must be null.
+- **Deduplication**: `(moduleId, type, prompt)` is the uniqueness key for exercises. On `POST /exercises`, each exercise in the batch is checked against this key before insert. Duplicates are skipped (not inserted, not errored); the rest are inserted normally. The response reports how many were inserted and how many were skipped.
 - Pool size for a module is derived at query time (count of exercises with that `moduleId`). There is no stored counter.
-- `POST /exercises` returns the server-generated ids of the inserted exercises.
 
 ---
 

--- a/docs/features/changes/2026-06-06-exercise-dedup.md
+++ b/docs/features/changes/2026-06-06-exercise-dedup.md
@@ -1,0 +1,28 @@
+# Change: Exercise deduplication on POST /exercises   (2026-06-06)
+
+## What changed
+- **F04** — `POST /exercises` now deduplicates on `(moduleId, type, prompt)`. Duplicate exercises in the batch are silently skipped (not rejected). Response changes from `{ exerciseIds: string[] }` to `{ inserted: string[], duplicatesSkipped: number }`.
+
+## Why
+Two problems motivated this:
+1. **Accidental double-seeding** — the seeding tool may be run more than once against the same module. Without dedup, exercises accumulate duplicates in the pool, distorting selection weights and inflating pool size.
+2. **Future duplicate prevention** — any future writer (bank refresh generator, content analysis tool) could inadvertently submit exercises already in the pool. A uniqueness constraint at the store level catches this regardless of the caller.
+
+Rejection of the whole batch was ruled out as too harsh for a seeding pipeline — one duplicate would abort the entire call. Skip-with-report is safe to call repeatedly and surfaces duplicate counts without forcing error handling on the caller.
+
+## Impact (add / modify / remove)
+
+**F04 — Exercises — `POST /exercises`**
+- **Modify**: response shape changes from `{ exerciseIds }` to `{ inserted, duplicatesSkipped }`.
+- **Modify**: duplicate exercises (same `moduleId`, `type`, `prompt`) are skipped silently within a batch.
+- **Add**: a uniqueness constraint on `(moduleId, type, prompt)` must be enforced at the store level.
+
+## Behavior to verify
+- Submitting the same batch of exercises twice: second call returns `inserted: []`, `duplicatesSkipped: N`.
+- Submitting a mixed batch (some new, some duplicates): new ones are inserted and returned in `inserted`; duplicates appear in `duplicatesSkipped` count.
+- A batch with no duplicates behaves exactly as before: all exercises inserted, `duplicatesSkipped: 0`.
+- Two exercises with the same `(moduleId, prompt)` but **different `type`** are both accepted (not duplicates).
+- Two exercises with the same `(type, prompt)` but **different `moduleId`** are both accepted (not duplicates).
+
+## Affected feature files
+- [`F04-exercise-bank.md`](../F04-exercise-bank.md)

--- a/src/dlg/exercises/PostExercises.ts
+++ b/src/dlg/exercises/PostExercises.ts
@@ -3,7 +3,7 @@ import { ObjectId } from "mongodb";
 import { TotoDelegate, UserContext, ValidationError } from "totoms";
 import { ControllerConfig } from "../../Config";
 import { Exercise } from "../../model/Exercise";
-import { ExerciseStore } from "../../store/ExerciseStore";
+import { ExerciseStore, InsertBatchResult } from "../../store/ExerciseStore";
 import { ParsedExerciseInput, parseExerciseInput } from "../../util/ExerciseValidation";
 
 export class PostExercises extends TotoDelegate<PostExercisesRequest, PostExercisesResponse> {
@@ -51,9 +51,9 @@ export class PostExercises extends TotoDelegate<PostExercisesRequest, PostExerci
             grammarConceptId: ex.grammarConceptId ?? null,
         }));
 
-        const exerciseIds = await store.insertBatch(exercises);
+        const result = await store.insertBatch(exercises);
 
-        return { exerciseIds };
+        return { inserted: result.inserted, duplicatesSkipped: result.duplicatesSkipped };
     }
 
 }
@@ -64,5 +64,6 @@ interface PostExercisesRequest {
 }
 
 interface PostExercisesResponse {
-    exerciseIds: string[];
+    inserted: string[];
+    duplicatesSkipped: number;
 }

--- a/src/store/ExerciseStore.ts
+++ b/src/store/ExerciseStore.ts
@@ -3,6 +3,11 @@ import { Exercise } from "../model/Exercise";
 
 const EXERCISES_COLLECTION = "exercises";
 
+export interface InsertBatchResult {
+    inserted: string[];
+    duplicatesSkipped: number;
+}
+
 export class ExerciseStore {
 
     private db: Db;
@@ -13,15 +18,29 @@ export class ExerciseStore {
 
     /**
      * Batch-inserts exercise documents into the collection.
-     * Returns the ids of the inserted exercises in the same order.
+     * Deduplicates by (moduleId, type, prompt): exercises matching an existing tuple are silently skipped.
+     * Returns the ids of the inserted exercises and the count of skipped duplicates.
      */
-    async insertBatch(exercises: Exercise[]): Promise<string[]> {
+    async insertBatch(exercises: Exercise[]): Promise<InsertBatchResult> {
 
-        if (exercises.length === 0) return [];
+        if (exercises.length === 0) return { inserted: [], duplicatesSkipped: 0 };
 
-        await this.db.collection(EXERCISES_COLLECTION).insertMany(exercises.map(e => e.toBSON()), { ordered: false });
+        const moduleIds = [...new Set(exercises.map(e => e.moduleId).filter((id): id is string => id !== null))];
 
-        return exercises.map(e => e.id);
+        const existing = await this.db.collection(EXERCISES_COLLECTION)
+            .find({ moduleId: { $in: moduleIds } }, { projection: { moduleId: 1, type: 1, prompt: 1 } } as any)
+            .toArray();
+
+        const existingKeys = new Set(existing.map((e: any) => `${e.moduleId}::${e.type}::${e.prompt}`));
+
+        const toInsert = exercises.filter(e => !existingKeys.has(`${e.moduleId}::${e.type}::${e.prompt}`));
+        const duplicatesSkipped = exercises.length - toInsert.length;
+
+        if (toInsert.length > 0) {
+            await this.db.collection(EXERCISES_COLLECTION).insertMany(toInsert.map(e => e.toBSON()), { ordered: false });
+        }
+
+        return { inserted: toInsert.map(e => e.id), duplicatesSkipped };
     }
 
     /**

--- a/test/ExerciseStore.insertBatch.test.ts
+++ b/test/ExerciseStore.insertBatch.test.ts
@@ -25,6 +25,12 @@ function makeMockCollection(docs: any[] = []) {
         findOne: async (filter: any) => store.find(doc => doc.id === filter.id) ?? null,
         insertOne: async (doc: any) => { store.push(doc); return { insertedId: "mock" }; },
         insertMany: async (docs: any[]) => { store.push(...docs); return { insertedCount: docs.length }; },
+        find: (filter: any, _options?: any) => ({
+            toArray: async () => {
+                const moduleIds: string[] = filter.moduleId?.$in ?? [];
+                return store.filter(doc => moduleIds.includes(doc.moduleId));
+            },
+        }),
         get docs() { return store; },
     };
 }
@@ -35,7 +41,7 @@ function makeMockDb(exercisesCol: any) {
 
 describe("ExerciseStore.insertBatch", () => {
 
-    it("inserts all exercises and returns their ids", async () => {
+    it("inserts all exercises and returns their ids in inserted", async () => {
 
         const col = makeMockCollection();
         const store = new ExerciseStore(makeMockDb(col));
@@ -43,20 +49,22 @@ describe("ExerciseStore.insertBatch", () => {
         const ex1 = makeExercise({ id: "ex-001" });
         const ex2 = makeExercise({ id: "ex-002", prompt: "Write 'goodbye'" });
 
-        const ids = await store.insertBatch([ex1, ex2]);
+        const result = await store.insertBatch([ex1, ex2]);
 
-        assert.deepEqual(ids, ["ex-001", "ex-002"]);
+        assert.deepEqual(result.inserted, ["ex-001", "ex-002"]);
+        assert.equal(result.duplicatesSkipped, 0);
         assert.equal(col.docs.length, 2);
     });
 
-    it("returns empty array when given empty input", async () => {
+    it("returns empty inserted and zero duplicatesSkipped for empty input", async () => {
 
         const col = makeMockCollection();
         const store = new ExerciseStore(makeMockDb(col));
 
-        const ids = await store.insertBatch([]);
+        const result = await store.insertBatch([]);
 
-        assert.deepEqual(ids, []);
+        assert.deepEqual(result.inserted, []);
+        assert.equal(result.duplicatesSkipped, 0);
         assert.equal(col.docs.length, 0);
     });
 
@@ -73,6 +81,65 @@ describe("ExerciseStore.insertBatch", () => {
         assert.equal(col.docs[0].type, "translation_active");
         assert.equal(col.docs[0].answer, "hej");
         assert.equal(col.docs[0].timesShown, 0);
+    });
+
+    it("skips an exercise that already exists by (moduleId, type, prompt)", async () => {
+
+        const existing = makeExercise({ id: "ex-existing" });
+        const col = makeMockCollection([existing.toBSON()]);
+        const store = new ExerciseStore(makeMockDb(col));
+
+        const duplicate = makeExercise({ id: "ex-new-id" });
+
+        const result = await store.insertBatch([duplicate]);
+
+        assert.deepEqual(result.inserted, []);
+        assert.equal(result.duplicatesSkipped, 1);
+        assert.equal(col.docs.length, 1);
+    });
+
+    it("inserts new exercises and skips duplicates in a mixed batch", async () => {
+
+        const existing = makeExercise({ id: "ex-existing" });
+        const col = makeMockCollection([existing.toBSON()]);
+        const store = new ExerciseStore(makeMockDb(col));
+
+        const duplicate = makeExercise({ id: "ex-dup" });
+        const newEx = makeExercise({ id: "ex-new", prompt: "Write 'goodbye'" });
+
+        const result = await store.insertBatch([duplicate, newEx]);
+
+        assert.deepEqual(result.inserted, ["ex-new"]);
+        assert.equal(result.duplicatesSkipped, 1);
+        assert.equal(col.docs.length, 2);
+    });
+
+    it("does not treat same prompt with different type as a duplicate", async () => {
+
+        const existing = makeExercise({ id: "ex-001", type: "translation_active", vocabularyItemId: "vocab-1", grammarConceptId: null });
+        const col = makeMockCollection([existing.toBSON()]);
+        const store = new ExerciseStore(makeMockDb(col));
+
+        const differentType = makeExercise({ id: "ex-002", type: "fill_blank", vocabularyItemId: "vocab-1", grammarConceptId: null });
+
+        const result = await store.insertBatch([differentType]);
+
+        assert.deepEqual(result.inserted, ["ex-002"]);
+        assert.equal(result.duplicatesSkipped, 0);
+    });
+
+    it("does not treat same prompt and type with different moduleId as a duplicate", async () => {
+
+        const existing = makeExercise({ id: "ex-001", moduleId: "mod-1" });
+        const col = makeMockCollection([existing.toBSON()]);
+        const store = new ExerciseStore(makeMockDb(col));
+
+        const differentModule = makeExercise({ id: "ex-002", moduleId: "mod-2" });
+
+        const result = await store.insertBatch([differentModule]);
+
+        assert.deepEqual(result.inserted, ["ex-002"]);
+        assert.equal(result.duplicatesSkipped, 0);
     });
 
 });


### PR DESCRIPTION
## Summary
- \`ExerciseStore.insertBatch\` now checks existing exercises by \`(moduleId, type, prompt)\` before inserting — duplicates are silently skipped
- Return type changes from \`string[]\` to \`{ inserted: string[], duplicatesSkipped: number }\`
- \`POST /exercises\` response updated accordingly: \`{ inserted, duplicatesSkipped }\`

## Test plan
- [ ] 276 tests pass (`npm test`)
- [ ] Build clean (`npm run build`)
- [ ] Submitting the same batch twice: second call returns `inserted: [], duplicatesSkipped: N`
- [ ] Mixed batch: new exercises appear in `inserted`, duplicates in `duplicatesSkipped`
- [ ] Same prompt + different type → both inserted
- [ ] Same prompt + same type + different moduleId → both inserted

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)