### PR TITLE
F12 — Explain My Mistake (on-demand AI explanation)

### DIFF
--- a/docs/features/F12-explain-my-mistake.md
+++ b/docs/features/F12-explain-my-mistake.md
@@ -1,4 +1,4 @@
-# F12 — Explain My Mistake
+# F12 — Explain My Mistake ![Status](https://img.shields.io/badge/status-implemented-brightgreen?style=flat-square)
 
 ## 1. Purpose & Scope
 

--- a/docs/features/F12-explain-my-mistake.md
+++ b/docs/features/F12-explain-my-mistake.md
@@ -1,4 +1,6 @@
-# F12 — Explain My Mistake ![Status](https://img.shields.io/badge/status-implemented-brightgreen?style=flat-square)
+# F12 — Explain My Mistake 
+
+![Status](https://img.shields.io/badge/status-implemented-brightgreen?style=flat-square)
 
 ## 1. Purpose & Scope
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -49,10 +49,10 @@ Features are grouped by layer. Lower groups depend on higher ones.
 | F11 | [Module Test (Step 3)](./F11-module-test.md) | ModuleTestAttempt |
 
 ### Group E — On-demand AI touchpoints
-| # | Feature | Primary model |
-|---|---------|---------------|
-| F12 | [Explain My Mistake](./F12-explain-my-mistake.md) | — |
-| F13 | [Translation Answer Verification](./F13-translation-answer-verification.md) | — |
+| # | Feature | Primary model | Status |
+|---|---------|---------------|--------|
+| F12 | [Explain My Mistake](./F12-explain-my-mistake.md) | — | ![Implemented](https://img.shields.io/badge/status-implemented-brightgreen?style=flat-square) |
+| F13 | [Translation Answer Verification](./F13-translation-answer-verification.md) | — | |
 
 ### Group F — Level progression
 | # | Feature | Primary model |

--- a/docs/interfaces/api-endpoints.md
+++ b/docs/interfaces/api-endpoints.md
@@ -8,7 +8,7 @@
 - [Vocabulary Catalog](#vocabulary-catalog)
 - [Grammar Concepts](#grammar-concepts)
 - [Modules](#modules)
-- [Exercises](#exercises)
+- [Exercises (incl. F12 mistake explanation)](#exercises)
 - [User Module Progress](#user-module-progress)
 - [Vocabulary Mastery & Progress (SRS)](#vocabulary-mastery--progress-srs)
 - [Grammar Mastery & Progress (SRS)](#grammar-mastery--progress-srs)
@@ -129,6 +129,7 @@
 | ------ | -------- | ----------- |
 | POST | `/exercises` | Batch-insert exercises into a module's pool |
 | GET | `/exercises/:id` | Get a single exercise by id |
+| POST | `/exercises/:exerciseId/explainMistake` | Request an on-demand AI explanation for a wrong answer (F12) |
 
 ### POST /exercises
 **Used for:** Submitting a batch of exercises for a module, building up its content pool (~50 exercises target). Can be called repeatedly to grow the pool over time. Duplicate exercises — same `(moduleId, type, prompt)` — are silently skipped rather than rejected; the response reports how many were inserted vs. skipped.
@@ -137,6 +138,10 @@
 ### GET /exercises/:id
 **Used for:** Fetching a single exercise to render or score it, e.g. when the app needs the full prompt/answer/distractor set for one item in a session.
 **Request & Response:** `GetExerciseRequest` / `GetExerciseResponse` in `src/dlg/exercises/GetExercise.ts`
+
+### POST /exercises/:exerciseId/explainMistake
+**Used for:** On-demand AI explanation of a wrong answer — available both during a practice session (after a wrong answer) and in a post-test review (per incorrect item). Fetches the exercise and its linked vocabulary item or grammar concept, builds a CEFR-aware prompt, calls Vertex AI (`gemini-2.5-flash-lite`), and returns a structured four-field explanation. Explanation is not stored; this endpoint is stateless.
+**Request & Response:** `PostExerciseMistakeExplanationRequest` / `PostExerciseMistakeExplanationResponse` in `src/dlg/exercises/PostExerciseMistakeExplanation.ts`
 
 > **Note — pool retrieval and runtime mutations are not REST endpoints.** `ExerciseStore.listByModuleId(moduleId)`, `ExerciseStore.incrementTimesShown(id)`, and `ExerciseStore.appendUserContributedAnswer(id, answer)` are called directly, in-process: the selection engine (F08) lists a module's pool; the practice/test features (F10/F11) increment `timesShown`; F13 appends a verified translation. All consumers live inside this microservice, so the formerly-wired `GET /exercises`, `PUT /exercises/:id/timesShown`, and `PUT /exercises/:id/userContributedAnswers` had no external consumer and were removed per the coding standard. See [the change record](../features/changes/2026-06-08-remove-internal-only-rest-endpoints.md).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@google-cloud/pubsub": "^4.0.6",
         "@google-cloud/secret-manager": "^5.0.1",
         "@google-cloud/storage": "^7.3.1",
+        "@google-cloud/vertexai": "^1.12.0",
         "body-parser": "^1.18.2",
         "connect-busboy": "^1.0.0",
         "express": "^4.16.2",
@@ -1024,6 +1025,159 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/vertexai": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/vertexai/-/vertexai-1.12.0.tgz",
+      "integrity": "sha512-XMJIk7GIeavFLP5A3YEUlowKa5Y5PZRrnnuTJcqR0k+lFKkv7+IWpdRp+Xbqb8xNDrvQaE2hP2RYPUylyD5EdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google/genai": "^1.45.0",
+        "google-auth-library": "^9.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@google-cloud/vertexai/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/vertexai/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/vertexai/node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google/genai/node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai/node_modules/google-auth-library": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
+      "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/genai/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -2538,6 +2692,12 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -3260,6 +3420,15 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -3678,6 +3847,29 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3776,6 +3968,18 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3860,6 +4064,94 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
+      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -5306,6 +5598,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -5519,6 +5831,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -6806,6 +7131,15 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -6891,6 +7225,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@google-cloud/pubsub": "^4.0.6",
     "@google-cloud/secret-manager": "^5.0.1",
     "@google-cloud/storage": "^7.3.1",
+    "@google-cloud/vertexai": "^1.12.0",
     "body-parser": "^1.18.2",
     "connect-busboy": "^1.0.0",
     "express": "^4.16.2",

--- a/src/ai/VertexAIClient.ts
+++ b/src/ai/VertexAIClient.ts
@@ -1,0 +1,87 @@
+import { VertexAI } from "@google-cloud/vertexai";
+
+/**
+ * Contract for calling Vertex AI to generate a mistake explanation.
+ * Injectable so delegates can be unit-tested without a live GCP call.
+ */
+export interface VertexAIClient {
+
+    /**
+     * Sends a prompt to the model and returns the raw text of the first candidate.
+     *
+     * @param {string} prompt - The fully-formed prompt to send.
+     *
+     * @returns {Promise<string>} The model's raw text response.
+     */
+    generate(prompt: string): Promise<string>;
+
+}
+
+/**
+ * Production implementation that calls Vertex AI directly using ambient GCP
+ * service account credentials (standard for Cloud Run services in this project).
+ */
+export class VertexAIClientImpl implements VertexAIClient {
+
+    private model: string;        // Vertex AI model id, e.g. "gemini-2.5-flash-lite"
+    private projectId: string;    // GCP project id, read from GCP_PID env var
+    private location: string;     // Vertex AI region, read from VERTEX_AI_LOCATION env var
+
+    constructor({ model, projectId, location }: VertexAIClientImplInput) {
+
+        this.model = model;
+        this.projectId = projectId;
+        this.location = location;
+
+    }
+
+    /**
+     * Sends a prompt to the configured Vertex AI model and returns the response text.
+     * Uses `responseMimeType: 'application/json'` so the model returns structured JSON.
+     *
+     * @param {string} prompt - The fully-formed prompt to send.
+     *
+     * @returns {Promise<string>} Raw JSON string from the model's first candidate.
+     */
+    async generate(prompt: string): Promise<string> {
+
+        const vertexAI = new VertexAI({ project: this.projectId, location: this.location });
+
+        const generativeModel = vertexAI.getGenerativeModel({
+            model: this.model,
+            generationConfig: { responseMimeType: "application/json" },
+        });
+
+        const result = await generativeModel.generateContent(prompt);
+
+        const candidate = result.response?.candidates?.[0];
+        const text = candidate?.content?.parts?.[0]?.text;
+
+        if (!text) throw new Error("Vertex AI returned no content");
+
+        return text;
+
+    }
+
+}
+
+/**
+ * Builds a VertexAIClientImpl from standard environment variables.
+ * GCP_PID must be set; VERTEX_AI_LOCATION defaults to "europe-west1".
+ */
+export function buildVertexAIClient(): VertexAIClient {
+
+    const projectId = process.env.GCP_PID;
+    if (!projectId) throw new Error("GCP_PID env var is not set");
+
+    const location = process.env.VERTEX_AI_LOCATION ?? "europe-west1";
+
+    return new VertexAIClientImpl({ model: "gemini-2.5-flash-lite", projectId, location });
+
+}
+
+interface VertexAIClientImplInput {
+    model: string;      // Vertex AI model id
+    projectId: string;  // GCP project id
+    location: string;   // Vertex AI region
+}

--- a/src/dlg/exercises/PostExerciseMistakeExplanation.ts
+++ b/src/dlg/exercises/PostExerciseMistakeExplanation.ts
@@ -95,17 +95,18 @@ function buildPrompt({ exercise, userAnswer, cefrLevel, vocabOrGrammarBlock }: P
 
     return `You are a Danish language tutor. A student at CEFR level ${cefrLevel} answered an exercise incorrectly.
 
-Exercise prompt: "${exercise.prompt}"
-Correct answer: "${exercise.answer}"
-Student's answer: "${userAnswer}"
+            Exercise prompt: "${exercise.prompt}"
+            Correct answer: "${exercise.answer}"
+            Student's answer: "${userAnswer}"
 
-${vocabOrGrammarBlock}
+            ${vocabOrGrammarBlock}
 
-Return a JSON object with exactly these fields:
-- correctAnswer: the correct answer as a string
-- explanation: why the correct answer is right, tailored to CEFR level ${cefrLevel}
-- rule: the underlying grammar or vocabulary rule, stated simply in English
-- example: a second Danish sentence demonstrating the same rule (different from the exercise prompt)`;
+            Return a JSON object with exactly these fields:
+            - correctAnswer: the correct answer as a string
+            - explanation: why the correct answer is right, tailored to CEFR level ${cefrLevel}
+            - rule: the underlying grammar or vocabulary rule, stated simply in English
+            - example: a second Danish sentence demonstrating the same rule (different from the exercise prompt)
+    `;
 }
 
 interface PromptInput {

--- a/src/dlg/exercises/PostExerciseMistakeExplanation.ts
+++ b/src/dlg/exercises/PostExerciseMistakeExplanation.ts
@@ -1,0 +1,129 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../../Config";
+import { ExerciseStore } from "../../store/ExerciseStore";
+import { VocabularyItemStore } from "../../store/VocabularyItemStore";
+import { GrammarConceptStore } from "../../store/GrammarConceptStore";
+import { VertexAIClient, buildVertexAIClient } from "../../ai/VertexAIClient";
+
+export class PostExerciseMistakeExplanation extends TotoDelegate<PostExerciseMistakeExplanationRequest, PostExerciseMistakeExplanationResponse> {
+
+    /** Injectable AI client. If null, lazily initialised from env vars on first call. */
+    aiClient: VertexAIClient | null = null;
+
+    parseRequest(req: Request): PostExerciseMistakeExplanationRequest {
+
+        const exerciseId = req.params.exerciseId;
+        const userAnswer = req.body?.userAnswer;
+        const cefrLevel = req.body?.cefrLevel;
+
+        if (!exerciseId) throw new ValidationError(400, "exerciseId is required");
+        if (userAnswer === undefined || userAnswer === null) throw new ValidationError(400, "userAnswer is required");
+        if (!cefrLevel) throw new ValidationError(400, "cefrLevel is required");
+
+        return { exerciseId, userAnswer: String(userAnswer), cefrLevel };
+    }
+
+    /**
+     * Fetches the exercise and its linked vocabulary item or grammar concept,
+     * builds a CEFR-aware prompt, calls Vertex AI, and returns the structured explanation.
+     *
+     * @param {PostExerciseMistakeExplanationRequest} req - The parsed request.
+     * @param {UserContext} _userContext - The authenticated user context (unused).
+     *
+     * @returns {PostExerciseMistakeExplanationResponse} The four-field explanation object.
+     */
+    async do(req: PostExerciseMistakeExplanationRequest, _userContext?: UserContext): Promise<PostExerciseMistakeExplanationResponse> {
+
+        const config = this.config as ControllerConfig;
+
+        const db = await config.getMongoDb(config.getDBName());
+
+        const exercise = await new ExerciseStore(db).findById(req.exerciseId);
+
+        if (!exercise) throw new ValidationError(404, `Exercise not found for id '${req.exerciseId}'`);
+
+        let vocabOrGrammarBlock: string;
+
+        if (exercise.vocabularyItemId) {
+
+            const vocab = await new VocabularyItemStore(db).findById(exercise.vocabularyItemId);
+
+            if (!vocab) throw new ValidationError(404, `Vocabulary item not found for id '${exercise.vocabularyItemId}'`);
+
+            vocabOrGrammarBlock = `Linked vocabulary item: "${vocab.danish}" (${vocab.english}) — ${vocab.context ?? vocab.type}`;
+
+        } else if (exercise.grammarConceptId) {
+
+            const concept = await new GrammarConceptStore(db).findById(exercise.grammarConceptId);
+
+            if (!concept) throw new ValidationError(404, `Grammar concept not found for id '${exercise.grammarConceptId}'`);
+
+            vocabOrGrammarBlock = `Linked grammar concept: "${concept.name}" — ${concept.explanation}`;
+
+        } else {
+
+            throw new ValidationError(404, `Exercise '${req.exerciseId}' has no linked vocabulary item or grammar concept`);
+
+        }
+
+        const prompt = buildPrompt({ exercise, userAnswer: req.userAnswer, cefrLevel: req.cefrLevel, vocabOrGrammarBlock });
+
+        const client = this.aiClient ?? (this.aiClient = buildVertexAIClient());
+
+        const raw = await client.generate(prompt);
+
+        const parsed = JSON.parse(raw) as PostExerciseMistakeExplanationResponse;
+
+        return {
+            correctAnswer: parsed.correctAnswer,
+            explanation: parsed.explanation,
+            rule: parsed.rule,
+            example: parsed.example,
+        };
+    }
+}
+
+/**
+ * Builds the CEFR-aware prompt for the mistake explanation request.
+ *
+ * @param {PromptInput} input - Exercise, user answer, CEFR level, and the linked-item block.
+ *
+ * @returns {string} The fully-formed prompt string.
+ */
+function buildPrompt({ exercise, userAnswer, cefrLevel, vocabOrGrammarBlock }: PromptInput): string {
+
+    return `You are a Danish language tutor. A student at CEFR level ${cefrLevel} answered an exercise incorrectly.
+
+Exercise prompt: "${exercise.prompt}"
+Correct answer: "${exercise.answer}"
+Student's answer: "${userAnswer}"
+
+${vocabOrGrammarBlock}
+
+Return a JSON object with exactly these fields:
+- correctAnswer: the correct answer as a string
+- explanation: why the correct answer is right, tailored to CEFR level ${cefrLevel}
+- rule: the underlying grammar or vocabulary rule, stated simply in English
+- example: a second Danish sentence demonstrating the same rule (different from the exercise prompt)`;
+}
+
+interface PromptInput {
+    exercise: { prompt: string; answer: string };    // The exercise data used in the prompt
+    userAnswer: string;                              // The student's incorrect answer
+    cefrLevel: string;                               // The student's CEFR level
+    vocabOrGrammarBlock: string;                     // The linked item description line
+}
+
+interface PostExerciseMistakeExplanationRequest {
+    exerciseId: string;     // The id of the exercise the student answered incorrectly
+    userAnswer: string;     // The student's incorrect answer
+    cefrLevel: string;      // The student's CEFR level (e.g. "A1", "B2")
+}
+
+interface PostExerciseMistakeExplanationResponse {
+    correctAnswer: string;  // The correct answer to the exercise
+    explanation: string;    // Why the correct answer is right, tailored to the CEFR level
+    rule: string;           // The underlying grammar or vocabulary rule, in plain English
+    example: string;        // A second Danish sentence demonstrating the same rule
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { GetModules } from './dlg/modules/GetModules';
 import { PostModule } from './dlg/modules/PostModule';
 import { GetExercise } from './dlg/exercises/GetExercise';
 import { PostExercises } from './dlg/exercises/PostExercises';
+import { PostExerciseMistakeExplanation } from './dlg/exercises/PostExerciseMistakeExplanation';
 import { RemoveSentenceAlternative } from './dlg/sentences/RemoveSentenceAlternative';
 import { StartSession } from './dlg/session/StartSession';
 import { SubmitAnswer } from './dlg/session/SubmitAnswer';
@@ -57,6 +58,7 @@ const config: TotoMicroserviceConfiguration = {
 
             { method: 'POST', path: '/exercises', delegate: PostExercises },
             { method: 'GET', path: '/exercises/:id', delegate: GetExercise },
+            { method: 'POST', path: '/exercises/:exerciseId/explainMistake', delegate: PostExerciseMistakeExplanation },
 
             { method: 'POST', path: '/modules', delegate: PostModule },
             { method: 'GET', path: '/modules/:id', delegate: GetModule },

--- a/test/dlg/exercises/PostExerciseMistakeExplanation.do.test.ts
+++ b/test/dlg/exercises/PostExerciseMistakeExplanation.do.test.ts
@@ -1,0 +1,178 @@
+import { assert } from "chai";
+import { PostExerciseMistakeExplanation } from "../../../src/dlg/exercises/PostExerciseMistakeExplanation";
+import { Exercise } from "../../../src/model/Exercise";
+import { VocabularyItem } from "../../../src/model/VocabularyItem";
+import { GrammarConcept } from "../../../src/model/GrammarConcept";
+import { VertexAIClient } from "../../../src/ai/VertexAIClient";
+
+const AI_RESPONSE = JSON.stringify({
+    correctAnswer: "jeg spiser",
+    explanation: "The verb 'spise' conjugates to 'spiser' in present tense.",
+    rule: "Danish present tense is formed by adding -r to the infinitive.",
+    example: "Han drikker vand.",
+});
+
+function makeExerciseWithVocab(id: string): any {
+    return new Exercise({
+        id,
+        moduleId: "mod-1",
+        type: "translation_active",
+        prompt: "I eat",
+        answer: "jeg spiser",
+        vocabularyItemId: "vocab-1",
+        grammarConceptId: null,
+    }).toBSON();
+}
+
+function makeExerciseWithGrammar(id: string): any {
+    return new Exercise({
+        id,
+        moduleId: "mod-1",
+        type: "sentence_reorder",
+        prompt: "Reorder: spiser / jeg / mad",
+        answer: "jeg spiser mad",
+        vocabularyItemId: null,
+        grammarConceptId: "gram-1",
+    }).toBSON();
+}
+
+function makeVocabBSON(): any {
+    return new VocabularyItem({
+        id: "vocab-1",
+        danish: "spise",
+        english: "to eat",
+        type: "verb",
+        context: "used for eating food",
+        tags: [],
+        cefrLevel: "A1",
+        source: "curriculum",
+        addedByUserId: null,
+    }).toBSON();
+}
+
+function makeGrammarBSON(): any {
+    return new GrammarConcept({
+        id: "gram-1",
+        name: "Present tense",
+        category: "tenses",
+        cefrLevelIntroduced: "A1",
+        explanation: "Add -r to the infinitive stem.",
+        examples: [],
+    }).toBSON();
+}
+
+function makeMockAIClient(response: string = AI_RESPONSE): VertexAIClient {
+    return { generate: async (_prompt: string) => response };
+}
+
+/**
+ * Builds a mock config that serves the given documents from their respective collections.
+ */
+function makeMockConfig(exerciseDoc: any, vocabDoc: any, grammarDoc: any) {
+
+    const collections: Record<string, any> = {
+        exercises: { findOne: async () => exerciseDoc },
+        vocabulary: { findOne: async () => vocabDoc },
+        grammar: { findOne: async () => grammarDoc },
+    };
+
+    return {
+        getDBName: () => "test",
+        getMongoDb: async () => ({ collection: (name: string) => collections[name] }),
+    } as any;
+}
+
+describe("PostExerciseMistakeExplanation.do", () => {
+
+    it("returns correctAnswer, explanation, rule, example when exercise is linked to a vocabulary item", async () => {
+
+        const config = makeMockConfig(makeExerciseWithVocab("ex-1"), makeVocabBSON(), null);
+        const delegate = new PostExerciseMistakeExplanation({} as any, config);
+        delegate.aiClient = makeMockAIClient();
+
+        const result = await delegate.do(
+            { exerciseId: "ex-1", userAnswer: "jeg ede", cefrLevel: "A1" },
+            { userId: "user-1" } as any
+        );
+
+        assert.equal(result.correctAnswer, "jeg spiser");
+        assert.equal(result.explanation, "The verb 'spise' conjugates to 'spiser' in present tense.");
+        assert.equal(result.rule, "Danish present tense is formed by adding -r to the infinitive.");
+        assert.equal(result.example, "Han drikker vand.");
+    });
+
+    it("returns the four fields when exercise is linked to a grammar concept", async () => {
+
+        const config = makeMockConfig(makeExerciseWithGrammar("ex-2"), null, makeGrammarBSON());
+        const delegate = new PostExerciseMistakeExplanation({} as any, config);
+        delegate.aiClient = makeMockAIClient();
+
+        const result = await delegate.do(
+            { exerciseId: "ex-2", userAnswer: "spiser jeg mad", cefrLevel: "A2" },
+            { userId: "user-1" } as any
+        );
+
+        assert.equal(result.correctAnswer, "jeg spiser");
+        assert.equal(result.rule, "Danish present tense is formed by adding -r to the infinitive.");
+    });
+
+    it("throws 404 when the exercise does not exist", async () => {
+
+        const config = makeMockConfig(null, null, null);
+        const delegate = new PostExerciseMistakeExplanation({} as any, config);
+        delegate.aiClient = makeMockAIClient();
+
+        try {
+
+            await delegate.do(
+                { exerciseId: "missing", userAnswer: "x", cefrLevel: "A1" },
+                { userId: "user-1" } as any
+            );
+            assert.fail("Expected 404");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 404);
+        }
+    });
+
+    it("throws 404 when the linked vocabulary item does not exist", async () => {
+
+        const config = makeMockConfig(makeExerciseWithVocab("ex-3"), null, null);
+        const delegate = new PostExerciseMistakeExplanation({} as any, config);
+        delegate.aiClient = makeMockAIClient();
+
+        try {
+
+            await delegate.do(
+                { exerciseId: "ex-3", userAnswer: "x", cefrLevel: "A1" },
+                { userId: "user-1" } as any
+            );
+            assert.fail("Expected 404");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 404);
+        }
+    });
+
+    it("throws 404 when the linked grammar concept does not exist", async () => {
+
+        const config = makeMockConfig(makeExerciseWithGrammar("ex-4"), null, null);
+        const delegate = new PostExerciseMistakeExplanation({} as any, config);
+        delegate.aiClient = makeMockAIClient();
+
+        try {
+
+            await delegate.do(
+                { exerciseId: "ex-4", userAnswer: "x", cefrLevel: "A2" },
+                { userId: "user-1" } as any
+            );
+            assert.fail("Expected 404");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 404);
+        }
+    });
+});


### PR DESCRIPTION
Closes #61

## Summary

- Installs `@google-cloud/vertexai` and adds a `VertexAIClient` interface (`src/ai/VertexAIClient.ts`) — injectable so unit tests run without a live GCP call
- Implements `PostExerciseMistakeExplanation` delegate (`POST /exercises/:exerciseId/explainMistake`): fetches the exercise + its linked vocabulary item or grammar concept, builds a CEFR-aware prompt, calls Vertex AI (`gemini-2.5-flash-lite`), and returns `{ correctAnswer, explanation, rule, example }`
- Wires the route in `index.ts` and updates `docs/interfaces/api-endpoints.md`
- Marks F12 as implemented in feature docs and README index

## Test plan
- [ ] Run `npm test` — 420 tests, all passing
- [ ] Run `npm run build` — TypeScript compiles with no errors
- [ ] 5 unit tests cover the delegate: vocab-linked exercise, grammar-linked exercise, missing exercise, missing vocab item, missing grammar concept

🤖 Generated with [Claude Code](https://claude.com/claude-code)