### PR TITLE
F08: Implement mastery-aware exercise selection engine

### DIFF
--- a/docs/features/F08-mastery-aware-exercise-selection.md
+++ b/docs/features/F08-mastery-aware-exercise-selection.md
@@ -1,5 +1,7 @@
 # F08 — Mastery-Aware Exercise Selection
 
+![Status](https://img.shields.io/badge/status-implemented-brightgreen?style=flat-square)
+
 ## 1. Purpose & Scope
 
 This feature is the personalization engine: given a pool of exercises (a module bank or a level test bank) and the user's mastery state, it draws a session-sized subset weighted toward the user's weak spots. **No AI is involved** — it is a deterministic-but-randomized weighted sampling algorithm. It is consumed by Practice Sessions (F10), Module Tests (F11), and Level Tests (F21). Delivering it as its own feature keeps the algorithm independently testable.
@@ -36,6 +38,13 @@ This feature is the personalization engine: given a pool of exercises (a module 
 - Inputs come from callers: mastery map from F06 (bulk read), recent session misses from the caller (F10/F11 know their last session), pool from F04 (`GET /exercises?moduleId=`) or F20 (`GET /levelTestBanks/:cefrLevel`).
 - Thresholds (0.85 deprioritize, boost magnitude) are tunable parameters.
 
+#### Technical Decisions
+
+- Implemented as `selectExercises` in `src/util/ExerciseSelector.ts` — a pure function taking `{ pool, masteryByItemId, recentMisses, targetCount }` and returning the selected `Exercise[]`. `masteryByItemId` is a single `Map<string, number>` keyed by the linked item id (`vocabularyItemId` or `grammarConceptId` — both id spaces are disjoint, so one map suffices); `recentMisses` is a `Set<string>` of exercise ids missed in the caller's most recent session.
+- The recent-miss boost is **additive**: `weight = (1 − masteryScore) + (RECENT_MISS_BOOST if missed else 0)`. Both `DEPRIORITIZE_MASTERY_THRESHOLD` (0.85) and `RECENT_MISS_BOOST` (0.5) live as tunable constants in `Config.ts`.
+- "Pool nearly empty" (OQ-02) is resolved as: if the count of non-deprioritized exercises (mastery ≤ 0.85) is less than `targetCount`, deprioritization is skipped entirely and the full pool is scored.
+- Dedup is implemented by randomly picking one exercise per linked item as the "primary" candidate; the rest are kept as a fallback pool only drawn from when there aren't enough distinct items to reach `targetCount`. The final draw reuses the existing `weightedSample` (Efraimidis-Spirakis) from `src/util/WeightedSampler.ts`.
+
 ---
 
 ## 3. Key Consumer Stories
@@ -59,5 +68,4 @@ This feature is the personalization engine: given a pool of exercises (a module 
 
 | # | Question | Options / Notes |
 |---|----------|-----------------|
-| OQ-01 | How is "most recent session" scoped — per module or global? | Likely per module for module sessions; per level for level tests |
-| OQ-02 | What counts as "pool nearly empty" for the deprioritization override? | e.g. fewer non-deprioritized exercises than the target count |
+| OQ-01 | How is "most recent session" scoped — per module or global? | Out of scope for the engine — `recentMisses` is an opaque set of exercise ids supplied by the caller (F10/F11/F21 each scope their own "most recent session") |

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -9,6 +9,20 @@ import { APIOptions, TotoControllerConfig } from 'totoms';
  */
 export const PRACTICE_MIN_UNSEEN_VOCAB_PERCENT = 50;
 
+/**
+ * Mastery score above which an exercise's linked item is considered mastered
+ * and the exercise is deprioritized during selection (F08), unless the pool
+ * of non-deprioritized exercises is too small to fill the session.
+ */
+export const DEPRIORITIZE_MASTERY_THRESHOLD = 0.85;
+
+/**
+ * Extra weight added to an exercise's selection weight (F08) when its linked
+ * item was answered incorrectly in the user's most recent session, so it
+ * resurfaces sooner.
+ */
+export const RECENT_MISS_BOOST = 0.5;
+
 export class ControllerConfig extends TotoControllerConfig {
 
     getMongoSecretNames(): { userSecretName: string; pwdSecretName: string; } | null {

--- a/src/util/ExerciseSelector.ts
+++ b/src/util/ExerciseSelector.ts
@@ -1,5 +1,6 @@
 import { Exercise } from "../model/Exercise";
 import { DEPRIORITIZE_MASTERY_THRESHOLD, RECENT_MISS_BOOST } from "../Config";
+import { weightedSample } from "./WeightedSampler";
 
 /**
  * An exercise scored for selection (F08): its linked item, the mastery score
@@ -56,4 +57,85 @@ export function scoreExercisePool(input: ScoreExercisePoolInput): ScoredExercise
     if (nonDeprioritized.length < targetCount) return scored;
 
     return nonDeprioritized;
+}
+
+/**
+ * Splits scored candidates into a "primary" set (one randomly-chosen exercise
+ * per linked item) and an "extra" set (the remaining exercises for items that
+ * have more than one candidate).
+ *
+ * This is how F08 avoids testing the same item/concept twice: the primary set
+ * is drawn from first, and the extras are only used as a fallback to fill the
+ * session when there aren't enough distinct items to reach the target count.
+ *
+ * @param scored the scored candidates to split
+ *
+ * @return the primary (deduped) and extra (fallback) candidate sets
+ */
+function dedupByLinkedItem(scored: ScoredExercise[]): { primary: ScoredExercise[]; extra: ScoredExercise[] } {
+
+    const candidatesByItem = new Map<string, ScoredExercise[]>();
+
+    for (const candidate of scored) {
+        const group = candidatesByItem.get(candidate.linkedItemId) ?? [];
+
+        group.push(candidate);
+        candidatesByItem.set(candidate.linkedItemId, group);
+    }
+
+    const primary: ScoredExercise[] = [];
+    const extra: ScoredExercise[] = [];
+
+    for (const group of candidatesByItem.values()) {
+        const pickedIndex = Math.floor(Math.random() * group.length);
+
+        group.forEach((candidate, index) => {
+            if (index === pickedIndex) primary.push(candidate);
+            else extra.push(candidate);
+        });
+    }
+
+    return { primary, extra };
+}
+
+export interface SelectExercisesInput {
+    pool: Exercise[];
+    masteryByItemId: Map<string, number>;
+    recentMisses: Set<string>;
+    targetCount: number;
+}
+
+/**
+ * Draws a session-sized, mastery-aware weighted sample of exercises from a pool (F08).
+ *
+ * Business logic:
+ * - Each exercise's weight is derived from its linked item's mastery — see scoreExercisePool.
+ * - When several exercises link to the same item, only one is considered per draw
+ *   (deduped at random); the others are kept as a fallback to fill the session if
+ *   there aren't enough distinct items to reach the target count.
+ * - The final selection is a weighted random sample without replacement, so weaker
+ *   areas are more likely to be picked without being deterministic.
+ *
+ * @param input the exercise pool, the mastery map (linked item id -> masteryScore),
+ *              the ids of exercises missed in the most recent session, and the
+ *              session's target exercise count
+ *
+ * @return the selected exercises, at most `targetCount` long
+ */
+export function selectExercises(input: SelectExercisesInput): Exercise[] {
+
+    const { pool, masteryByItemId, recentMisses, targetCount } = input;
+
+    const scored = scoreExercisePool({ pool, masteryByItemId, recentMisses, targetCount });
+    const { primary, extra } = dedupByLinkedItem(scored);
+
+    const selected = weightedSample(primary, candidate => candidate.weight, targetCount);
+
+    if (selected.length < targetCount) {
+        const stillNeeded = targetCount - selected.length;
+
+        selected.push(...weightedSample(extra, candidate => candidate.weight, stillNeeded));
+    }
+
+    return selected.map(candidate => candidate.exercise);
 }

--- a/src/util/ExerciseSelector.ts
+++ b/src/util/ExerciseSelector.ts
@@ -1,0 +1,59 @@
+import { Exercise } from "../model/Exercise";
+import { DEPRIORITIZE_MASTERY_THRESHOLD, RECENT_MISS_BOOST } from "../Config";
+
+/**
+ * An exercise scored for selection (F08): its linked item, the mastery score
+ * resolved from the mastery map, and the resulting selection weight.
+ */
+export interface ScoredExercise {
+    exercise: Exercise;
+    linkedItemId: string;
+    masteryScore: number;
+    weight: number;
+}
+
+export interface ScoreExercisePoolInput {
+    pool: Exercise[];
+    masteryByItemId: Map<string, number>;
+    recentMisses: Set<string>;
+    targetCount: number;
+}
+
+/**
+ * Scores and filters an exercise pool for mastery-aware selection (F08).
+ *
+ * For each exercise, resolves the mastery score of its linked item (vocabulary
+ * or grammar concept — every exercise links to exactly one) and computes a
+ * selection weight as `(1 - masteryScore)`, boosted by RECENT_MISS_BOOST when
+ * the exercise was answered incorrectly in the user's most recent session.
+ *
+ * Exercises whose linked item mastery exceeds DEPRIORITIZE_MASTERY_THRESHOLD
+ * are deprioritized (excluded from the result), unless doing so would leave
+ * fewer exercises than the session's target count — in which case the pool is
+ * considered nearly empty and nothing is excluded.
+ *
+ * @param input the exercise pool, the mastery map (linked item id -> masteryScore),
+ *              the ids of exercises missed in the most recent session, and the
+ *              session's target exercise count
+ *
+ * @return the scored, filtered candidates ready for the final selection draw
+ */
+export function scoreExercisePool(input: ScoreExercisePoolInput): ScoredExercise[] {
+
+    const { pool, masteryByItemId, recentMisses, targetCount } = input;
+
+    const scored = pool.map(exercise => {
+
+        const linkedItemId = (exercise.vocabularyItemId ?? exercise.grammarConceptId)!;
+        const masteryScore = masteryByItemId.get(linkedItemId) ?? 0;
+        const boost = recentMisses.has(exercise.id) ? RECENT_MISS_BOOST : 0;
+
+        return { exercise, linkedItemId, masteryScore, weight: (1 - masteryScore) + boost };
+    });
+
+    const nonDeprioritized = scored.filter(s => s.masteryScore <= DEPRIORITIZE_MASTERY_THRESHOLD);
+
+    if (nonDeprioritized.length < targetCount) return scored;
+
+    return nonDeprioritized;
+}

--- a/test/ExerciseSelector.selectExercises.test.ts
+++ b/test/ExerciseSelector.selectExercises.test.ts
@@ -1,0 +1,118 @@
+import { assert } from "chai";
+import { Exercise } from "../src/model/Exercise";
+import { selectExercises } from "../src/util/ExerciseSelector";
+
+function makeExercise(overrides: Partial<ConstructorParameters<typeof Exercise>[0]> = {}): Exercise {
+
+    return new Exercise({
+        id: "ex-001",
+        moduleId: "mod-1",
+        type: "translation_active",
+        prompt: "Write 'hello' in Danish",
+        promptTranslation: null,
+        answer: "hej",
+        vocabularyItemId: "vocab-1",
+        grammarConceptId: null,
+        ...overrides,
+    });
+}
+
+/**
+ * Builds `exercisesPerItem` exercises for each of `itemCount` distinct vocabulary
+ * items, e.g. makePoolWithDuplicates(5, 2) -> 10 exercises across 5 linked items.
+ */
+function makePoolWithDuplicates(itemCount: number, exercisesPerItem: number): Exercise[] {
+
+    const pool: Exercise[] = [];
+
+    for (let item = 0; item < itemCount; item++) {
+        for (let copy = 0; copy < exercisesPerItem; copy++) {
+            pool.push(makeExercise({ id: `ex-${item}-${copy}`, vocabularyItemId: `vocab-${item}` }));
+        }
+    }
+
+    return pool;
+}
+
+describe("selectExercises", () => {
+
+    it("returns exactly targetCount exercises when the pool is large enough", () => {
+
+        const pool = makePoolWithDuplicates(10, 1);
+
+        const selected = selectExercises({ pool, masteryByItemId: new Map(), recentMisses: new Set(), targetCount: 4 });
+
+        assert.lengthOf(selected, 4);
+    });
+
+    it("returns the whole pool when it is smaller than the target count", () => {
+
+        const pool = makePoolWithDuplicates(3, 1);
+
+        const selected = selectExercises({ pool, masteryByItemId: new Map(), recentMisses: new Set(), targetCount: 10 });
+
+        assert.lengthOf(selected, 3);
+    });
+
+    it("only returns exercises that belong to the pool", () => {
+
+        const pool = makePoolWithDuplicates(8, 1);
+        const poolIds = new Set(pool.map(e => e.id));
+
+        const selected = selectExercises({ pool, masteryByItemId: new Map(), recentMisses: new Set(), targetCount: 5 });
+
+        for (const exercise of selected) assert.isTrue(poolIds.has(exercise.id), `${exercise.id} should come from the pool`);
+    });
+
+    describe("dedup by linked item", () => {
+
+        it("does not pick two exercises for the same linked item when enough distinct items exist to fill the session", () => {
+
+            // 6 distinct items, 2 exercises each — plenty to fill a 4-exercise session without repeats
+            const pool = makePoolWithDuplicates(6, 2);
+
+            const selected = selectExercises({ pool, masteryByItemId: new Map(), recentMisses: new Set(), targetCount: 4 });
+            const linkedItemIds = selected.map(e => e.vocabularyItemId);
+
+            assert.lengthOf(new Set(linkedItemIds), linkedItemIds.length);
+        });
+
+        it("falls back to repeating a linked item's exercises when there are fewer distinct items than the target count", () => {
+
+            // Only 2 distinct items, 3 exercises each — must repeat an item to reach 4
+            const pool = makePoolWithDuplicates(2, 3);
+
+            const selected = selectExercises({ pool, masteryByItemId: new Map(), recentMisses: new Set(), targetCount: 4 });
+            const linkedItemIds = selected.map(e => e.vocabularyItemId);
+
+            assert.lengthOf(selected, 4);
+            assert.isAtMost(new Set(linkedItemIds).size, 2);
+            for (const id of linkedItemIds) assert.oneOf(id, ["vocab-0", "vocab-1"]);
+        });
+
+        it("never selects the very same exercise twice", () => {
+
+            const pool = makePoolWithDuplicates(2, 3);
+
+            const selected = selectExercises({ pool, masteryByItemId: new Map(), recentMisses: new Set(), targetCount: 6 });
+            const exerciseIds = selected.map(e => e.id);
+
+            assert.lengthOf(new Set(exerciseIds), exerciseIds.length);
+        });
+    });
+
+    describe("integration with scoring", () => {
+
+        it("excludes mastered exercises from the draw when enough weak ones remain to fill the session", () => {
+
+            const mastered = makeExercise({ id: "ex-mastered", vocabularyItemId: "vocab-mastered" });
+            const weakPool = makePoolWithDuplicates(5, 1).map((e, i) => makeExercise({ id: `ex-weak-${i}`, vocabularyItemId: `vocab-weak-${i}` }));
+
+            const masteryByItemId = new Map<string, number>([["vocab-mastered", 0.95], ...weakPool.map((_, i): [string, number] => [`vocab-weak-${i}`, 0.1])]);
+
+            const selected = selectExercises({ pool: [mastered, ...weakPool], masteryByItemId, recentMisses: new Set(), targetCount: 3 });
+
+            assert.notInclude(selected.map(e => e.id), "ex-mastered");
+        });
+    });
+});

--- a/test/ExerciseSelector.test.ts
+++ b/test/ExerciseSelector.test.ts
@@ -1,0 +1,128 @@
+import { assert } from "chai";
+import { Exercise } from "../src/model/Exercise";
+import { scoreExercisePool } from "../src/util/ExerciseSelector";
+import { DEPRIORITIZE_MASTERY_THRESHOLD, RECENT_MISS_BOOST } from "../src/Config";
+
+function makeExercise(overrides: Partial<ConstructorParameters<typeof Exercise>[0]> = {}): Exercise {
+
+    return new Exercise({
+        id: "ex-001",
+        moduleId: "mod-1",
+        type: "translation_active",
+        prompt: "Write 'hello' in Danish",
+        promptTranslation: null,
+        answer: "hej",
+        vocabularyItemId: "vocab-1",
+        grammarConceptId: null,
+        ...overrides,
+    });
+}
+
+describe("scoreExercisePool", () => {
+
+    describe("mastery resolution", () => {
+
+        it("resolves mastery from the vocabulary item linked to the exercise", () => {
+
+            const exercise = makeExercise({ id: "ex-vocab", vocabularyItemId: "vocab-1", grammarConceptId: null });
+            const masteryByItemId = new Map([["vocab-1", 0.4]]);
+
+            const [scored] = scoreExercisePool({ pool: [exercise], masteryByItemId, recentMisses: new Set(), targetCount: 5 });
+
+            assert.equal(scored.linkedItemId, "vocab-1");
+            assert.equal(scored.weight, 0.6);
+        });
+
+        it("resolves mastery from the grammar concept linked to the exercise", () => {
+
+            const exercise = makeExercise({ id: "ex-grammar", type: "sentence_reorder", vocabularyItemId: null, grammarConceptId: "grammar-1" });
+            const masteryByItemId = new Map([["grammar-1", 0.3]]);
+
+            const [scored] = scoreExercisePool({ pool: [exercise], masteryByItemId, recentMisses: new Set(), targetCount: 5 });
+
+            assert.equal(scored.linkedItemId, "grammar-1");
+            assert.equal(scored.weight, 0.7);
+        });
+
+        it("treats a linked item absent from the mastery map as never reviewed (masteryScore 0)", () => {
+
+            const exercise = makeExercise({ id: "ex-unseen", vocabularyItemId: "vocab-unseen", grammarConceptId: null });
+
+            const [scored] = scoreExercisePool({ pool: [exercise], masteryByItemId: new Map(), recentMisses: new Set(), targetCount: 5 });
+
+            assert.equal(scored.weight, 1);
+        });
+    });
+
+    describe("deprioritization", () => {
+
+        it(`excludes exercises whose linked item mastery is above ${DEPRIORITIZE_MASTERY_THRESHOLD} when the pool has enough other exercises`, () => {
+
+            const mastered = makeExercise({ id: "ex-mastered", vocabularyItemId: "vocab-mastered" });
+            const weak = makeExercise({ id: "ex-weak", vocabularyItemId: "vocab-weak" });
+            const masteryByItemId = new Map([["vocab-mastered", 0.9], ["vocab-weak", 0.2]]);
+
+            const scored = scoreExercisePool({ pool: [mastered, weak], masteryByItemId, recentMisses: new Set(), targetCount: 1 });
+
+            assert.lengthOf(scored, 1);
+            assert.equal(scored[0].exercise.id, "ex-weak");
+        });
+
+        it(`keeps exercises at exactly the ${DEPRIORITIZE_MASTERY_THRESHOLD} threshold (only scores strictly above as deprioritized)`, () => {
+
+            const atThreshold = makeExercise({ id: "ex-at-threshold", vocabularyItemId: "vocab-at-threshold" });
+            const filler = makeExercise({ id: "ex-filler", vocabularyItemId: "vocab-filler" });
+            const masteryByItemId = new Map([["vocab-at-threshold", DEPRIORITIZE_MASTERY_THRESHOLD], ["vocab-filler", 0.1]]);
+
+            const scored = scoreExercisePool({ pool: [atThreshold, filler], masteryByItemId, recentMisses: new Set(), targetCount: 1 });
+
+            assert.include(scored.map(s => s.exercise.id), "ex-at-threshold");
+        });
+
+        it("falls back to including deprioritized exercises when too few non-deprioritized exercises remain to fill the session", () => {
+
+            const mastered1 = makeExercise({ id: "ex-mastered-1", vocabularyItemId: "vocab-mastered-1" });
+            const mastered2 = makeExercise({ id: "ex-mastered-2", vocabularyItemId: "vocab-mastered-2" });
+            const weak = makeExercise({ id: "ex-weak", vocabularyItemId: "vocab-weak" });
+            const masteryByItemId = new Map([["vocab-mastered-1", 0.9], ["vocab-mastered-2", 0.95], ["vocab-weak", 0.2]]);
+
+            const scored = scoreExercisePool({ pool: [mastered1, mastered2, weak], masteryByItemId, recentMisses: new Set(), targetCount: 3 });
+
+            assert.lengthOf(scored, 3);
+            assert.includeMembers(scored.map(s => s.exercise.id), ["ex-mastered-1", "ex-mastered-2", "ex-weak"]);
+        });
+    });
+
+    describe("weight computation", () => {
+
+        it("weighs an exercise by (1 - masteryScore)", () => {
+
+            const exercise = makeExercise({ id: "ex-001", vocabularyItemId: "vocab-1" });
+            const masteryByItemId = new Map([["vocab-1", 0.35]]);
+
+            const [scored] = scoreExercisePool({ pool: [exercise], masteryByItemId, recentMisses: new Set(), targetCount: 5 });
+
+            assert.approximately(scored.weight, 0.65, 1e-9);
+        });
+
+        it(`adds RECENT_MISS_BOOST (${RECENT_MISS_BOOST}) to the weight of exercises the user got wrong in the most recent session`, () => {
+
+            const exercise = makeExercise({ id: "ex-recent-miss", vocabularyItemId: "vocab-1" });
+            const masteryByItemId = new Map([["vocab-1", 0.35]]);
+
+            const [scored] = scoreExercisePool({ pool: [exercise], masteryByItemId, recentMisses: new Set(["ex-recent-miss"]), targetCount: 5 });
+
+            assert.approximately(scored.weight, 0.65 + RECENT_MISS_BOOST, 1e-9);
+        });
+
+        it("does not boost exercises that are not in the recent-misses set", () => {
+
+            const exercise = makeExercise({ id: "ex-not-missed", vocabularyItemId: "vocab-1" });
+            const masteryByItemId = new Map([["vocab-1", 0.35]]);
+
+            const [scored] = scoreExercisePool({ pool: [exercise], masteryByItemId, recentMisses: new Set(["some-other-exercise"]), targetCount: 5 });
+
+            assert.approximately(scored.weight, 0.65, 1e-9);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Implements the F08 selection engine as a self-contained, pure utility `selectExercises` in `src/util/ExerciseSelector.ts`, ready to be consumed by Practice Sessions (F10), Module Tests (F11), and Level Tests (F21)
- Resolves each exercise's linked item (vocab or grammar) mastery, deprioritizes mastered items (>0.85, unless the pool is nearly empty), weights remaining candidates by `(1 − masteryScore)` plus an additive recent-miss boost, dedupes by linked item (one random pick per item, with fallback to fill the session), and draws the final weighted sample via the existing `weightedSample`
- Adds two tunable constants to `Config.ts`: `DEPRIORITIZE_MASTERY_THRESHOLD` (0.85) and `RECENT_MISS_BOOST` (+0.5)
- Updates the F08 feature doc with the "Implemented" badge, records the API shape and resolved tunables/thresholds as Technical Decisions, and resolves OQ-02 (OQ-01 remains a caller-side concern, documented as such)

Closes #57

## Test plan
- [x] `npm test` — 350 passing, including new `ExerciseSelector` unit tests covering mastery resolution, deprioritization + "pool nearly empty" override, weight computation + recent-miss boost, dedup-by-linked-item, fallback-to-fill, and end-to-end selection draws
- [x] `npm run build` — builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)