### PR TITLE
F09: Grammar Introduction endpoint

### DIFF
--- a/docs/features/F09-grammar-introduction.md
+++ b/docs/features/F09-grammar-introduction.md
@@ -1,4 +1,4 @@
-# F09 — Grammar Introduction (Module Step 1)
+# F09 — Grammar Introduction (Module Step 1) ![Status](https://img.shields.io/badge/status-implemented-brightgreen?style=flat-square)
 
 ## 1. Purpose & Scope
 
@@ -50,6 +50,14 @@ Step 1 of a module run is purely instructional: for each grammar concept in the 
 
 ## 5. Open Questions
 
-| # | Question | Options / Notes |
-|---|----------|-----------------|
-| OQ-01 | Does Step 1 trigger `in_progress`, or only Step 2? | Avoid double-handling; pick the boundary explicitly |
+All open questions resolved.
+
+| # | Question | Resolution |
+|---|----------|------------|
+| OQ-01 | Does Step 1 trigger `in_progress`, or only Step 2? | **Deferred to F10.** This endpoint is pure read-only; no `UserModuleProgress` update is performed. |
+
+## 6. Technical Decisions
+
+- **Response shape**: `{ concepts: [{ name, explanation, examples }] }` — only the fields the app needs for display are returned; `id`, `category`, and `cefrLevelIntroduced` are intentionally omitted from the response.
+- **Order preservation**: `GrammarConceptStore.findByIds` uses MongoDB `$in`, which does not preserve input order. The delegate re-sorts results client-side using a `Map` keyed by concept id before returning.
+- **Empty module**: if `grammarConceptIds` is empty the delegate returns `{ concepts: [] }` immediately without querying the grammar collection.

--- a/src/dlg/modules/GetGrammarIntroduction.ts
+++ b/src/dlg/modules/GetGrammarIntroduction.ts
@@ -1,0 +1,72 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../../Config";
+import { GrammarConceptExample } from "../../model/GrammarConcept";
+import { GrammarConceptStore } from "../../store/GrammarConceptStore";
+import { ModuleStore } from "../../store/ModuleStore";
+
+export class GetGrammarIntroduction extends TotoDelegate<GetGrammarIntroductionRequest, GetGrammarIntroductionResponse> {
+
+    /**
+     * Parses moduleId from the route params.
+     */
+    parseRequest(req: Request): GetGrammarIntroductionRequest {
+
+        const moduleId = req.params.moduleId;
+
+        if (!moduleId) throw new ValidationError(400, "moduleId is required");
+
+        return { moduleId };
+    }
+
+    /**
+     * Returns the module's grammar concepts with name, explanation, and examples,
+     * ordered to match the grammarConceptIds array on the module document.
+     */
+    async do(req: GetGrammarIntroductionRequest, _userContext?: UserContext): Promise<GetGrammarIntroductionResponse> {
+
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+
+        const moduleStore = new ModuleStore(db);
+
+        const module = await moduleStore.findById(req.moduleId);
+
+        if (!module) throw new ValidationError(404, `Module with id '${req.moduleId}' not found`);
+
+        if (module.grammarConceptIds.length === 0) {
+            return { concepts: [] };
+        }
+
+        const conceptStore = new GrammarConceptStore(db);
+
+        const concepts = await conceptStore.findByIds(module.grammarConceptIds);
+
+        // Re-sort to match grammarConceptIds order: MongoDB $in does not preserve insertion order.
+        const conceptById = new Map(concepts.map(c => [c.id, c]));
+
+        const ordered = module.grammarConceptIds.map(id => conceptById.get(id)).filter((c): c is NonNullable<typeof c> => c !== undefined);
+
+        return {
+            concepts: ordered.map(c => ({
+                name: c.name,
+                explanation: c.explanation,
+                examples: c.examples,
+            })),
+        };
+    }
+}
+
+interface GetGrammarIntroductionRequest {
+    moduleId: string;
+}
+
+interface GetGrammarIntroductionResponse {
+    concepts: GrammarConceptSummary[];
+}
+
+interface GrammarConceptSummary {
+    name: string;
+    explanation: string;
+    examples: GrammarConceptExample[];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { PostSentence } from './dlg/sentences/PostSentence';
 import { PostSentences } from './dlg/sentences/PostSentences';
 import { PostVocabularyItem } from './dlg/vocabulary/PostVocabularyItem';
 import { PostVocabularyItemBatch } from './dlg/vocabulary/PostVocabularyItemBatch';
+import { GetGrammarIntroduction } from './dlg/modules/GetGrammarIntroduction';
 import { GetModule } from './dlg/modules/GetModule';
 import { GetModules } from './dlg/modules/GetModules';
 import { PostModule } from './dlg/modules/PostModule';
@@ -62,6 +63,7 @@ const config: TotoMicroserviceConfiguration = {
             { method: 'POST', path: '/modules', delegate: PostModule },
             { method: 'GET', path: '/modules/:id', delegate: GetModule },
             { method: 'GET', path: '/modules', delegate: GetModules },
+            { method: 'GET', path: '/modules/:moduleId/grammarIntroduction', delegate: GetGrammarIntroduction },
 
             { method: 'POST', path: '/grammarConcepts', delegate: PostGrammarConcept },
             { method: 'POST', path: '/grammarConcepts/batch', delegate: PostGrammarConceptBatch },

--- a/test/GetGrammarIntroduction.do.test.ts
+++ b/test/GetGrammarIntroduction.do.test.ts
@@ -1,0 +1,97 @@
+import { assert } from "chai";
+import { GetGrammarIntroduction } from "../src/dlg/modules/GetGrammarIntroduction";
+import { Module } from "../src/model/Module";
+import { GrammarConcept } from "../src/model/GrammarConcept";
+
+function makeMockConfig(moduleDoc: any | null, conceptDocs: any[]) {
+
+    const collections: Record<string, any> = {
+        modules: {
+            findOne: async (filter: any) => (moduleDoc && moduleDoc.id === filter.id ? moduleDoc : null),
+        },
+        grammar: {
+            find: (filter: any) => ({
+                toArray: async () => conceptDocs.filter(d => (filter.id?.$in ?? []).includes(d.id)),
+            }),
+        },
+    };
+
+    return {
+        getDBName: () => "test",
+        getMongoDb: async () => ({ collection: (name: string) => collections[name] }),
+    } as any;
+}
+
+function makeModuleBSON(grammarConceptIds: string[]): any {
+    return new Module({
+        id: "mod-01",
+        title: "Test Module",
+        theme: "daily life",
+        communicationGoal: "greet people",
+        cefrLevel: "A1",
+        grammarConceptIds,
+    }).toBSON();
+}
+
+function makeConceptBSON(id: string, name: string): any {
+    return new GrammarConcept({
+        id,
+        name,
+        category: "tenses",
+        cefrLevelIntroduced: "A1",
+        explanation: `Explanation for ${name}`,
+        examples: [{ danish: "Hej", english: "Hello" }],
+    }).toBSON();
+}
+
+describe("GetGrammarIntroduction.do", () => {
+
+    it("returns concepts in grammarConceptIds order even when the collection returns them out of order", async () => {
+
+        const moduleDoc = makeModuleBSON(["gc-A", "gc-B", "gc-C"]);
+        const conceptDocs = [
+            makeConceptBSON("gc-C", "Concept C"),
+            makeConceptBSON("gc-A", "Concept A"),
+            makeConceptBSON("gc-B", "Concept B"),
+        ];
+
+        const config = makeMockConfig(moduleDoc, conceptDocs);
+        const delegate = new GetGrammarIntroduction({} as any, config);
+
+        const result = await delegate.do({ moduleId: "mod-01" });
+
+        assert.equal(result.concepts.length, 3);
+        assert.equal(result.concepts[0].name, "Concept A");
+        assert.equal(result.concepts[1].name, "Concept B");
+        assert.equal(result.concepts[2].name, "Concept C");
+    });
+
+    it("returns empty concepts array when module has no grammarConceptIds", async () => {
+
+        const moduleDoc = makeModuleBSON([]);
+        const config = makeMockConfig(moduleDoc, []);
+        const delegate = new GetGrammarIntroduction({} as any, config);
+
+        const result = await delegate.do({ moduleId: "mod-01" });
+
+        assert.deepEqual(result.concepts, []);
+    });
+
+    it("throws 404 when module is not found", async () => {
+
+        const config = makeMockConfig(null, []);
+        const delegate = new GetGrammarIntroduction({} as any, config);
+
+        try {
+
+            await delegate.do({ moduleId: "non-existent" });
+
+            assert.fail("Expected an error to be thrown");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 404);
+        }
+    });
+
+});

--- a/test/GetGrammarIntroduction.parseRequest.test.ts
+++ b/test/GetGrammarIntroduction.parseRequest.test.ts
@@ -1,0 +1,26 @@
+import { assert } from "chai";
+import { Request } from "express";
+import { GetGrammarIntroduction } from "../src/dlg/modules/GetGrammarIntroduction";
+
+function makeReq(params: Record<string, any>): Request {
+    return { params, body: {} } as unknown as Request;
+}
+
+describe("GetGrammarIntroduction.parseRequest", () => {
+
+    it("parses moduleId from route params", () => {
+
+        const delegate = new GetGrammarIntroduction({} as any, {} as any);
+        const parsed = delegate.parseRequest(makeReq({ moduleId: "danish-A1-01" }));
+
+        assert.equal(parsed.moduleId, "danish-A1-01");
+    });
+
+    it("throws 400 when moduleId param is missing", () => {
+
+        const delegate = new GetGrammarIntroduction({} as any, {} as any);
+
+        assert.throws(() => delegate.parseRequest(makeReq({})), /moduleId/i);
+    });
+
+});


### PR DESCRIPTION
## Summary

- Adds `GET /modules/:moduleId/grammarIntroduction` — returns the module's grammar concepts (`name`, `explanation`, `examples`) in the order defined by `grammarConceptIds` on the module document
- Pure read-only; no `UserModuleProgress` side-effects (OQ-01 resolved: `in_progress` transition deferred to F10)
- Re-sorts MongoDB results client-side to preserve `grammarConceptIds` order (MongoDB `$in` does not preserve it)

## Test plan

- [x] `GetGrammarIntroduction.parseRequest` — parses `moduleId`, throws 400 when missing
- [x] `GetGrammarIntroduction.do` — correct order even when DB returns concepts out of order, empty array for modules with no concepts, 404 for unknown module
- [x] All 281 tests pass (`npm test`)
- [x] Project builds cleanly (`npm run build`)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)