### PR TITLE
feat(F11): implement Module Test — graded, resumable practice-style session

### DIFF
--- a/docs/features/F11-module-test.md
+++ b/docs/features/F11-module-test.md
@@ -1,5 +1,7 @@
 # F11 — Module Test (Module Step 3)
 
+![Status](https://img.shields.io/badge/status-implemented-brightgreen?style=flat-square)
+
 ## 1. Purpose & Scope
 
 Step 3 is the graded assessment that completes a module. It is **time-locked** until `testUnlockDelayHours` (default 4) after **Step 2 is complete** — i.e. after the user has reached full vocabulary coverage (`practiceCompletedAt`), not merely after a single practice session — enforcing spaced repetition. Once unlocked, the user takes a **20-question** test, answering each question with immediate feedback (as in practice), then sees the score and full review. Passing (≥ `testPassThreshold`, default 80%) marks the module `completed`. Mastery scores are updated here (as they are during practice). Failed attempts are recorded; retry is allowed after `testRetryDelayMinutes` (default 20).
@@ -112,5 +114,5 @@ The test draws from the **same exercise pool** as practice, using the **same mas
 |---|----------|-----------------|
 | OQ-01 | _Resolved_ — fixed at 20 questions per module test in v2.0. | — |
 | OQ-02 | _Resolved_ — the unlock timer is anchored to `practiceCompletedAt`, set once when coverage is first reached; re-running practice does not reset it (see F10 OQ-02). | — |
-| OQ-03 | Does a passed module's test remain replayable for practice? | Idea implies retake draws from the pool; clarify whether it re-grades mastery |
-| OQ-04 | Should in-progress attempts expire/auto-abandon after inactivity? | Avoid stale un-submitted attempts blocking resume vs. retry (mirrors F10 OQ-03) |
+| OQ-03 | _Resolved_ — no retakes after a module is `completed`. `POST …/tests` returns 400 when the module status is `completed`. | — |
+| OQ-04 | _Open_ — should in-progress attempts expire/auto-abandon after inactivity? Avoid stale un-submitted attempts blocking resume vs. retry (mirrors F10 OQ-03). Deferred to a future improvement. | — |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -46,7 +46,7 @@ Features are grouped by layer. Lower groups depend on higher ones.
 |---|---------|---------------|--------|
 | F09 | [Grammar Introduction (Step 1)](./F09-grammar-introduction.md) | — | ![Implemented](https://img.shields.io/badge/status-implemented-brightgreen?style=flat-square) |
 | F10 | [Practice Session (Step 2)](./F10-practice-session.md) | PracticeSession | ![Implemented](https://img.shields.io/badge/status-implemented-brightgreen?style=flat-square) |
-| F11 | [Module Test (Step 3)](./F11-module-test.md) | ModuleTestAttempt |
+| F11 | [Module Test (Step 3)](./F11-module-test.md) | ModuleTestAttempt | ![Implemented](https://img.shields.io/badge/status-implemented-brightgreen?style=flat-square) |
 
 ### Group E — On-demand AI touchpoints
 | # | Feature | Primary model | Status |

--- a/docs/interfaces/api-endpoints.md
+++ b/docs/interfaces/api-endpoints.md
@@ -13,6 +13,7 @@
 - [Vocabulary Mastery & Progress (SRS)](#vocabulary-mastery--progress-srs)
 - [Grammar Mastery & Progress (SRS)](#grammar-mastery--progress-srs)
 - [Practice Sessions (F10)](#practice-sessions-f10)
+- [Module Tests (F11)](#module-tests-f11)
 - [Legacy endpoints (pending removal)](#legacy-endpoints-pending-removal)
 - [API Design compliance](#api-design-compliance)
 
@@ -230,6 +231,42 @@
 ### POST /users/:userId/practiceSessions/:sessionId/complete
 **Used for:** Completing a practice session. Updates mastery scores via the SRS algorithm (F06) for every exercise attempted. Appends the session's encountered vocabulary item ids to `UserModuleProgress.vocabularyItemsPracticed` (F07). Evaluates the coverage gate: if all `Module.vocabularyItemIds` are now covered, sets `practiceCompletedAt` on `UserModuleProgress` (starting the `testUnlockDelayHours` countdown). Returns `{ step2Complete: boolean, unseenVocabCount: number }` so the app knows whether to offer another practice session or route toward the Module Test.
 **Request & Response:** `CompletePracticeSessionRequest` / `CompletePracticeSessionResponse` in `src/dlg/practiceSessions/CompletePracticeSession.ts`
+
+---
+
+## Module Tests (F11)
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET | `/users/:userId/modules/:moduleId/testEligibility` | Authoritative unlock check for a module test |
+| POST | `/users/:userId/modules/:moduleId/tests` | Start a new module test attempt |
+| GET | `/users/:userId/moduleTests/:attemptId` | Get the current state of a module test attempt (for resume) |
+| POST | `/users/:userId/moduleTests/:attemptId/answers` | Submit an answer for one exercise in the test |
+| POST | `/users/:userId/moduleTests/:attemptId/submit` | Finalise the attempt; compute score and update mastery |
+| GET | `/users/:userId/moduleTests/:attemptId/review` | Fetch the full graded review for a submitted attempt |
+
+### GET /users/:userId/modules/:moduleId/testEligibility
+**Used for:** Checking whether the Module Test is currently unlocked for a given user and module. Returns `eligible: true` when all conditions are met; returns `eligible: false` with `testUnlocksAt` / `testRetryAvailableAt` / `remainingMs` when a delay is still active. The test requires: (1) `practiceCompletedAt` set (Step 2 fully complete — full vocabulary coverage), (2) `TEST_UNLOCK_DELAY_HOURS` (4 h) elapsed since `practiceCompletedAt`, (3) if a failed attempt exists, `TEST_RETRY_DELAY_MINUTES` (20 min) elapsed since its `takenAt`. Returns `{ eligible: false }` when the module is already `completed` (no retakes). This endpoint is the authoritative gate enforced by `POST .../tests`; the client-side countdown rendered from the timestamps is only a hint.
+**Request & Response:** `GetTestEligibilityRequest` / `GetTestEligibilityResponse` in `src/dlg/moduleTests/GetTestEligibility.ts`
+
+### POST /users/:userId/modules/:moduleId/tests
+**Used for:** Starting a new Module Test attempt for a user and module (Step 3). Verifies all eligibility conditions (see above). Draws exactly 20 exercises via F08's mastery-aware selection — unconstrained (no fresh/repeat split, no coverage override). Returns the 20 questions **without** correct answers plus the full exercise objects so the client can render immediately. Returns **409** with `{ code: 409, message: "...", attemptId }` if an active (un-submitted) attempt already exists — the client resumes it via `GET .../moduleTests/:attemptId`. Returns **400** if the module is already `completed` (no retakes).
+**Request & Response:** `StartModuleTestRequest` / `StartModuleTestResponse` in `src/dlg/moduleTests/StartModuleTest.ts`
+
+### GET /users/:userId/moduleTests/:attemptId
+**Used for:** Resuming an in-progress module test after the app is closed. Returns the full attempt state — `exerciseIds`, `answers` recorded so far, `currentPosition` — plus the full exercise objects **without** correct answers, so the client restores the in-progress UI. An in-progress attempt is always resumable regardless of unlock timing (it started legitimately).
+**Request & Response:** `GetModuleTestRequest` / `GetModuleTestResponse` in `src/dlg/moduleTests/GetModuleTest.ts`
+
+### POST /users/:userId/moduleTests/:attemptId/answers
+**Used for:** Submitting a user's answer for one exercise during a module test. Body: `{ exerciseId, userAnswer }`. Normalises the answer (same logic as F10) and checks it against the exercise's `answer`, `alternativeAnswers`, and `userContributedAnswers`. **The first answer is final for grading — there is no retry queue and no re-attempts.** Returns immediate feedback: `{ isCorrect, correctAnswer }`. The correct answer is always returned so the client can show it on a wrong answer, exactly as in practice. Increments `timesShown` on the exercise.
+**Request & Response:** `SubmitTestAnswerRequest` / `SubmitTestAnswerResponse` in `src/dlg/moduleTests/SubmitTestAnswer.ts`
+
+### POST /users/:userId/moduleTests/:attemptId/submit
+**Used for:** Finalising a module test attempt. Computes the score as `% of exerciseIds whose final isCorrect is true`; unanswered exercises count as wrong. Determines pass/fail against `TEST_PASS_THRESHOLD` (80%). Updates mastery (F06) for every answered exercise — same SRS loop as practice completion. Records a `TestAttemptRecord` summary in `UserModuleProgress.testAttempts`. On pass: transitions `UserModuleProgress.status` to `completed`. Returns `{ score, passed }`.
+**Request & Response:** `SubmitModuleTestRequest` / `SubmitModuleTestResponse` in `src/dlg/moduleTests/SubmitModuleTest.ts`
+
+### GET /users/:userId/moduleTests/:attemptId/review
+**Used for:** Fetching the full graded review for a submitted module test attempt. Returns `score`, `passed`, and a `questions` array containing every exercise's `prompt`, `isCorrect`, `userAnswer`, and `correctAnswer`. Unlike `GET .../moduleTests/:attemptId`, this endpoint **exposes correct answers** — it is only valid after the attempt has been submitted (`takenAt` set). Unanswered exercises appear with `isCorrect: false` and `userAnswer: ""`. Enables "Explain my mistake" (F12) per incorrect item.
+**Request & Response:** `GetTestReviewRequest` / `GetTestReviewResponse` in `src/dlg/moduleTests/GetTestReview.ts`
 
 ---
 

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -23,6 +23,31 @@ export const DEPRIORITIZE_MASTERY_THRESHOLD = 0.85;
  */
 export const RECENT_MISS_BOOST = 0.5;
 
+/**
+ * Number of questions drawn for each Module Test (F11).
+ * Fixed at 20 in v2.0.
+ */
+export const MODULE_TEST_SIZE = 20;
+
+/**
+ * Hours after Step 2 completion (`practiceCompletedAt`) before a Module Test
+ * is unlocked (F11). Enforces the spaced-repetition gap between practice and
+ * assessment.
+ */
+export const TEST_UNLOCK_DELAY_HOURS = 4;
+
+/**
+ * Minimum percentage of correct answers required to pass a Module Test (F11).
+ * Expressed as a value between 0 and 100.
+ */
+export const TEST_PASS_THRESHOLD = 80;
+
+/**
+ * Minutes after a failed Module Test's `takenAt` timestamp before the user
+ * may start a retry attempt (F11).
+ */
+export const TEST_RETRY_DELAY_MINUTES = 20;
+
 export class ControllerConfig extends TotoControllerConfig {
 
     getMongoSecretNames(): { userSecretName: string; pwdSecretName: string; } | null {

--- a/src/dlg/moduleTests/GetModuleTest.ts
+++ b/src/dlg/moduleTests/GetModuleTest.ts
@@ -1,0 +1,87 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../../Config";
+import { Exercise } from "../../model/Exercise";
+import { ExerciseStore } from "../../store/ExerciseStore";
+import { ModuleTestAttemptStore } from "../../store/ModuleTestAttemptStore";
+import { TestAnswer } from "../../model/ModuleTestAttempt";
+
+/**
+ * Returns the current state of a Module Test attempt for resume after an app close (F11).
+ *
+ * Exercises are returned without correct answers — the client restores the in-progress
+ * UI without seeing answers it has not yet submitted.
+ * An in-progress attempt is always resumable regardless of unlock timing.
+ */
+export class GetModuleTest extends TotoDelegate<GetModuleTestRequest, GetModuleTestResponse> {
+
+    /**
+     * Extracts userId and attemptId from the route parameters.
+     */
+    parseRequest(req: Request): GetModuleTestRequest {
+
+        const userId = req.params.userId;
+        const attemptId = req.params.attemptId;
+
+        if (!userId) throw new ValidationError(400, "userId is required");
+        if (!attemptId) throw new ValidationError(400, "attemptId is required");
+
+        return { userId, attemptId };
+    }
+
+    /**
+     * Returns the attempt state enriched with full exercise objects (without correct answers).
+     * Verifies ownership before returning any data.
+     */
+    async do(req: GetModuleTestRequest, _userContext?: UserContext): Promise<GetModuleTestResponse> {
+
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+
+        const attemptStore = new ModuleTestAttemptStore({ db, config });
+        const attempt = await attemptStore.findById(req.attemptId);
+
+        if (!attempt) throw new ValidationError(404, `Module test attempt ${req.attemptId} not found`);
+        if (attempt.userId !== req.userId) throw new ValidationError(403, "Attempt does not belong to the specified user");
+
+        const exerciseStore = new ExerciseStore(db);
+        const exercises = await exerciseStore.findByIds(attempt.exerciseIds);
+
+        return {
+            attemptId: attempt.id!,
+            moduleId: attempt.moduleId,
+            exercises: exercises.map(e => stripAnswer(e)),
+            answers: attempt.answers,
+            currentPosition: attempt.currentPosition,
+            startedAt: attempt.startedAt,
+            takenAt: attempt.takenAt,
+        };
+    }
+}
+
+/**
+ * Returns a copy of the exercise without `answer`, `alternativeAnswers`, and
+ * `userContributedAnswers` so the client cannot see the correct answer while the
+ * attempt is still in-progress.
+ */
+function stripAnswer(exercise: Exercise): any {
+
+    const { answer: _a, alternativeAnswers: _alt, userContributedAnswers: _uca, ...rest } = exercise as any;
+
+    return rest;
+}
+
+interface GetModuleTestRequest {
+    userId: string;     // The user id making the request
+    attemptId: string;  // The id of the module test attempt to retrieve
+}
+
+interface GetModuleTestResponse {
+    attemptId: string;          // The attempt id
+    moduleId: string;           // The module id
+    exercises: any[];           // Full exercise objects without correct answers
+    answers: TestAnswer[];      // Answers submitted so far
+    currentPosition: number;    // 0-based index of the next unanswered exercise
+    startedAt: string;          // ISO-8601 timestamp of when the attempt was started
+    takenAt: string | null;     // ISO-8601 submission timestamp; null if in-progress
+}

--- a/src/dlg/moduleTests/GetTestEligibility.ts
+++ b/src/dlg/moduleTests/GetTestEligibility.ts
@@ -1,0 +1,111 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { TEST_PASS_THRESHOLD, TEST_RETRY_DELAY_MINUTES, TEST_UNLOCK_DELAY_HOURS } from "../../Config";
+import { ControllerConfig } from "../../Config";
+import { UserModuleProgressStore } from "../../store/UserModuleProgressStore";
+
+/**
+ * Returns the authoritative test eligibility state for a given user and module (F11).
+ *
+ * Eligibility rules:
+ * - The module must not already be `completed` (OQ-03: no retakes).
+ * - `practiceCompletedAt` must be set on UserModuleProgress (Step 2 fully complete).
+ * - `testUnlockDelayHours` must have elapsed since `practiceCompletedAt`.
+ * - If a prior FAILED submitted attempt exists, `testRetryDelayMinutes` must have elapsed
+ *   since the most recent failed attempt's `takenAt`. Passed attempts are ignored.
+ */
+export class GetTestEligibility extends TotoDelegate<GetTestEligibilityRequest, GetTestEligibilityResponse> {
+
+    /**
+     * Extracts userId and moduleId from the route parameters.
+     */
+    parseRequest(req: Request): GetTestEligibilityRequest {
+
+        const userId = req.params.userId;
+        const moduleId = req.params.moduleId;
+
+        if (!userId) throw new ValidationError(400, "userId is required");
+        if (!moduleId) throw new ValidationError(400, "moduleId is required");
+
+        return { userId, moduleId, now: new Date() };
+    }
+
+    /**
+     * Evaluates test eligibility for the given user and module.
+     *
+     * Returns `{ eligible: false }` (with no timestamps) when:
+     * - No progress record exists, or `practiceCompletedAt` is null (Step 2 not complete).
+     * - The module is already `completed` (no retakes — OQ-03).
+     *
+     * Returns `{ eligible: false, testUnlocksAt, remainingMs }` when the unlock delay has not elapsed.
+     *
+     * Returns `{ eligible: false, testRetryAvailableAt, remainingMs }` when a failed attempt's
+     * retry delay has not elapsed.
+     *
+     * Returns `{ eligible: true, testUnlocksAt, testRetryAvailableAt? }` when all conditions pass.
+     */
+    async do(req: GetTestEligibilityRequest, _userContext?: UserContext): Promise<GetTestEligibilityResponse> {
+
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+        const now = req.now;
+
+        const progressStore = new UserModuleProgressStore({ db, config });
+        const progress = await progressStore.findByUserAndModule(req.userId, req.moduleId);
+
+        if (!progress || !progress.practiceCompletedAt) {
+            return { eligible: false };
+        }
+
+        if (progress.status === "completed") {
+            return { eligible: false };
+        }
+
+        const testUnlocksAt = new Date(new Date(progress.practiceCompletedAt).getTime() + TEST_UNLOCK_DELAY_HOURS * 60 * 60 * 1000).toISOString();
+
+        if (now < new Date(testUnlocksAt)) {
+            return {
+                eligible: false,
+                testUnlocksAt,
+                remainingMs: new Date(testUnlocksAt).getTime() - now.getTime(),
+            };
+        }
+
+        const failedAttempts = progress.testAttempts.filter(a => !a.passed && a.takenAt);
+        const mostRecentFailed = failedAttempts.sort((a, b) => new Date(b.takenAt).getTime() - new Date(a.takenAt).getTime())[0];
+
+        let testRetryAvailableAt: string | undefined;
+
+        if (mostRecentFailed) {
+
+            testRetryAvailableAt = new Date(new Date(mostRecentFailed.takenAt).getTime() + TEST_RETRY_DELAY_MINUTES * 60 * 1000).toISOString();
+
+            if (now < new Date(testRetryAvailableAt)) {
+                return {
+                    eligible: false,
+                    testRetryAvailableAt,
+                    remainingMs: new Date(testRetryAvailableAt).getTime() - now.getTime(),
+                };
+            }
+        }
+
+        return {
+            eligible: true,
+            testUnlocksAt,
+            testRetryAvailableAt,
+        };
+    }
+}
+
+interface GetTestEligibilityRequest {
+    userId: string;     // The user id
+    moduleId: string;   // The module id
+    now: Date;          // The current time (injectable for testability)
+}
+
+interface GetTestEligibilityResponse {
+    eligible: boolean;              // Whether the test may be started right now
+    testUnlocksAt?: string;         // ISO-8601 timestamp when the test unlocks; absent when Step 2 is not complete
+    testRetryAvailableAt?: string;  // ISO-8601 timestamp when a retry becomes available; present only after a failed attempt
+    remainingMs?: number;           // Milliseconds until eligible; present only when eligible is false and a deadline is known
+}

--- a/src/dlg/moduleTests/GetTestReview.ts
+++ b/src/dlg/moduleTests/GetTestReview.ts
@@ -1,0 +1,98 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../../Config";
+import { ExerciseStore } from "../../store/ExerciseStore";
+import { ModuleTestAttemptStore } from "../../store/ModuleTestAttemptStore";
+
+/**
+ * Returns the full review of a completed Module Test attempt (F11).
+ *
+ * Exposes correct answers for every question — unlike `GetModuleTest`, which
+ * hides correct answers for in-progress attempts.
+ *
+ * For each question the review includes:
+ * - The exercise prompt (via the full exercise object)
+ * - `isCorrect`, `userAnswer`, and `correctAnswer`
+ *
+ * Unanswered exercises are represented as incorrect with an empty `userAnswer`.
+ *
+ * Enables "Explain my mistake" (F12) per incorrect item.
+ */
+export class GetTestReview extends TotoDelegate<GetTestReviewRequest, GetTestReviewResponse> {
+
+    /**
+     * Extracts userId and attemptId from the route parameters.
+     */
+    parseRequest(req: Request): GetTestReviewRequest {
+
+        const userId = req.params.userId;
+        const attemptId = req.params.attemptId;
+
+        if (!userId) throw new ValidationError(400, "userId is required");
+        if (!attemptId) throw new ValidationError(400, "attemptId is required");
+
+        return { userId, attemptId };
+    }
+
+    /**
+     * Returns the graded review for a submitted attempt.
+     * Validates ownership, submission state, then returns score + per-question results.
+     */
+    async do(req: GetTestReviewRequest, _userContext?: UserContext): Promise<GetTestReviewResponse> {
+
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+
+        const attemptStore = new ModuleTestAttemptStore({ db, config });
+        const attempt = await attemptStore.findById(req.attemptId);
+
+        if (!attempt) throw new ValidationError(404, `Module test attempt ${req.attemptId} not found`);
+        if (attempt.userId !== req.userId) throw new ValidationError(403, "Attempt does not belong to the specified user");
+        if (attempt.takenAt === null) throw new ValidationError(400, "Attempt is not yet submitted");
+
+        const exerciseStore = new ExerciseStore(db);
+        const exercises = await exerciseStore.findByIds(attempt.exerciseIds);
+        const exerciseById = new Map(exercises.map(e => [e.id, e]));
+
+        const answerByExerciseId = new Map(attempt.answers.map(a => [a.exerciseId, a]));
+
+        const questions: ReviewQuestion[] = attempt.exerciseIds.map(exerciseId => {
+
+            const exercise = exerciseById.get(exerciseId);
+            const answer = answerByExerciseId.get(exerciseId);
+
+            return {
+                exerciseId,
+                prompt: exercise?.prompt ?? "",
+                isCorrect: answer?.isCorrect ?? false,
+                userAnswer: answer?.userAnswer ?? "",
+                correctAnswer: exercise?.answer ?? "",
+            };
+        });
+
+        return {
+            score: attempt.score!,
+            passed: attempt.passed!,
+            questions,
+        };
+    }
+}
+
+interface ReviewQuestion {
+    exerciseId: string;     // The exercise id
+    prompt: string;         // The exercise prompt
+    isCorrect: boolean;     // Whether the user's answer was correct
+    userAnswer: string;     // The user's submitted answer (empty string if unanswered)
+    correctAnswer: string;  // The correct answer — always exposed in the review
+}
+
+interface GetTestReviewRequest {
+    userId: string;     // The user id making the request
+    attemptId: string;  // The attempt id to review
+}
+
+interface GetTestReviewResponse {
+    score: number;                  // Percentage correct (0–100)
+    passed: boolean;                // Whether the attempt passed
+    questions: ReviewQuestion[];    // Per-question review items
+}

--- a/src/dlg/moduleTests/StartModuleTest.ts
+++ b/src/dlg/moduleTests/StartModuleTest.ts
@@ -1,0 +1,177 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { MODULE_TEST_SIZE, TEST_RETRY_DELAY_MINUTES, TEST_UNLOCK_DELAY_HOURS } from "../../Config";
+import { ControllerConfig } from "../../Config";
+import { Exercise } from "../../model/Exercise";
+import { ModuleTestAttempt } from "../../model/ModuleTestAttempt";
+import { ExerciseStore } from "../../store/ExerciseStore";
+import { ModuleStore } from "../../store/ModuleStore";
+import { ModuleTestAttemptStore } from "../../store/ModuleTestAttemptStore";
+import { UserGrammarConceptProgressStore } from "../../store/UserGrammarConceptProgressStore";
+import { UserModuleProgressStore } from "../../store/UserModuleProgressStore";
+import { UserVocabularyProgressStore } from "../../store/UserVocabularyProgressStore";
+import { selectExercises } from "../../util/ExerciseSelector";
+
+/**
+ * Thrown when an active (un-submitted) test attempt already exists for the user + module.
+ * The client must resume the existing attempt via GET …/moduleTests/:attemptId.
+ */
+class ActiveAttemptError extends ValidationError {
+
+    attemptId: string;  // The id of the already-active attempt to resume
+
+    constructor(attemptId: string) {
+        super(409, "An active module test attempt already exists for this module");
+        this.attemptId = attemptId;
+    }
+}
+
+/**
+ * Starts a new Module Test attempt for the given user and module (F11).
+ *
+ * Business rules enforced:
+ * - 404 if the module does not exist.
+ * - 400 if Step 2 is not complete (`practiceCompletedAt` is null).
+ * - 400 if the test unlock delay has not elapsed since `practiceCompletedAt`.
+ * - 400 if the module is already `completed` (OQ-03: no retakes).
+ * - 400 if a failed attempt's retry delay has not yet elapsed.
+ * - 409 (with `attemptId`) if an active (un-submitted) attempt already exists.
+ * - Otherwise: draws 20 exercises via F08 (unconstrained — no fresh/repeat split),
+ *   creates the attempt, and returns the questions without correct answers.
+ */
+export class StartModuleTest extends TotoDelegate<StartModuleTestRequest, StartModuleTestResponse> {
+
+    /**
+     * Extracts userId and moduleId from the route parameters.
+     */
+    parseRequest(req: Request): StartModuleTestRequest {
+
+        const userId = req.params.userId;
+        const moduleId = req.params.moduleId;
+
+        if (!userId) throw new ValidationError(400, "userId is required");
+        if (!moduleId) throw new ValidationError(400, "moduleId is required");
+
+        return { userId, moduleId, now: new Date() };
+    }
+
+    /**
+     * Creates a new Module Test attempt after verifying all eligibility conditions.
+     * Returns the 20 selected exercises without their correct answers.
+     */
+    async do(req: StartModuleTestRequest, _userContext?: UserContext): Promise<StartModuleTestResponse> {
+
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+        const now = req.now;
+
+        const moduleStore = new ModuleStore(db);
+        const module = await moduleStore.findById(req.moduleId);
+
+        if (!module) throw new ValidationError(404, `Module ${req.moduleId} not found`);
+
+        const progressStore = new UserModuleProgressStore({ db, config });
+        const progress = await progressStore.findByUserAndModule(req.userId, req.moduleId);
+
+        if (!progress?.practiceCompletedAt) {
+            throw new ValidationError(400, "Step 2 is not complete — practiceCompletedAt is not set");
+        }
+
+        if (progress.status === "completed") {
+            throw new ValidationError(400, "Module is already completed — no retakes allowed");
+        }
+
+        const testUnlocksAt = new Date(new Date(progress.practiceCompletedAt).getTime() + TEST_UNLOCK_DELAY_HOURS * 60 * 60 * 1000);
+
+        if (now < testUnlocksAt) {
+            throw new ValidationError(400, `Test is not yet unlocked — unlocks at ${testUnlocksAt.toISOString()}`);
+        }
+
+        const failedAttempts = progress.testAttempts.filter(a => !a.passed && a.takenAt);
+        const mostRecentFailed = failedAttempts.sort((a, b) => new Date(b.takenAt).getTime() - new Date(a.takenAt).getTime())[0];
+
+        if (mostRecentFailed) {
+
+            const retryAvailableAt = new Date(new Date(mostRecentFailed.takenAt).getTime() + TEST_RETRY_DELAY_MINUTES * 60 * 1000);
+
+            if (now < retryAvailableAt) {
+                throw new ValidationError(400, `Retry not yet available — retry after ${retryAvailableAt.toISOString()}`);
+            }
+        }
+
+        const attemptStore = new ModuleTestAttemptStore({ db, config });
+        const existing = await attemptStore.findActiveByUserAndModule(req.userId, req.moduleId);
+
+        if (existing) throw new ActiveAttemptError(existing.id!);
+
+        const exerciseStore = new ExerciseStore(db);
+        const allExercises = await exerciseStore.listByModuleId(req.moduleId);
+
+        const vocabProgressStore = new UserVocabularyProgressStore({ db, config });
+        const grammarProgressStore = new UserGrammarConceptProgressStore({ db, config });
+
+        const vocabProgressList = await vocabProgressStore.listByUser(req.userId, module.vocabularyItemIds);
+        const grammarProgressList = await grammarProgressStore.listByUser(req.userId, module.grammarConceptIds);
+
+        const masteryByItemId = new Map<string, number>([
+            ...vocabProgressList.map((p): [string, number] => [p.vocabularyItemId, p.masteryScore]),
+            ...grammarProgressList.map((p): [string, number] => [p.grammarConceptId, p.masteryScore]),
+        ]);
+
+        // F08 unconstrained selection — no fresh/repeat split, no coverage override
+        const selected = selectExercises({
+            pool: allExercises,
+            masteryByItemId,
+            recentMisses: new Set(),
+            targetCount: MODULE_TEST_SIZE,
+        });
+
+        const startedAt = now.toISOString();
+
+        const attempt = new ModuleTestAttempt({
+            userId: req.userId,
+            moduleId: req.moduleId,
+            exerciseIds: selected.map(e => e.id),
+            answers: [],
+            currentPosition: 0,
+            verifiedExerciseIds: [],
+            score: null,
+            passed: null,
+            startedAt,
+            takenAt: null,
+            exerciseResults: [],
+        });
+
+        const attemptId = await attemptStore.create(attempt);
+
+        // Strip correct answers before returning to the client
+        const exercisesWithoutAnswers = selected.map(e => stripAnswer(e));
+
+        return { attemptId, moduleId: req.moduleId, exercises: exercisesWithoutAnswers, startedAt };
+    }
+}
+
+/**
+ * Returns a copy of the exercise with the `answer`, `alternativeAnswers`, and
+ * `userContributedAnswers` fields removed so the client cannot see the correct answer
+ * before submitting.
+ */
+function stripAnswer(exercise: Exercise): any {
+
+    const { answer: _a, alternativeAnswers: _alt, userContributedAnswers: _uca, ...rest } = exercise as any;
+
+    return rest;
+}
+
+interface StartModuleTestRequest {
+    userId: string;     // The user id
+    moduleId: string;   // The module id
+    now: Date;          // The current time (injectable for testability)
+}
+
+interface StartModuleTestResponse {
+    attemptId: string;      // The id of the newly created attempt
+    moduleId: string;       // The module id
+    exercises: any[];       // Selected exercises without correct answers
+    startedAt: string;      // ISO-8601 timestamp of when the attempt was started
+}

--- a/src/dlg/moduleTests/SubmitModuleTest.ts
+++ b/src/dlg/moduleTests/SubmitModuleTest.ts
@@ -1,0 +1,129 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { TEST_PASS_THRESHOLD } from "../../Config";
+import { ControllerConfig } from "../../Config";
+import { ExerciseResult } from "../../model/ExerciseResult";
+import { TestAttemptRecord } from "../../model/UserModuleProgress";
+import { ExerciseStore } from "../../store/ExerciseStore";
+import { ModuleTestAttemptStore } from "../../store/ModuleTestAttemptStore";
+import { UserGrammarConceptProgressStore } from "../../store/UserGrammarConceptProgressStore";
+import { UserModuleProgressStore } from "../../store/UserModuleProgressStore";
+import { UserVocabularyProgressStore } from "../../store/UserVocabularyProgressStore";
+
+/**
+ * Finalises a Module Test attempt (F11).
+ *
+ * Steps:
+ * 1. Load the attempt; validate it is in-progress.
+ * 2. Compute the score: % of `exerciseIds` whose final `isCorrect` is true;
+ *    unanswered exercises count as wrong.
+ * 3. Determine pass/fail against `TEST_PASS_THRESHOLD`.
+ * 4. Update mastery (F06) for every answered exercise — same loop as CompletePracticeSession.
+ * 5. Persist the grading outcome on the attempt (`score`, `passed`, `takenAt`, `exerciseResults`).
+ * 6. Record a TestAttemptRecord summary in `UserModuleProgress.testAttempts`.
+ * 7. On pass: transition `UserModuleProgress` status to `completed`.
+ */
+export class SubmitModuleTest extends TotoDelegate<SubmitModuleTestRequest, SubmitModuleTestResponse> {
+
+    /**
+     * Extracts userId and attemptId from the route parameters.
+     */
+    parseRequest(req: Request): SubmitModuleTestRequest {
+
+        const userId = req.params.userId;
+        const attemptId = req.params.attemptId;
+
+        if (!userId) throw new ValidationError(400, "userId is required");
+        if (!attemptId) throw new ValidationError(400, "attemptId is required");
+
+        return { userId, attemptId };
+    }
+
+    /**
+     * Grades the attempt and performs all downstream effects (mastery, progress, module transition).
+     */
+    async do(req: SubmitModuleTestRequest, _userContext?: UserContext): Promise<SubmitModuleTestResponse> {
+
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+
+        const attemptStore = new ModuleTestAttemptStore({ db, config });
+        const attempt = await attemptStore.findById(req.attemptId);
+
+        if (!attempt) throw new ValidationError(404, `Module test attempt ${req.attemptId} not found`);
+        if (attempt.takenAt !== null) throw new ValidationError(400, "Attempt is already submitted");
+
+        // Build an answer lookup for O(1) access
+        const answerByExerciseId = new Map(attempt.answers.map(a => [a.exerciseId, a]));
+
+        // Unanswered exercises count as wrong — iterate exerciseIds (not answers) as the source of truth
+        const correctCount = attempt.exerciseIds.filter(id => answerByExerciseId.get(id)?.isCorrect === true).length;
+        const score = attempt.exerciseIds.length > 0 ? Math.round((correctCount / attempt.exerciseIds.length) * 100) : 0;
+        const passed = score >= TEST_PASS_THRESHOLD;
+        const takenAt = new Date().toISOString();
+
+        // Update mastery (F06) — bulk-fetch exercises to avoid N+1 queries
+        const exerciseStore = new ExerciseStore(db);
+        const exercises = await exerciseStore.findByIds(attempt.exerciseIds);
+        const exerciseById = new Map(exercises.map(e => [e.id, e]));
+
+        const vocabProgressStore = new UserVocabularyProgressStore({ db, config });
+        const grammarProgressStore = new UserGrammarConceptProgressStore({ db, config });
+
+        const exerciseResults: ExerciseResult[] = [];
+
+        for (const answer of attempt.answers) {
+
+            const exercise = exerciseById.get(answer.exerciseId);
+
+            if (!exercise) continue;
+
+            const result = new ExerciseResult({
+                exerciseId: exercise.id,
+                type: exercise.type,
+                isCorrect: answer.isCorrect,
+                userAnswer: answer.userAnswer,
+                correctAnswer: exercise.answer,
+                timestamp: answer.answeredAt,
+                moduleId: attempt.moduleId,
+            });
+
+            exerciseResults.push(result);
+
+            if (exercise.vocabularyItemId) {
+                await vocabProgressStore.appendResultAndRecompute(req.userId, exercise.vocabularyItemId, result);
+            } else if (exercise.grammarConceptId) {
+                await grammarProgressStore.appendResultAndRecompute(req.userId, exercise.grammarConceptId, result);
+            }
+        }
+
+        // Persist the grading outcome on the attempt
+        await attemptStore.submit(req.attemptId, { score, passed, takenAt, exerciseResults });
+
+        // Record summary in UserModuleProgress.testAttempts
+        const progressStore = new UserModuleProgressStore({ db, config });
+
+        await progressStore.appendTestAttempt(
+            req.userId,
+            attempt.moduleId,
+            new TestAttemptRecord({ id: req.attemptId, score, passed, takenAt })
+        );
+
+        // On pass: transition module to completed
+        if (passed) {
+            await progressStore.transitionStatus(req.userId, attempt.moduleId, "completed");
+        }
+
+        return { score, passed };
+    }
+}
+
+interface SubmitModuleTestRequest {
+    userId: string;     // The user id
+    attemptId: string;  // The module test attempt id
+}
+
+interface SubmitModuleTestResponse {
+    score: number;      // Percentage correct (0–100)
+    passed: boolean;    // Whether the attempt passed
+}

--- a/src/dlg/moduleTests/SubmitTestAnswer.ts
+++ b/src/dlg/moduleTests/SubmitTestAnswer.ts
@@ -1,0 +1,92 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../../Config";
+import { ExerciseStore } from "../../store/ExerciseStore";
+import { ModuleTestAttemptStore } from "../../store/ModuleTestAttemptStore";
+import { checkAnswer } from "../../util/AnswerChecker";
+
+/**
+ * Submits a single answer for one exercise in an in-progress Module Test attempt (F11).
+ *
+ * Business rules:
+ * - The attempt must exist and not yet be submitted (`takenAt` null).
+ * - The `exerciseId` must belong to the attempt's `exerciseIds` list.
+ * - The answer is checked via normalised matching (same logic as F10).
+ * - The first answer to each exercise is final for grading — there is no retry queue.
+ * - Immediate feedback is returned: on a wrong answer, the correct answer is included.
+ * - `timesShown` is incremented on the exercise (same as practice).
+ */
+export class SubmitTestAnswer extends TotoDelegate<SubmitTestAnswerRequest, SubmitTestAnswerResponse> {
+
+    /**
+     * Extracts userId, attemptId, exerciseId, and userAnswer from the request.
+     */
+    parseRequest(req: Request): SubmitTestAnswerRequest {
+
+        const userId = req.params.userId;
+        const attemptId = req.params.attemptId;
+        const exerciseId = req.body?.exerciseId;
+        const userAnswer = req.body?.userAnswer;
+
+        if (!userId) throw new ValidationError(400, "userId is required");
+        if (!attemptId) throw new ValidationError(400, "attemptId is required");
+        if (!exerciseId) throw new ValidationError(400, "exerciseId is required");
+        if (userAnswer === undefined || userAnswer === null) throw new ValidationError(400, "userAnswer is required");
+
+        return { userId, attemptId, exerciseId, userAnswer: String(userAnswer) };
+    }
+
+    /**
+     * Checks the answer, stores the result, advances the cursor, and returns immediate feedback.
+     * Does not add to any retry queue — first answer is final.
+     */
+    async do(req: SubmitTestAnswerRequest, _userContext?: UserContext): Promise<SubmitTestAnswerResponse> {
+
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+
+        const attemptStore = new ModuleTestAttemptStore({ db, config });
+        const attempt = await attemptStore.findById(req.attemptId);
+
+        if (!attempt) throw new ValidationError(404, `Module test attempt ${req.attemptId} not found`);
+        if (attempt.takenAt !== null) throw new ValidationError(400, "Attempt is already submitted");
+
+        if (!attempt.exerciseIds.includes(req.exerciseId)) {
+            throw new ValidationError(400, `Exercise ${req.exerciseId} is not part of this attempt`);
+        }
+
+        const exerciseStore = new ExerciseStore(db);
+        const exercise = await exerciseStore.findById(req.exerciseId);
+
+        if (!exercise) throw new ValidationError(404, `Exercise ${req.exerciseId} not found`);
+
+        const { isCorrect, correctAnswer } = checkAnswer(req.userAnswer, exercise);
+
+        const now = new Date().toISOString();
+
+        await attemptStore.appendAnswer(req.attemptId, {
+            exerciseId: req.exerciseId,
+            isCorrect,
+            userAnswer: req.userAnswer,
+            answeredAt: now,
+        });
+
+        await attemptStore.advancePosition(req.attemptId);
+
+        await exerciseStore.incrementTimesShown(req.exerciseId);
+
+        return { isCorrect, correctAnswer };
+    }
+}
+
+interface SubmitTestAnswerRequest {
+    userId: string;     // The user id
+    attemptId: string;  // The module test attempt id
+    exerciseId: string; // The exercise being answered
+    userAnswer: string; // The raw answer string submitted by the user
+}
+
+interface SubmitTestAnswerResponse {
+    isCorrect: boolean;     // Whether the answer was judged correct
+    correctAnswer: string;  // The correct answer; always returned for immediate feedback
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,12 @@ import { StartPracticeSession } from './dlg/practiceSessions/StartPracticeSessio
 import { GetPracticeSession } from './dlg/practiceSessions/GetPracticeSession';
 import { SubmitPracticeAnswer } from './dlg/practiceSessions/SubmitPracticeAnswer';
 import { CompletePracticeSession } from './dlg/practiceSessions/CompletePracticeSession';
+import { GetTestEligibility } from './dlg/moduleTests/GetTestEligibility';
+import { StartModuleTest } from './dlg/moduleTests/StartModuleTest';
+import { GetModuleTest } from './dlg/moduleTests/GetModuleTest';
+import { SubmitTestAnswer } from './dlg/moduleTests/SubmitTestAnswer';
+import { SubmitModuleTest } from './dlg/moduleTests/SubmitModuleTest';
+import { GetTestReview } from './dlg/moduleTests/GetTestReview';
 
 const config: TotoMicroserviceConfiguration = {
     serviceName: "tome-ms-language",
@@ -104,6 +110,13 @@ const config: TotoMicroserviceConfiguration = {
             { method: 'GET', path: '/users/:userId/practiceSessions/:sessionId', delegate: GetPracticeSession },
             { method: 'POST', path: '/users/:userId/practiceSessions/:sessionId/answers', delegate: SubmitPracticeAnswer },
             { method: 'POST', path: '/users/:userId/practiceSessions/:sessionId/complete', delegate: CompletePracticeSession },
+
+            { method: 'GET', path: '/users/:userId/modules/:moduleId/testEligibility', delegate: GetTestEligibility },
+            { method: 'POST', path: '/users/:userId/modules/:moduleId/tests', delegate: StartModuleTest },
+            { method: 'GET', path: '/users/:userId/moduleTests/:attemptId', delegate: GetModuleTest },
+            { method: 'POST', path: '/users/:userId/moduleTests/:attemptId/answers', delegate: SubmitTestAnswer },
+            { method: 'POST', path: '/users/:userId/moduleTests/:attemptId/submit', delegate: SubmitModuleTest },
+            { method: 'GET', path: '/users/:userId/moduleTests/:attemptId/review', delegate: GetTestReview },
         ],
         apiOptions: { noCorrelationId: true }
     },

--- a/src/model/ModuleTestAttempt.ts
+++ b/src/model/ModuleTestAttempt.ts
@@ -1,0 +1,113 @@
+import { WithId } from "mongodb";
+import { ExerciseResult } from "./ExerciseResult";
+
+/**
+ * A single answer submitted by the user during a module test.
+ * The first answer to each exercise is final for grading — there is no retry queue.
+ */
+export interface TestAnswer {
+    exerciseId: string;     // The id of the exercise that was answered
+    isCorrect: boolean;     // Whether the answer was judged correct by the normalised matcher (may be flipped by F13 AI verification)
+    userAnswer: string;     // The raw answer string submitted by the user
+    answeredAt: string;     // ISO-8601 timestamp of when the answer was submitted
+}
+
+/**
+ * A stateful, resumable Module Test attempt (F11).
+ *
+ * Lifecycle: created on POST .../tests → answers accumulated via POST .../answers
+ * → finalised on POST .../submit (takenAt set, score/passed computed).
+ * While takenAt is null the attempt is in-progress and can be resumed.
+ *
+ * The full document lives in the `moduleTestAttempts` collection.
+ * On submit, a lightweight TestAttemptRecord summary is also embedded in
+ * UserModuleProgress.testAttempts[] for eligibility checks and history display.
+ */
+export class ModuleTestAttempt {
+
+    id?: string;                        // MongoDB _id as a hex string; absent before first save
+    userId: string;                     // The user who owns this attempt
+    moduleId: string;                   // The module being tested
+    exerciseIds: string[];              // Ordered list of exercise ids for this attempt (set at start, never changed)
+    answers: TestAnswer[];              // All answers submitted so far — one per exercise, first answer is final
+    currentPosition: number;            // 0-based index of the next unanswered exercise
+    verifiedExerciseIds: string[];      // Exercise ids for which AI answer verification (F13) was already used this attempt
+    score: number | null;               // Percentage correct (0–100); null until the attempt is submitted
+    passed: boolean | null;             // Whether score >= testPassThreshold; null until the attempt is submitted
+    startedAt: string;                  // ISO-8601 timestamp of when the attempt was started
+    takenAt: string | null;             // ISO-8601 timestamp of submission; null while in-progress
+    exerciseResults: ExerciseResult[];  // Per-exercise mastery results (F06); populated on submit
+
+    constructor({ id, userId, moduleId, exerciseIds, answers, currentPosition, verifiedExerciseIds, score, passed, startedAt, takenAt, exerciseResults }: ModuleTestAttemptInput) {
+
+        this.id = id;
+        this.userId = userId;
+        this.moduleId = moduleId;
+        this.exerciseIds = exerciseIds ?? [];
+        this.answers = answers ?? [];
+        this.currentPosition = currentPosition ?? 0;
+        this.verifiedExerciseIds = verifiedExerciseIds ?? [];
+        this.score = score ?? null;
+        this.passed = passed ?? null;
+        this.startedAt = startedAt;
+        this.takenAt = takenAt ?? null;
+        this.exerciseResults = exerciseResults ?? [];
+    }
+
+    /**
+     * Creates a ModuleTestAttempt from a raw MongoDB BSON document.
+     */
+    static fromBSON(data: WithId<any>): ModuleTestAttempt {
+
+        return new ModuleTestAttempt({
+            id: data._id.toString(),
+            userId: data.userId,
+            moduleId: data.moduleId,
+            exerciseIds: data.exerciseIds ?? [],
+            answers: data.answers ?? [],
+            currentPosition: data.currentPosition ?? 0,
+            verifiedExerciseIds: data.verifiedExerciseIds ?? [],
+            score: data.score ?? null,
+            passed: data.passed ?? null,
+            startedAt: data.startedAt,
+            takenAt: data.takenAt ?? null,
+            exerciseResults: (data.exerciseResults ?? []).map((r: any) => ExerciseResult.fromBSON(r)),
+        });
+    }
+
+    /**
+     * Serializes the attempt to a plain object for MongoDB storage.
+     * Does not include _id — MongoDB generates it on insert.
+     */
+    toBSON(): any {
+
+        return {
+            userId: this.userId,
+            moduleId: this.moduleId,
+            exerciseIds: this.exerciseIds,
+            answers: this.answers,
+            currentPosition: this.currentPosition,
+            verifiedExerciseIds: this.verifiedExerciseIds,
+            score: this.score,
+            passed: this.passed,
+            startedAt: this.startedAt,
+            takenAt: this.takenAt,
+            exerciseResults: this.exerciseResults.map(r => r.toBSON()),
+        };
+    }
+}
+
+interface ModuleTestAttemptInput {
+    id?: string;
+    userId: string;
+    moduleId: string;
+    exerciseIds?: string[];
+    answers?: TestAnswer[];
+    currentPosition?: number;
+    verifiedExerciseIds?: string[];
+    score?: number | null;
+    passed?: boolean | null;
+    startedAt: string;
+    takenAt?: string | null;
+    exerciseResults?: ExerciseResult[];
+}

--- a/src/model/UserModuleProgress.ts
+++ b/src/model/UserModuleProgress.ts
@@ -3,22 +3,32 @@ import { WithId } from "mongodb";
 export const MODULE_STATUSES = ["locked", "available", "in_progress", "completed"] as const;
 export type ModuleStatus = typeof MODULE_STATUSES[number];
 
-export class ModuleTestAttempt {
+/**
+ * Lightweight summary of a completed Module Test attempt, embedded in UserModuleProgress.testAttempts[].
+ * Holds only the grading outcome and timing needed for eligibility checks and history display.
+ * The full stateful attempt document lives in the `moduleTestAttempts` collection (see ModuleTestAttempt model).
+ */
+export class TestAttemptRecord {
 
-    id: string;
-    score: number;
-    passed: boolean;
-    takenAt: string;
+    id: string;         // The MongoDB _id (as hex string) of the full ModuleTestAttempt document
+    score: number;      // Percentage correct (0–100)
+    passed: boolean;    // Whether the attempt passed (score >= testPassThreshold)
+    takenAt: string;    // ISO-8601 timestamp of when the attempt was submitted
 
     constructor({ id, score, passed, takenAt }: { id: string; score: number; passed: boolean; takenAt: string }) {
+
         this.id = id;
         this.score = score;
         this.passed = passed;
         this.takenAt = takenAt;
     }
 
-    static fromBSON(data: any): ModuleTestAttempt {
-        return new ModuleTestAttempt({
+    /**
+     * Creates a TestAttemptRecord from a raw BSON document.
+     */
+    static fromBSON(data: any): TestAttemptRecord {
+
+        return new TestAttemptRecord({
             id: data.id,
             score: data.score,
             passed: data.passed,
@@ -26,7 +36,11 @@ export class ModuleTestAttempt {
         });
     }
 
+    /**
+     * Serializes the record to a plain object for MongoDB storage (embedded in UserModuleProgress).
+     */
     toBSON(): any {
+
         return {
             id: this.id,
             score: this.score,
@@ -45,7 +59,7 @@ export class UserModuleProgress {
     completedAt: string | null;
     vocabularyItemsPracticed: string[];
     practiceCompletedAt: string | null;
-    testAttempts: ModuleTestAttempt[];
+    testAttempts: TestAttemptRecord[];
 
     constructor({ userId, moduleId, status, startedAt, completedAt, vocabularyItemsPracticed, practiceCompletedAt, testAttempts }: UserModuleProgressInput) {
         this.userId = userId;
@@ -67,7 +81,7 @@ export class UserModuleProgress {
             completedAt: data.completedAt ?? null,
             vocabularyItemsPracticed: data.vocabularyItemsPracticed ?? [],
             practiceCompletedAt: data.practiceCompletedAt ?? null,
-            testAttempts: (data.testAttempts ?? []).map((a: any) => ModuleTestAttempt.fromBSON(a)),
+            testAttempts: (data.testAttempts ?? []).map((a: any) => TestAttemptRecord.fromBSON(a)),
         });
     }
 
@@ -93,5 +107,5 @@ interface UserModuleProgressInput {
     completedAt: string | null;
     vocabularyItemsPracticed?: string[];
     practiceCompletedAt?: string | null;
-    testAttempts: ModuleTestAttempt[];
+    testAttempts: TestAttemptRecord[];
 }

--- a/src/store/ModuleTestAttemptStore.ts
+++ b/src/store/ModuleTestAttemptStore.ts
@@ -1,0 +1,162 @@
+import { Db, ObjectId } from "mongodb";
+import { ControllerConfig } from "../Config";
+import { ModuleTestAttempt, TestAnswer } from "../model/ModuleTestAttempt";
+import { ExerciseResult } from "../model/ExerciseResult";
+
+const COLLECTION = "moduleTestAttempts";
+
+/**
+ * Encapsulates all database access for the `moduleTestAttempts` collection.
+ * Each document is a full stateful Module Test attempt (F11).
+ */
+export class ModuleTestAttemptStore {
+
+    private db: Db;
+    private config: ControllerConfig;
+
+    constructor({ db, config }: { db: Db; config: ControllerConfig }) {
+
+        this.db = db;
+        this.config = config;
+    }
+
+    /**
+     * Inserts a new ModuleTestAttempt document and returns the MongoDB-generated _id as a string.
+     *
+     * @param {ModuleTestAttempt} attempt - The attempt to persist.
+     *
+     * @returns {Promise<string>} The inserted document's _id as a hex string.
+     */
+    async create(attempt: ModuleTestAttempt): Promise<string> {
+
+        const result = await this.db.collection(COLLECTION).insertOne(attempt.toBSON());
+
+        return result.insertedId.toString();
+    }
+
+    /**
+     * Finds a single attempt by its MongoDB _id.
+     * Returns null if no document matches.
+     *
+     * @param {string} attemptId - The hex-string _id to look up.
+     *
+     * @returns {Promise<ModuleTestAttempt | null>} The found attempt, or null.
+     */
+    async findById(attemptId: string): Promise<ModuleTestAttempt | null> {
+
+        const doc = await this.db.collection(COLLECTION).findOne({ _id: new ObjectId(attemptId) });
+
+        if (!doc) return null;
+
+        return ModuleTestAttempt.fromBSON(doc as any);
+    }
+
+    /**
+     * Returns the single in-progress (un-submitted) attempt for a user + module pair.
+     * An attempt is in-progress when its `takenAt` field is null.
+     * Returns null when no active attempt exists.
+     *
+     * @param {string} userId - The user id.
+     * @param {string} moduleId - The module id.
+     *
+     * @returns {Promise<ModuleTestAttempt | null>} The active attempt, or null.
+     */
+    async findActiveByUserAndModule(userId: string, moduleId: string): Promise<ModuleTestAttempt | null> {
+
+        const doc = await this.db.collection(COLLECTION).findOne({ userId, moduleId, takenAt: null });
+
+        if (!doc) return null;
+
+        return ModuleTestAttempt.fromBSON(doc as any);
+    }
+
+    /**
+     * Appends a TestAnswer to the attempt's answers array.
+     * The first answer to each exercise is final for grading — there is no retry mechanism.
+     *
+     * @param {string} attemptId - The attempt _id.
+     * @param {TestAnswer} answer - The answer to append.
+     */
+    async appendAnswer(attemptId: string, answer: TestAnswer): Promise<void> {
+
+        await this.db.collection(COLLECTION).updateOne(
+            { _id: new ObjectId(attemptId) },
+            { $push: { answers: answer } } as any
+        );
+    }
+
+    /**
+     * Increments `currentPosition` by 1, advancing the cursor to the next exercise.
+     *
+     * @param {string} attemptId - The attempt _id.
+     */
+    async advancePosition(attemptId: string): Promise<void> {
+
+        await this.db.collection(COLLECTION).updateOne(
+            { _id: new ObjectId(attemptId) },
+            { $inc: { currentPosition: 1 } }
+        );
+    }
+
+    /**
+     * Appends an exercise id to `verifiedExerciseIds`.
+     * Used by the F13 answer verification flow to enforce the one-per-attempt guard.
+     *
+     * @param {string} attemptId - The attempt _id.
+     * @param {string} exerciseId - The exercise id to mark as AI-verified.
+     */
+    async addVerifiedExerciseId(attemptId: string, exerciseId: string): Promise<void> {
+
+        await this.db.collection(COLLECTION).updateOne(
+            { _id: new ObjectId(attemptId) },
+            { $push: { verifiedExerciseIds: exerciseId } } as any
+        );
+    }
+
+    /**
+     * Flips the stored `isCorrect` flag to true for the given exercise in the answers array.
+     * Called by the F13 answer verification flow when the AI validates a translation.
+     * This must happen before submit so the score naturally reflects it.
+     *
+     * @param {string} attemptId - The attempt _id.
+     * @param {string} exerciseId - The exercise id whose answer should be flipped to correct.
+     */
+    async flipAnswerToCorrect(attemptId: string, exerciseId: string): Promise<void> {
+
+        await this.db.collection(COLLECTION).updateOne(
+            { _id: new ObjectId(attemptId), "answers.exerciseId": exerciseId },
+            { $set: { "answers.$.isCorrect": true } } as any
+        );
+    }
+
+    /**
+     * Finalises a Module Test attempt by persisting the computed score, pass/fail verdict,
+     * submission timestamp, and per-exercise mastery results.
+     * Sets `takenAt` to mark the attempt as submitted — after this call `findActiveByUserAndModule`
+     * will no longer return this attempt.
+     *
+     * @param {string} attemptId - The attempt _id.
+     * @param {{ score, passed, takenAt, exerciseResults }} params - The grading outcome to persist.
+     */
+    async submit(attemptId: string, { score, passed, takenAt, exerciseResults }: SubmitParams): Promise<void> {
+
+        await this.db.collection(COLLECTION).updateOne(
+            { _id: new ObjectId(attemptId) },
+            {
+                $set: {
+                    score,
+                    passed,
+                    takenAt,
+                    exerciseResults: exerciseResults.map(r => r.toBSON()),
+                },
+            } as any
+        );
+    }
+}
+
+interface SubmitParams {
+    score: number;                  // Percentage correct (0–100)
+    passed: boolean;                // Whether score >= testPassThreshold
+    takenAt: string;                // ISO-8601 submission timestamp
+    exerciseResults: ExerciseResult[]; // Per-exercise mastery results for F06
+}

--- a/src/store/UserModuleProgressStore.ts
+++ b/src/store/UserModuleProgressStore.ts
@@ -1,6 +1,6 @@
 import { Db } from "mongodb";
 import { ControllerConfig } from "../Config";
-import { UserModuleProgress, ModuleTestAttempt } from "../model/UserModuleProgress";
+import { UserModuleProgress, TestAttemptRecord } from "../model/UserModuleProgress";
 
 const COLLECTION = "userModuleProgress";
 
@@ -73,7 +73,7 @@ export class UserModuleProgressStore {
         return this.upsert(updated);
     }
 
-    async appendTestAttempt(userId: string, moduleId: string, attempt: ModuleTestAttempt): Promise<UserModuleProgress | null> {
+    async appendTestAttempt(userId: string, moduleId: string, attempt: TestAttemptRecord): Promise<UserModuleProgress | null> {
         const result = await this.db.collection(COLLECTION).updateOne(
             { userId, moduleId },
             { $push: { testAttempts: attempt.toBSON() } } as any

--- a/test/dlg/moduleTests/GetModuleTest.do.test.ts
+++ b/test/dlg/moduleTests/GetModuleTest.do.test.ts
@@ -1,0 +1,119 @@
+import { assert } from "chai";
+import { ObjectId } from "mongodb";
+import { GetModuleTest } from "../../../src/dlg/moduleTests/GetModuleTest";
+import { Exercise } from "../../../src/model/Exercise";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAttemptBSON(oid: ObjectId, overrides: any = {}): any {
+    return {
+        _id: oid,
+        userId: "user-1",
+        moduleId: "mod-1",
+        exerciseIds: ["ex-1", "ex-2"],
+        answers: [{ exerciseId: "ex-1", isCorrect: true, userAnswer: "hej", answeredAt: "2026-06-11T10:00:00.000Z" }],
+        currentPosition: 1,
+        verifiedExerciseIds: [],
+        score: null,
+        passed: null,
+        startedAt: "2026-06-11T09:00:00.000Z",
+        takenAt: null,
+        exerciseResults: [],
+        ...overrides,
+    };
+}
+
+function makeExerciseBSON(id: string): any {
+    return new Exercise({
+        id,
+        moduleId: "mod-1",
+        type: "translation_active",
+        prompt: `prompt-${id}`,
+        answer: `answer-${id}`,
+        vocabularyItemId: "v-1",
+        grammarConceptId: null,
+    }).toBSON();
+}
+
+function makeMockConfig(attemptDoc: any | null, exerciseDocs: any[]) {
+
+    const collections: Record<string, any> = {
+        moduleTestAttempts: {
+            findOne: async (filter: any) => {
+                if (!attemptDoc) return null;
+                if (filter._id) return attemptDoc._id.equals(filter._id) ? attemptDoc : null;
+                return null;
+            },
+        },
+        exercises: {
+            find: () => ({ toArray: async () => exerciseDocs }),
+        },
+    };
+
+    return {
+        getDBName: () => "test",
+        getMongoDb: async () => ({ collection: (name: string) => collections[name] }),
+    } as any;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GetModuleTest.do", () => {
+
+    it("returns the attempt state with exercises and answers but without correct answers", async () => {
+
+        const oid = new ObjectId();
+        const config = makeMockConfig(makeAttemptBSON(oid), [makeExerciseBSON("ex-1"), makeExerciseBSON("ex-2")]);
+        const delegate = new GetModuleTest({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        assert.equal(result.attemptId, oid.toString());
+        assert.equal(result.moduleId, "mod-1");
+        assert.equal(result.currentPosition, 1);
+        assert.equal(result.exercises.length, 2);
+        assert.equal(result.answers.length, 1);
+
+        // Correct answers must not be exposed during an in-progress attempt
+        for (const ex of result.exercises) {
+            assert.isUndefined((ex as any).answer, "exercises must not expose correct answer");
+        }
+    });
+
+    it("throws 404 when the attempt is not found", async () => {
+
+        const config = makeMockConfig(null, []);
+        const delegate = new GetModuleTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", attemptId: new ObjectId().toString() }, {} as any);
+            assert.fail("Expected 404");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 404);
+        }
+    });
+
+    it("throws 403 when the attempt does not belong to the requesting user", async () => {
+
+        const oid = new ObjectId();
+        const config = makeMockConfig(makeAttemptBSON(oid, { userId: "other-user" }), []);
+        const delegate = new GetModuleTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+            assert.fail("Expected 403");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 403);
+        }
+    });
+});

--- a/test/dlg/moduleTests/GetTestEligibility.do.test.ts
+++ b/test/dlg/moduleTests/GetTestEligibility.do.test.ts
@@ -1,0 +1,188 @@
+import { assert } from "chai";
+import { GetTestEligibility } from "../../../src/dlg/moduleTests/GetTestEligibility";
+import { UserModuleProgress, TestAttemptRecord } from "../../../src/model/UserModuleProgress";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const NOW = new Date("2026-06-11T14:00:00.000Z");
+
+/**
+ * Returns a practiceCompletedAt timestamp that is `hoursAgo` hours before NOW.
+ */
+function hoursBeforeNow(hoursAgo: number): string {
+    return new Date(NOW.getTime() - hoursAgo * 60 * 60 * 1000).toISOString();
+}
+
+/**
+ * Returns a takenAt timestamp that is `minutesAgo` minutes before NOW.
+ */
+function minutesBeforeNow(minutesAgo: number): string {
+    return new Date(NOW.getTime() - minutesAgo * 60 * 1000).toISOString();
+}
+
+function makeProgress(overrides: Partial<ConstructorParameters<typeof UserModuleProgress>[0]> = {}): UserModuleProgress {
+    return new UserModuleProgress({
+        userId: "user-1",
+        moduleId: "mod-1",
+        status: "in_progress",
+        startedAt: "2026-06-01T09:00:00.000Z",
+        completedAt: null,
+        testAttempts: [],
+        ...overrides,
+    });
+}
+
+function makeMockConfig(progressDoc: any | null) {
+
+    const collections: Record<string, any> = {
+        userModuleProgress: {
+            findOne: async () => progressDoc,
+        },
+    };
+
+    return {
+        getDBName: () => "test",
+        getMongoDb: async () => ({ collection: (name: string) => collections[name] }),
+    } as any;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GetTestEligibility.do", () => {
+
+    it("returns not eligible when practiceCompletedAt is null (Step 2 not complete)", async () => {
+
+        const progress = makeProgress({ practiceCompletedAt: null });
+        const config = makeMockConfig(progress.toBSON());
+        const delegate = new GetTestEligibility({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: NOW }, {} as any);
+
+        assert.isFalse(result.eligible);
+        assert.isUndefined(result.testUnlocksAt);
+    });
+
+    it("returns not eligible when no progress record exists", async () => {
+
+        const config = makeMockConfig(null);
+        const delegate = new GetTestEligibility({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: NOW }, {} as any);
+
+        assert.isFalse(result.eligible);
+        assert.isUndefined(result.testUnlocksAt);
+    });
+
+    it("returns not eligible with testUnlocksAt when unlock delay has not elapsed", async () => {
+
+        // practiceCompletedAt was 2 hours ago — unlock requires 4 hours
+        const progress = makeProgress({ practiceCompletedAt: hoursBeforeNow(2) });
+        const config = makeMockConfig(progress.toBSON());
+        const delegate = new GetTestEligibility({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: NOW }, {} as any);
+
+        assert.isFalse(result.eligible);
+        assert.isString(result.testUnlocksAt);
+        assert.isNumber(result.remainingMs);
+        assert.isAbove(result.remainingMs!, 0);
+    });
+
+    it("returns eligible when unlock delay has elapsed and no prior failed attempt", async () => {
+
+        // practiceCompletedAt was 5 hours ago — more than the 4-hour delay
+        const progress = makeProgress({ practiceCompletedAt: hoursBeforeNow(5) });
+        const config = makeMockConfig(progress.toBSON());
+        const delegate = new GetTestEligibility({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: NOW }, {} as any);
+
+        assert.isTrue(result.eligible);
+    });
+
+    it("returns not eligible when retry delay has not elapsed after a failed attempt", async () => {
+
+        // practiceCompletedAt: unlocked long ago; failed attempt 10 minutes ago (delay is 20 min)
+        const failedAttempt = new TestAttemptRecord({ id: "att-1", score: 50, passed: false, takenAt: minutesBeforeNow(10) });
+        const progress = makeProgress({
+            practiceCompletedAt: hoursBeforeNow(10),
+            testAttempts: [failedAttempt],
+        });
+        const config = makeMockConfig(progress.toBSON());
+        const delegate = new GetTestEligibility({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: NOW }, {} as any);
+
+        assert.isFalse(result.eligible);
+        assert.isString(result.testRetryAvailableAt);
+        assert.isNumber(result.remainingMs);
+        assert.isAbove(result.remainingMs!, 0);
+    });
+
+    it("returns eligible after retry delay has elapsed following a failed attempt", async () => {
+
+        // Failed attempt 25 minutes ago (delay is 20 min)
+        const failedAttempt = new TestAttemptRecord({ id: "att-1", score: 50, passed: false, takenAt: minutesBeforeNow(25) });
+        const progress = makeProgress({
+            practiceCompletedAt: hoursBeforeNow(10),
+            testAttempts: [failedAttempt],
+        });
+        const config = makeMockConfig(progress.toBSON());
+        const delegate = new GetTestEligibility({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: NOW }, {} as any);
+
+        assert.isTrue(result.eligible);
+    });
+
+    it("returns not eligible when the module is already completed (OQ-03: no retakes)", async () => {
+
+        const progress = makeProgress({
+            status: "completed",
+            practiceCompletedAt: hoursBeforeNow(10),
+        });
+        const config = makeMockConfig(progress.toBSON());
+        const delegate = new GetTestEligibility({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: NOW }, {} as any);
+
+        assert.isFalse(result.eligible);
+    });
+
+    it("ignores passed attempts when computing retry delay — only failed submitted attempts count", async () => {
+
+        const passedAttempt = new TestAttemptRecord({ id: "att-1", score: 90, passed: true, takenAt: minutesBeforeNow(5) });
+        const progress = makeProgress({
+            practiceCompletedAt: hoursBeforeNow(10),
+            testAttempts: [passedAttempt],
+        });
+        const config = makeMockConfig(progress.toBSON());
+        const delegate = new GetTestEligibility({} as any, config);
+
+        // A passed attempt should not trigger the retry delay
+        const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: NOW }, {} as any);
+
+        assert.isTrue(result.eligible);
+    });
+
+    it("uses the most recent failed attempt for the retry delay when multiple failed attempts exist", async () => {
+
+        // Two failed attempts — the more recent one is 10 min ago (delay 20 min → still locked)
+        const olderFailed = new TestAttemptRecord({ id: "att-1", score: 50, passed: false, takenAt: minutesBeforeNow(30) });
+        const recentFailed = new TestAttemptRecord({ id: "att-2", score: 60, passed: false, takenAt: minutesBeforeNow(10) });
+        const progress = makeProgress({
+            practiceCompletedAt: hoursBeforeNow(10),
+            testAttempts: [olderFailed, recentFailed],
+        });
+        const config = makeMockConfig(progress.toBSON());
+        const delegate = new GetTestEligibility({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: NOW }, {} as any);
+
+        assert.isFalse(result.eligible);
+    });
+});

--- a/test/dlg/moduleTests/GetTestEligibility.do.test.ts
+++ b/test/dlg/moduleTests/GetTestEligibility.do.test.ts
@@ -1,5 +1,6 @@
 import { assert } from "chai";
 import { GetTestEligibility } from "../../../src/dlg/moduleTests/GetTestEligibility";
+import { TEST_UNLOCK_DELAY_HOURS, TEST_RETRY_DELAY_MINUTES } from "../../../src/Config";
 import { UserModuleProgress, TestAttemptRecord } from "../../../src/model/UserModuleProgress";
 
 // ---------------------------------------------------------------------------
@@ -77,37 +78,60 @@ describe("GetTestEligibility.do", () => {
         assert.isUndefined(result.testUnlocksAt);
     });
 
-    it("returns not eligible with testUnlocksAt when unlock delay has not elapsed", async () => {
+    it("testUnlocksAt equals practiceCompletedAt + TEST_UNLOCK_DELAY_HOURS when still locked", async () => {
 
-        // practiceCompletedAt was 2 hours ago — unlock requires 4 hours
-        const progress = makeProgress({ practiceCompletedAt: hoursBeforeNow(2) });
+        // practiceCompletedAt 2 hours ago — unlock requires 4 hours
+        const practiceCompletedAt = hoursBeforeNow(2);
+        const progress = makeProgress({ practiceCompletedAt });
         const config = makeMockConfig(progress.toBSON());
         const delegate = new GetTestEligibility({} as any, config);
 
         const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: NOW }, {} as any);
 
+        const expectedTestUnlocksAt = new Date(new Date(practiceCompletedAt).getTime() + TEST_UNLOCK_DELAY_HOURS * 60 * 60 * 1000).toISOString();
+
         assert.isFalse(result.eligible);
-        assert.isString(result.testUnlocksAt);
-        assert.isNumber(result.remainingMs);
+        assert.equal(result.testUnlocksAt, expectedTestUnlocksAt, "testUnlocksAt must be practiceCompletedAt + TEST_UNLOCK_DELAY_HOURS");
+    });
+
+    it("remainingMs equals the exact milliseconds until testUnlocksAt when still locked", async () => {
+
+        const practiceCompletedAt = hoursBeforeNow(2);
+        const progress = makeProgress({ practiceCompletedAt });
+        const config = makeMockConfig(progress.toBSON());
+        const delegate = new GetTestEligibility({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: NOW }, {} as any);
+
+        const expectedTestUnlocksAt = new Date(new Date(practiceCompletedAt).getTime() + TEST_UNLOCK_DELAY_HOURS * 60 * 60 * 1000);
+        const expectedRemainingMs = expectedTestUnlocksAt.getTime() - NOW.getTime();
+
+        assert.equal(result.remainingMs, expectedRemainingMs, "remainingMs must be exact ms until testUnlocksAt");
         assert.isAbove(result.remainingMs!, 0);
     });
 
-    it("returns eligible when unlock delay has elapsed and no prior failed attempt", async () => {
+    it("testUnlocksAt is still returned when eligible (for client countdown reference)", async () => {
 
-        // practiceCompletedAt was 5 hours ago — more than the 4-hour delay
-        const progress = makeProgress({ practiceCompletedAt: hoursBeforeNow(5) });
+        // practiceCompletedAt 5 hours ago — more than the 4-hour delay
+        const practiceCompletedAt = hoursBeforeNow(5);
+        const progress = makeProgress({ practiceCompletedAt });
         const config = makeMockConfig(progress.toBSON());
         const delegate = new GetTestEligibility({} as any, config);
 
         const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: NOW }, {} as any);
 
+        const expectedTestUnlocksAt = new Date(new Date(practiceCompletedAt).getTime() + TEST_UNLOCK_DELAY_HOURS * 60 * 60 * 1000).toISOString();
+
         assert.isTrue(result.eligible);
+        assert.equal(result.testUnlocksAt, expectedTestUnlocksAt, "testUnlocksAt must always be returned when practiceCompletedAt is set");
+        assert.isUndefined(result.remainingMs, "remainingMs must be absent when eligible");
     });
 
-    it("returns not eligible when retry delay has not elapsed after a failed attempt", async () => {
+    it("testRetryAvailableAt equals takenAt + TEST_RETRY_DELAY_MINUTES when retry locked", async () => {
 
-        // practiceCompletedAt: unlocked long ago; failed attempt 10 minutes ago (delay is 20 min)
-        const failedAttempt = new TestAttemptRecord({ id: "att-1", score: 50, passed: false, takenAt: minutesBeforeNow(10) });
+        // Failed attempt 10 minutes ago — retry delay is 20 min
+        const takenAt = minutesBeforeNow(10);
+        const failedAttempt = new TestAttemptRecord({ id: "att-1", score: 50, passed: false, takenAt });
         const progress = makeProgress({
             practiceCompletedAt: hoursBeforeNow(10),
             testAttempts: [failedAttempt],
@@ -117,16 +141,16 @@ describe("GetTestEligibility.do", () => {
 
         const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: NOW }, {} as any);
 
+        const expectedRetryAt = new Date(new Date(takenAt).getTime() + TEST_RETRY_DELAY_MINUTES * 60 * 1000).toISOString();
+
         assert.isFalse(result.eligible);
-        assert.isString(result.testRetryAvailableAt);
-        assert.isNumber(result.remainingMs);
-        assert.isAbove(result.remainingMs!, 0);
+        assert.equal(result.testRetryAvailableAt, expectedRetryAt, "testRetryAvailableAt must be takenAt + TEST_RETRY_DELAY_MINUTES");
     });
 
-    it("returns eligible after retry delay has elapsed following a failed attempt", async () => {
+    it("remainingMs equals the exact milliseconds until testRetryAvailableAt when retry locked", async () => {
 
-        // Failed attempt 25 minutes ago (delay is 20 min)
-        const failedAttempt = new TestAttemptRecord({ id: "att-1", score: 50, passed: false, takenAt: minutesBeforeNow(25) });
+        const takenAt = minutesBeforeNow(10);
+        const failedAttempt = new TestAttemptRecord({ id: "att-1", score: 50, passed: false, takenAt });
         const progress = makeProgress({
             practiceCompletedAt: hoursBeforeNow(10),
             testAttempts: [failedAttempt],
@@ -136,7 +160,32 @@ describe("GetTestEligibility.do", () => {
 
         const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: NOW }, {} as any);
 
+        const expectedRetryAt = new Date(new Date(takenAt).getTime() + TEST_RETRY_DELAY_MINUTES * 60 * 1000);
+        const expectedRemainingMs = expectedRetryAt.getTime() - NOW.getTime();
+
+        assert.equal(result.remainingMs, expectedRemainingMs, "remainingMs must be exact ms until testRetryAvailableAt");
+        assert.isAbove(result.remainingMs!, 0);
+    });
+
+    it("testRetryAvailableAt is still returned when eligible after retry delay has elapsed", async () => {
+
+        // Failed attempt 25 min ago (delay 20 min → now eligible)
+        const takenAt = minutesBeforeNow(25);
+        const failedAttempt = new TestAttemptRecord({ id: "att-1", score: 50, passed: false, takenAt });
+        const progress = makeProgress({
+            practiceCompletedAt: hoursBeforeNow(10),
+            testAttempts: [failedAttempt],
+        });
+        const config = makeMockConfig(progress.toBSON());
+        const delegate = new GetTestEligibility({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: NOW }, {} as any);
+
+        const expectedRetryAt = new Date(new Date(takenAt).getTime() + TEST_RETRY_DELAY_MINUTES * 60 * 1000).toISOString();
+
         assert.isTrue(result.eligible);
+        assert.equal(result.testRetryAvailableAt, expectedRetryAt, "testRetryAvailableAt must still be returned when eligible, for client display");
+        assert.isUndefined(result.remainingMs, "remainingMs must be absent when eligible");
     });
 
     it("returns not eligible when the module is already completed (OQ-03: no retakes)", async () => {
@@ -153,7 +202,7 @@ describe("GetTestEligibility.do", () => {
         assert.isFalse(result.eligible);
     });
 
-    it("ignores passed attempts when computing retry delay — only failed submitted attempts count", async () => {
+    it("ignores passed attempts — testRetryAvailableAt is absent when there are no failed attempts", async () => {
 
         const passedAttempt = new TestAttemptRecord({ id: "att-1", score: 90, passed: true, takenAt: minutesBeforeNow(5) });
         const progress = makeProgress({
@@ -163,13 +212,13 @@ describe("GetTestEligibility.do", () => {
         const config = makeMockConfig(progress.toBSON());
         const delegate = new GetTestEligibility({} as any, config);
 
-        // A passed attempt should not trigger the retry delay
         const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: NOW }, {} as any);
 
         assert.isTrue(result.eligible);
+        assert.isUndefined(result.testRetryAvailableAt, "testRetryAvailableAt must be absent when there are no failed attempts");
     });
 
-    it("uses the most recent failed attempt for the retry delay when multiple failed attempts exist", async () => {
+    it("uses the most recent failed attempt's takenAt when computing testRetryAvailableAt", async () => {
 
         // Two failed attempts — the more recent one is 10 min ago (delay 20 min → still locked)
         const olderFailed = new TestAttemptRecord({ id: "att-1", score: 50, passed: false, takenAt: minutesBeforeNow(30) });
@@ -183,6 +232,9 @@ describe("GetTestEligibility.do", () => {
 
         const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: NOW }, {} as any);
 
+        const expectedRetryAt = new Date(new Date(recentFailed.takenAt).getTime() + TEST_RETRY_DELAY_MINUTES * 60 * 1000).toISOString();
+
         assert.isFalse(result.eligible);
+        assert.equal(result.testRetryAvailableAt, expectedRetryAt, "must anchor to the most recent failed attempt, not the older one");
     });
 });

--- a/test/dlg/moduleTests/GetTestReview.do.test.ts
+++ b/test/dlg/moduleTests/GetTestReview.do.test.ts
@@ -1,0 +1,195 @@
+import { assert } from "chai";
+import { ObjectId } from "mongodb";
+import { GetTestReview } from "../../../src/dlg/moduleTests/GetTestReview";
+import { Exercise } from "../../../src/model/Exercise";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeExerciseBSON(id: string, answer: string): any {
+    return new Exercise({
+        id,
+        moduleId: "mod-1",
+        type: "translation_active",
+        prompt: `prompt-${id}`,
+        answer,
+        vocabularyItemId: "v-1",
+        grammarConceptId: null,
+    }).toBSON();
+}
+
+function makeAttemptBSON(oid: ObjectId, overrides: any = {}): any {
+    return {
+        _id: oid,
+        userId: "user-1",
+        moduleId: "mod-1",
+        exerciseIds: ["ex-1", "ex-2"],
+        answers: [
+            { exerciseId: "ex-1", isCorrect: true, userAnswer: "hej", answeredAt: "2026-06-11T10:00:00.000Z" },
+            { exerciseId: "ex-2", isCorrect: false, userAnswer: "forkert", answeredAt: "2026-06-11T10:01:00.000Z" },
+        ],
+        currentPosition: 2,
+        verifiedExerciseIds: [],
+        score: 50,
+        passed: false,
+        startedAt: "2026-06-11T09:00:00.000Z",
+        takenAt: "2026-06-11T10:05:00.000Z",
+        exerciseResults: [],
+        ...overrides,
+    };
+}
+
+function makeMockConfig(attemptDoc: any | null, exerciseDocs: any[]) {
+
+    const collections: Record<string, any> = {
+        moduleTestAttempts: {
+            findOne: async (filter: any) => {
+                if (!attemptDoc) return null;
+                if (filter._id) return attemptDoc._id.equals(filter._id) ? attemptDoc : null;
+                return null;
+            },
+        },
+        exercises: {
+            find: () => ({ toArray: async () => exerciseDocs }),
+        },
+    };
+
+    return {
+        getDBName: () => "test",
+        getMongoDb: async () => ({ collection: (name: string) => collections[name] }),
+    } as any;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GetTestReview.do", () => {
+
+    it("returns score, passed, and per-question results including correct answers", async () => {
+
+        const oid = new ObjectId();
+        const config = makeMockConfig(
+            makeAttemptBSON(oid),
+            [makeExerciseBSON("ex-1", "hej"), makeExerciseBSON("ex-2", "farvel")]
+        );
+        const delegate = new GetTestReview({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        assert.equal(result.score, 50);
+        assert.isFalse(result.passed);
+        assert.equal(result.questions.length, 2);
+    });
+
+    it("exposes the correct answer for every question in the review", async () => {
+
+        const oid = new ObjectId();
+        const config = makeMockConfig(
+            makeAttemptBSON(oid),
+            [makeExerciseBSON("ex-1", "hej"), makeExerciseBSON("ex-2", "farvel")]
+        );
+        const delegate = new GetTestReview({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        const q1 = result.questions.find(q => q.exerciseId === "ex-1")!;
+        const q2 = result.questions.find(q => q.exerciseId === "ex-2")!;
+
+        assert.equal(q1.correctAnswer, "hej");
+        assert.equal(q2.correctAnswer, "farvel");
+    });
+
+    it("includes the user's answer and marks incorrect answers on wrong questions", async () => {
+
+        const oid = new ObjectId();
+        const config = makeMockConfig(
+            makeAttemptBSON(oid),
+            [makeExerciseBSON("ex-1", "hej"), makeExerciseBSON("ex-2", "farvel")]
+        );
+        const delegate = new GetTestReview({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        const q2 = result.questions.find(q => q.exerciseId === "ex-2")!;
+
+        assert.isFalse(q2.isCorrect);
+        assert.equal(q2.userAnswer, "forkert");
+    });
+
+    it("marks unanswered exercises as incorrect with empty userAnswer in the review", async () => {
+
+        const oid = new ObjectId();
+        // Only ex-1 was answered; ex-2 was not
+        const attemptDoc = makeAttemptBSON(oid, {
+            answers: [{ exerciseId: "ex-1", isCorrect: true, userAnswer: "hej", answeredAt: "2026-06-11T10:00:00.000Z" }],
+        });
+        const config = makeMockConfig(attemptDoc, [makeExerciseBSON("ex-1", "hej"), makeExerciseBSON("ex-2", "farvel")]);
+        const delegate = new GetTestReview({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        const unanswered = result.questions.find(q => q.exerciseId === "ex-2")!;
+
+        assert.isNotNull(unanswered);
+        assert.isFalse(unanswered.isCorrect);
+        assert.equal(unanswered.userAnswer, "");
+    });
+
+    it("throws 404 when the attempt is not found", async () => {
+
+        const config = makeMockConfig(null, []);
+        const delegate = new GetTestReview({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", attemptId: new ObjectId().toString() }, {} as any);
+            assert.fail("Expected 404");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 404);
+        }
+    });
+
+    it("throws 400 when the attempt is not yet submitted (takenAt is null)", async () => {
+
+        const oid = new ObjectId();
+        const config = makeMockConfig(
+            makeAttemptBSON(oid, { takenAt: null, score: null, passed: null }),
+            [makeExerciseBSON("ex-1", "hej")]
+        );
+        const delegate = new GetTestReview({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+            assert.fail("Expected 400");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 400);
+        }
+    });
+
+    it("throws 403 when the attempt does not belong to the requesting user", async () => {
+
+        const oid = new ObjectId();
+        const config = makeMockConfig(
+            makeAttemptBSON(oid, { userId: "other-user" }),
+            []
+        );
+        const delegate = new GetTestReview({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+            assert.fail("Expected 403");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 403);
+        }
+    });
+});

--- a/test/dlg/moduleTests/StartModuleTest.do.test.ts
+++ b/test/dlg/moduleTests/StartModuleTest.do.test.ts
@@ -1,0 +1,274 @@
+import { assert } from "chai";
+import { ObjectId } from "mongodb";
+import { StartModuleTest } from "../../../src/dlg/moduleTests/StartModuleTest";
+import { Exercise } from "../../../src/model/Exercise";
+import { Module } from "../../../src/model/Module";
+import { UserModuleProgress, TestAttemptRecord } from "../../../src/model/UserModuleProgress";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeModule(overrides: Partial<ConstructorParameters<typeof Module>[0]> = {}): Module {
+    return new Module({
+        id: "mod-1",
+        title: "A1 Basics",
+        theme: "greetings",
+        communicationGoal: "greet people",
+        cefrLevel: "A1",
+        vocabularyItemIds: ["v-1", "v-2"],
+        grammarConceptIds: [],
+        practiceSessionSize: 4,
+        ...overrides,
+    });
+}
+
+function makeExercise(id: string, vocabId: string = "v-1"): Exercise {
+    return new Exercise({
+        id,
+        moduleId: "mod-1",
+        type: "translation_active",
+        prompt: `prompt-${id}`,
+        answer: `answer-${id}`,
+        vocabularyItemId: vocabId,
+        grammarConceptId: null,
+    });
+}
+
+function makeProgress(overrides: Partial<ConstructorParameters<typeof UserModuleProgress>[0]> = {}): UserModuleProgress {
+    return new UserModuleProgress({
+        userId: "user-1",
+        moduleId: "mod-1",
+        status: "in_progress",
+        startedAt: "2026-06-01T09:00:00.000Z",
+        completedAt: null,
+        testAttempts: [],
+        practiceCompletedAt: "2026-06-01T00:00:00.000Z", // long ago — unlocked
+        ...overrides,
+    });
+}
+
+/**
+ * Builds 22 distinct exercises (more than the 20-exercise draw) linked to 2 vocab items.
+ */
+function makeLargeExercisePool(): Exercise[] {
+    return Array.from({ length: 22 }, (_, i) => makeExercise(`ex-${i + 1}`, i % 2 === 0 ? "v-1" : "v-2"));
+}
+
+/**
+ * Builds a mock config that simulates:
+ * - modules collection returning moduleBSON on findOne
+ * - exercises collection returning exerciseBSONs on find
+ * - userModuleProgress collection returning progressBSON on findOne; replaceOne no-op
+ * - userVocabularyProgress / userGrammarProgress: empty (no mastery yet)
+ * - moduleTestAttempts: no active attempt (findOne returns null), insertOne returns an oid
+ */
+function makeMockConfig(moduleBSON: any, exerciseBSONs: any[], progressBSON: any | null, activeAttemptBSON: any | null = null) {
+
+    const insertedOid = new ObjectId();
+
+    const collections: Record<string, any> = {
+        modules: {
+            findOne: async () => moduleBSON,
+        },
+        exercises: {
+            find: () => ({ toArray: async () => exerciseBSONs }),
+        },
+        userModuleProgress: {
+            findOne: async () => progressBSON,
+            replaceOne: async () => ({ upsertedCount: 1 }),
+        },
+        userVocabularyProgress: {
+            find: () => ({ toArray: async () => [] }),
+        },
+        userGrammarProgress: {
+            find: () => ({ toArray: async () => [] }),
+        },
+        moduleTestAttempts: {
+            findOne: async () => activeAttemptBSON,
+            insertOne: async () => ({ insertedId: insertedOid }),
+        },
+    };
+
+    return {
+        getDBName: () => "test",
+        getMongoDb: async () => ({ collection: (name: string) => collections[name] }),
+    } as any;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("StartModuleTest.do", () => {
+
+    it("returns an attemptId, startedAt, and the selected exercises (without answers)", async () => {
+
+        const mod = makeModule();
+        const exercises = makeLargeExercisePool();
+        const progress = makeProgress();
+
+        const config = makeMockConfig(mod.toBSON(), exercises.map(e => e.toBSON()), progress.toBSON());
+        const delegate = new StartModuleTest({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: new Date("2026-06-11T14:00:00.000Z") }, {} as any);
+
+        assert.isString(result.attemptId);
+        assert.isString(result.startedAt);
+        assert.isArray(result.exercises);
+        assert.equal(result.exercises.length, 20);
+
+        // Answers must be stripped from exercises returned to the client
+        for (const ex of result.exercises) {
+            assert.isUndefined((ex as any).answer, "exercises must not expose the correct answer");
+        }
+    });
+
+    it("draws exactly 20 exercises when the pool is large enough", async () => {
+
+        const mod = makeModule();
+        const exercises = makeLargeExercisePool();
+        const progress = makeProgress();
+
+        const config = makeMockConfig(mod.toBSON(), exercises.map(e => e.toBSON()), progress.toBSON());
+        const delegate = new StartModuleTest({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", moduleId: "mod-1", now: new Date("2026-06-11T14:00:00.000Z") }, {} as any);
+
+        assert.equal(result.exercises.length, 20);
+    });
+
+    it("throws 409 with attemptId when an active attempt already exists", async () => {
+
+        const mod = makeModule();
+        const exercises = makeLargeExercisePool();
+        const progress = makeProgress();
+        const existingAttemptOid = new ObjectId();
+
+        const activeAttemptBSON = {
+            _id: existingAttemptOid,
+            userId: "user-1",
+            moduleId: "mod-1",
+            exerciseIds: [],
+            answers: [],
+            currentPosition: 0,
+            verifiedExerciseIds: [],
+            score: null,
+            passed: null,
+            startedAt: "2026-06-11T09:00:00.000Z",
+            takenAt: null,
+            exerciseResults: [],
+        };
+
+        const config = makeMockConfig(mod.toBSON(), exercises.map(e => e.toBSON()), progress.toBSON(), activeAttemptBSON);
+        const delegate = new StartModuleTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", moduleId: "mod-1", now: new Date("2026-06-11T14:00:00.000Z") }, {} as any);
+            assert.fail("Expected 409 error");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 409);
+            assert.equal(err.attemptId, existingAttemptOid.toString());
+        }
+    });
+
+    it("throws 404 when the module is not found", async () => {
+
+        const config = makeMockConfig(null, [], makeProgress().toBSON());
+        const delegate = new StartModuleTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", moduleId: "mod-1", now: new Date("2026-06-11T14:00:00.000Z") }, {} as any);
+            assert.fail("Expected 404 error");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 404);
+        }
+    });
+
+    it("throws 400 when practiceCompletedAt is null (Step 2 not complete)", async () => {
+
+        const mod = makeModule();
+        const progress = makeProgress({ practiceCompletedAt: null });
+
+        const config = makeMockConfig(mod.toBSON(), [], progress.toBSON());
+        const delegate = new StartModuleTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", moduleId: "mod-1", now: new Date("2026-06-11T14:00:00.000Z") }, {} as any);
+            assert.fail("Expected 400 error");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 400);
+        }
+    });
+
+    it("throws 400 when the unlock delay has not elapsed", async () => {
+
+        const mod = makeModule();
+        // practiceCompletedAt was 2 hours ago — unlock requires 4 hours
+        const twoHoursAgo = new Date(new Date("2026-06-11T14:00:00.000Z").getTime() - 2 * 60 * 60 * 1000).toISOString();
+        const progress = makeProgress({ practiceCompletedAt: twoHoursAgo });
+
+        const config = makeMockConfig(mod.toBSON(), [], progress.toBSON());
+        const delegate = new StartModuleTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", moduleId: "mod-1", now: new Date("2026-06-11T14:00:00.000Z") }, {} as any);
+            assert.fail("Expected 400 error");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 400);
+        }
+    });
+
+    it("throws 400 when the module is already completed (OQ-03: no retakes)", async () => {
+
+        const mod = makeModule();
+        const progress = makeProgress({ status: "completed" });
+
+        const config = makeMockConfig(mod.toBSON(), makeLargeExercisePool().map(e => e.toBSON()), progress.toBSON());
+        const delegate = new StartModuleTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", moduleId: "mod-1", now: new Date("2026-06-11T14:00:00.000Z") }, {} as any);
+            assert.fail("Expected 400 error");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 400);
+        }
+    });
+
+    it("throws 400 when the retry delay has not elapsed after a failed attempt", async () => {
+
+        const mod = makeModule();
+        // Failed attempt 10 minutes ago; retry delay is 20 minutes
+        const tenMinutesAgo = new Date(new Date("2026-06-11T14:00:00.000Z").getTime() - 10 * 60 * 1000).toISOString();
+        const failedAttempt = new TestAttemptRecord({ id: "att-1", score: 50, passed: false, takenAt: tenMinutesAgo });
+        const progress = makeProgress({ testAttempts: [failedAttempt] });
+
+        const config = makeMockConfig(mod.toBSON(), makeLargeExercisePool().map(e => e.toBSON()), progress.toBSON());
+        const delegate = new StartModuleTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", moduleId: "mod-1", now: new Date("2026-06-11T14:00:00.000Z") }, {} as any);
+            assert.fail("Expected 400 error");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 400);
+        }
+    });
+});

--- a/test/dlg/moduleTests/SubmitModuleTest.do.test.ts
+++ b/test/dlg/moduleTests/SubmitModuleTest.do.test.ts
@@ -1,0 +1,263 @@
+import { assert } from "chai";
+import { ObjectId } from "mongodb";
+import { SubmitModuleTest } from "../../../src/dlg/moduleTests/SubmitModuleTest";
+import { Exercise } from "../../../src/model/Exercise";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeExerciseBSON(id: string, vocabId: string = "v-1"): any {
+    return new Exercise({
+        id,
+        moduleId: "mod-1",
+        type: "translation_active",
+        prompt: `prompt-${id}`,
+        answer: `answer-${id}`,
+        vocabularyItemId: vocabId,
+        grammarConceptId: null,
+    }).toBSON();
+}
+
+/**
+ * Builds an attempt BSON with `count` exercises, `correctCount` of which are answered correctly.
+ */
+function makeAttemptBSON(oid: ObjectId, count: number, correctCount: number, overrides: any = {}): any {
+
+    const exerciseIds = Array.from({ length: count }, (_, i) => `ex-${i + 1}`);
+    const answers = exerciseIds.map((id, i) => ({
+        exerciseId: id,
+        isCorrect: i < correctCount,
+        userAnswer: "hej",
+        answeredAt: "2026-06-11T10:00:00.000Z",
+    }));
+
+    return {
+        _id: oid,
+        userId: "user-1",
+        moduleId: "mod-1",
+        exerciseIds,
+        answers,
+        currentPosition: count,
+        verifiedExerciseIds: [],
+        score: null,
+        passed: null,
+        startedAt: "2026-06-11T09:00:00.000Z",
+        takenAt: null,
+        exerciseResults: [],
+        ...overrides,
+    };
+}
+
+/**
+ * Builds a mock config wiring all collections needed by SubmitModuleTest.
+ * Records mutations for assertion.
+ */
+function makeMockConfig(attemptDoc: any | null, exerciseDocs: any[]) {
+
+    const mutations: any[] = [];
+    let currentAttempt: any = attemptDoc ? { ...attemptDoc } : null;
+
+    const exerciseMap = new Map(exerciseDocs.map((e: any) => [e.id, e]));
+
+    const collections: Record<string, any> = {
+        moduleTestAttempts: {
+            findOne: async (filter: any) => {
+                if (!currentAttempt) return null;
+                if (filter._id) return currentAttempt._id.equals(filter._id) ? currentAttempt : null;
+                return null;
+            },
+            updateOne: async (_filter: any, update: any) => {
+                if (!currentAttempt) return { matchedCount: 0 };
+                if (update.$set) Object.assign(currentAttempt, update.$set);
+                mutations.push({ op: "submitAttempt", update });
+                return { matchedCount: 1 };
+            },
+        },
+        exercises: {
+            find: (_filter: any) => ({ toArray: async () => exerciseDocs }),
+        },
+        userModuleProgress: {
+            findOne: async () => ({
+                userId: "user-1",
+                moduleId: "mod-1",
+                status: "in_progress",
+                startedAt: "2026-06-01T09:00:00.000Z",
+                completedAt: null,
+                vocabularyItemsPracticed: [],
+                practiceCompletedAt: "2026-06-01T00:00:00.000Z",
+                testAttempts: [],
+            }),
+            replaceOne: async (_f: any, doc: any) => {
+                mutations.push({ op: "upsertProgress", doc });
+                return { upsertedCount: 1 };
+            },
+            updateOne: async (_filter: any, update: any) => {
+                mutations.push({ op: "appendTestAttempt", update });
+                return { matchedCount: 1 };
+            },
+        },
+        userVocabularyProgress: {
+            findOne: async () => null,
+            replaceOne: async (_f: any, doc: any) => {
+                mutations.push({ op: "upsertVocabProgress", doc });
+                return { upsertedCount: 1 };
+            },
+        },
+        userGrammarProgress: {
+            findOne: async () => null,
+            replaceOne: async () => ({ upsertedCount: 1 }),
+        },
+    };
+
+    return {
+        config: {
+            getDBName: () => "test",
+            getMongoDb: async () => ({ collection: (name: string) => collections[name] }),
+        } as any,
+        mutations,
+        getCurrentAttempt: () => currentAttempt,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SubmitModuleTest.do", () => {
+
+    it("computes a passing score (100%) when all exercises are answered correctly", async () => {
+
+        const oid = new ObjectId();
+        const exercises = Array.from({ length: 20 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const { config } = makeMockConfig(makeAttemptBSON(oid, 20, 20), exercises);
+        const delegate = new SubmitModuleTest({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        assert.equal(result.score, 100);
+        assert.isTrue(result.passed);
+    });
+
+    it("computes a failing score when fewer than 80% are correct", async () => {
+
+        const oid = new ObjectId();
+        // 15 correct out of 20 = 75% → fail
+        const exercises = Array.from({ length: 20 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const { config } = makeMockConfig(makeAttemptBSON(oid, 20, 15), exercises);
+        const delegate = new SubmitModuleTest({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        assert.equal(result.score, 75);
+        assert.isFalse(result.passed);
+    });
+
+    it("counts unanswered exercises as wrong when computing the score", async () => {
+
+        const oid = new ObjectId();
+        // 10 exercises, 8 answered and all correct, 2 unanswered → score = 8/10 = 80%
+        const exercises = Array.from({ length: 10 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const attemptDoc = makeAttemptBSON(oid, 10, 8);
+        // Remove the last 2 answers to simulate unanswered exercises
+        attemptDoc.answers = attemptDoc.answers.slice(0, 8);
+
+        const { config } = makeMockConfig(attemptDoc, exercises);
+        const delegate = new SubmitModuleTest({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        assert.equal(result.score, 80);
+        assert.isTrue(result.passed);
+    });
+
+    it("persists the score, passed flag, and takenAt on the attempt", async () => {
+
+        const oid = new ObjectId();
+        const exercises = Array.from({ length: 20 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const { config, mutations, getCurrentAttempt } = makeMockConfig(makeAttemptBSON(oid, 20, 16), exercises);
+        const delegate = new SubmitModuleTest({} as any, config);
+
+        await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        const submitted = getCurrentAttempt();
+        assert.isNumber(submitted.score);
+        assert.isBoolean(submitted.passed);
+        assert.isString(submitted.takenAt);
+
+        assert.isTrue(mutations.some(m => m.op === "submitAttempt"));
+    });
+
+    it("records a TestAttemptRecord summary in UserModuleProgress.testAttempts", async () => {
+
+        const oid = new ObjectId();
+        const exercises = Array.from({ length: 20 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const { config, mutations } = makeMockConfig(makeAttemptBSON(oid, 20, 18), exercises);
+        const delegate = new SubmitModuleTest({} as any, config);
+
+        await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        assert.isTrue(mutations.some(m => m.op === "appendTestAttempt"));
+    });
+
+    it("transitions the module to completed on a passing score", async () => {
+
+        const oid = new ObjectId();
+        const exercises = Array.from({ length: 20 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const { config, mutations } = makeMockConfig(makeAttemptBSON(oid, 20, 20), exercises);
+        const delegate = new SubmitModuleTest({} as any, config);
+
+        await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        const progressTransition = mutations.find(m => m.op === "upsertProgress" && m.doc?.status === "completed");
+        assert.isTrue(!!progressTransition, "expected module to be transitioned to completed");
+    });
+
+    it("does NOT transition the module to completed on a failing score", async () => {
+
+        const oid = new ObjectId();
+        // 14/20 = 70% → fail
+        const exercises = Array.from({ length: 20 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const { config, mutations } = makeMockConfig(makeAttemptBSON(oid, 20, 14), exercises);
+        const delegate = new SubmitModuleTest({} as any, config);
+
+        await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        const completedTransition = mutations.find(m => m.op === "upsertProgress" && m.doc?.status === "completed");
+        assert.isFalse(!!completedTransition, "module must NOT be transitioned to completed on a fail");
+    });
+
+    it("throws 404 when the attempt does not exist", async () => {
+
+        const { config } = makeMockConfig(null, []);
+        const delegate = new SubmitModuleTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", attemptId: new ObjectId().toString() }, {} as any);
+            assert.fail("Expected 404");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 404);
+        }
+    });
+
+    it("throws 400 when the attempt is already submitted", async () => {
+
+        const oid = new ObjectId();
+        const exercises = Array.from({ length: 5 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const { config } = makeMockConfig(makeAttemptBSON(oid, 5, 5, { takenAt: "2026-06-11T11:00:00.000Z" }), exercises);
+        const delegate = new SubmitModuleTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+            assert.fail("Expected 400");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 400);
+        }
+    });
+});

--- a/test/dlg/moduleTests/SubmitTestAnswer.do.test.ts
+++ b/test/dlg/moduleTests/SubmitTestAnswer.do.test.ts
@@ -1,0 +1,215 @@
+import { assert } from "chai";
+import { ObjectId } from "mongodb";
+import { SubmitTestAnswer } from "../../../src/dlg/moduleTests/SubmitTestAnswer";
+import { Exercise } from "../../../src/model/Exercise";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeExerciseBSON(id: string, answer: string, alternatives: string[] = []): any {
+    return new Exercise({
+        id,
+        moduleId: "mod-1",
+        type: "translation_active",
+        prompt: `prompt-${id}`,
+        answer,
+        alternativeAnswers: alternatives,
+        userContributedAnswers: [],
+        vocabularyItemId: "v-1",
+    }).toBSON();
+}
+
+function makeAttemptBSON(oid: ObjectId, overrides: any = {}): any {
+    return {
+        _id: oid,
+        userId: "user-1",
+        moduleId: "mod-1",
+        exerciseIds: ["ex-1", "ex-2"],
+        answers: [],
+        currentPosition: 0,
+        verifiedExerciseIds: [],
+        score: null,
+        passed: null,
+        startedAt: "2026-06-11T09:00:00.000Z",
+        takenAt: null,
+        exerciseResults: [],
+        ...overrides,
+    };
+}
+
+function makeMockConfig(attemptDoc: any | null, exerciseDoc: any | null) {
+
+    const mutations: string[] = [];
+    let currentAttempt: any = attemptDoc ? { ...attemptDoc } : null;
+
+    const collections: Record<string, any> = {
+        moduleTestAttempts: {
+            findOne: async (filter: any) => {
+                if (!currentAttempt) return null;
+                if (filter._id) return currentAttempt._id.equals(filter._id) ? currentAttempt : null;
+                return null;
+            },
+            updateOne: async (_filter: any, update: any) => {
+                if (!currentAttempt) return { matchedCount: 0 };
+                if (update.$push?.answers) {
+                    currentAttempt.answers = [...(currentAttempt.answers ?? []), update.$push.answers];
+                    mutations.push("appendAnswer");
+                }
+                if (update.$inc?.currentPosition !== undefined) {
+                    currentAttempt.currentPosition = (currentAttempt.currentPosition ?? 0) + 1;
+                    mutations.push("advancePosition");
+                }
+                return { matchedCount: 1 };
+            },
+        },
+        exercises: {
+            findOne: async () => exerciseDoc,
+            updateOne: async () => {
+                mutations.push("incrementTimesShown");
+                return { matchedCount: 1 };
+            },
+        },
+    };
+
+    return {
+        config: {
+            getDBName: () => "test",
+            getMongoDb: async () => ({ collection: (name: string) => collections[name] }),
+        } as any,
+        mutations,
+        getCurrentAttempt: () => currentAttempt,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SubmitTestAnswer.do", () => {
+
+    it("marks the answer correct, advances cursor, and increments timesShown", async () => {
+
+        const oid = new ObjectId();
+        const { config, mutations } = makeMockConfig(makeAttemptBSON(oid), makeExerciseBSON("ex-1", "hej"));
+        const delegate = new SubmitTestAnswer({} as any, config);
+
+        const result = await delegate.do(
+            { userId: "user-1", attemptId: oid.toString(), exerciseId: "ex-1", userAnswer: "hej" },
+            {} as any
+        );
+
+        assert.isTrue(result.isCorrect);
+        assert.equal(result.correctAnswer, "hej");
+        assert.include(mutations, "appendAnswer");
+        assert.include(mutations, "advancePosition");
+        assert.include(mutations, "incrementTimesShown");
+    });
+
+    it("marks the answer incorrect and returns the correct answer as immediate feedback", async () => {
+
+        const oid = new ObjectId();
+        const { config, mutations } = makeMockConfig(makeAttemptBSON(oid), makeExerciseBSON("ex-1", "hej"));
+        const delegate = new SubmitTestAnswer({} as any, config);
+
+        const result = await delegate.do(
+            { userId: "user-1", attemptId: oid.toString(), exerciseId: "ex-1", userAnswer: "farvel" },
+            {} as any
+        );
+
+        assert.isFalse(result.isCorrect);
+        assert.equal(result.correctAnswer, "hej");
+        assert.include(mutations, "appendAnswer");
+        assert.include(mutations, "advancePosition");
+    });
+
+    it("does NOT add to any retry queue — first answer is final", async () => {
+
+        const oid = new ObjectId();
+        const { config, mutations } = makeMockConfig(makeAttemptBSON(oid), makeExerciseBSON("ex-1", "hej"));
+        const delegate = new SubmitTestAnswer({} as any, config);
+
+        await delegate.do(
+            { userId: "user-1", attemptId: oid.toString(), exerciseId: "ex-1", userAnswer: "farvel" },
+            {} as any
+        );
+
+        assert.notInclude(mutations, "addToRetryQueue");
+    });
+
+    it("accepts alternative answers as correct", async () => {
+
+        const oid = new ObjectId();
+        const { config } = makeMockConfig(makeAttemptBSON(oid), makeExerciseBSON("ex-1", "hej", ["goddag"]));
+        const delegate = new SubmitTestAnswer({} as any, config);
+
+        const result = await delegate.do(
+            { userId: "user-1", attemptId: oid.toString(), exerciseId: "ex-1", userAnswer: "Goddag" },
+            {} as any
+        );
+
+        assert.isTrue(result.isCorrect);
+    });
+
+    it("throws 404 when the attempt does not exist", async () => {
+
+        const { config } = makeMockConfig(null, makeExerciseBSON("ex-1", "hej"));
+        const delegate = new SubmitTestAnswer({} as any, config);
+
+        try {
+
+            await delegate.do(
+                { userId: "user-1", attemptId: new ObjectId().toString(), exerciseId: "ex-1", userAnswer: "hej" },
+                {} as any
+            );
+            assert.fail("Expected 404");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 404);
+        }
+    });
+
+    it("throws 400 when the attempt is already submitted (takenAt set)", async () => {
+
+        const oid = new ObjectId();
+        const { config } = makeMockConfig(
+            makeAttemptBSON(oid, { takenAt: "2026-06-11T11:00:00.000Z" }),
+            makeExerciseBSON("ex-1", "hej")
+        );
+        const delegate = new SubmitTestAnswer({} as any, config);
+
+        try {
+
+            await delegate.do(
+                { userId: "user-1", attemptId: oid.toString(), exerciseId: "ex-1", userAnswer: "hej" },
+                {} as any
+            );
+            assert.fail("Expected 400");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 400);
+        }
+    });
+
+    it("throws 400 when the exerciseId is not part of the attempt", async () => {
+
+        const oid = new ObjectId();
+        const { config } = makeMockConfig(makeAttemptBSON(oid), makeExerciseBSON("ex-99", "hej"));
+        const delegate = new SubmitTestAnswer({} as any, config);
+
+        try {
+
+            await delegate.do(
+                { userId: "user-1", attemptId: oid.toString(), exerciseId: "ex-99", userAnswer: "hej" },
+                {} as any
+            );
+            assert.fail("Expected 400");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 400);
+        }
+    });
+});

--- a/test/dlg/user/GetMeProgress.test.ts
+++ b/test/dlg/user/GetMeProgress.test.ts
@@ -2,7 +2,7 @@
 import { Request } from "express";
 import { User } from "../../../src/model/User";
 import { Module } from "../../../src/model/Module";
-import { UserModuleProgress, ModuleTestAttempt } from "../../../src/model/UserModuleProgress";
+import { UserModuleProgress, TestAttemptRecord } from "../../../src/model/UserModuleProgress";
 import { GetMeProgress } from "../../../src/dlg/user/GetMeProgress";
 
 const userContext = { email: "alice@example.com", userId: "u1", authProvider: "test" };
@@ -23,7 +23,7 @@ function makeProgress(moduleId: string, status: string, overrides: Partial<{
     startedAt: string | null;
     completedAt: string | null;
     practiceCompletedAt: string | null;
-    testAttempts: ModuleTestAttempt[];
+    testAttempts: TestAttemptRecord[];
 }> = {}): UserModuleProgress {
     return new UserModuleProgress({
         userId: "uuid-001", moduleId, status: status as any,
@@ -32,8 +32,8 @@ function makeProgress(moduleId: string, status: string, overrides: Partial<{
     });
 }
 
-function makeAttempt(passed: boolean, takenAt: string): ModuleTestAttempt {
-    return new ModuleTestAttempt({ id: "att-1", score: passed ? 90 : 50, passed, takenAt });
+function makeAttempt(passed: boolean, takenAt: string): TestAttemptRecord {
+    return new TestAttemptRecord({ id: "att-1", score: passed ? 90 : 50, passed, takenAt });
 }
 
 /**

--- a/test/model/ModuleTestAttempt.model.test.ts
+++ b/test/model/ModuleTestAttempt.model.test.ts
@@ -1,0 +1,101 @@
+import { strict as assert } from "assert";
+import { ObjectId } from "mongodb";
+import { ModuleTestAttempt } from "../../src/model/ModuleTestAttempt";
+import { ExerciseResult } from "../../src/model/ExerciseResult";
+
+function makeResult(exerciseId: string, isCorrect: boolean): ExerciseResult {
+    return new ExerciseResult({
+        exerciseId,
+        type: "translation_active",
+        isCorrect,
+        userAnswer: "hej",
+        correctAnswer: "hej",
+        timestamp: "2026-06-11T10:00:00.000Z",
+        moduleId: "mod-1",
+    });
+}
+
+describe("ModuleTestAttempt.fromBSON", () => {
+
+    it("round-trips all fields through toBSON / fromBSON", () => {
+
+        const oid = new ObjectId();
+
+        const attempt = new ModuleTestAttempt({
+            userId: "user-1",
+            moduleId: "mod-1",
+            exerciseIds: ["ex-1", "ex-2"],
+            answers: [{ exerciseId: "ex-1", isCorrect: true, userAnswer: "hej", answeredAt: "2026-06-11T10:00:00.000Z" }],
+            currentPosition: 1,
+            verifiedExerciseIds: [],
+            score: null,
+            passed: null,
+            startedAt: "2026-06-11T09:00:00.000Z",
+            takenAt: null,
+            exerciseResults: [],
+        });
+
+        // Simulate a round-trip through MongoDB (fromBSON expects a WithId doc)
+        const bson = { _id: oid, ...attempt.toBSON() };
+        const result = ModuleTestAttempt.fromBSON(bson as any);
+
+        assert.equal(result.id, oid.toString());
+        assert.equal(result.userId, "user-1");
+        assert.equal(result.moduleId, "mod-1");
+        assert.deepEqual(result.exerciseIds, ["ex-1", "ex-2"]);
+        assert.equal(result.answers.length, 1);
+        assert.equal(result.answers[0].exerciseId, "ex-1");
+        assert.equal(result.currentPosition, 1);
+        assert.deepEqual(result.verifiedExerciseIds, []);
+        assert.equal(result.score, null);
+        assert.equal(result.passed, null);
+        assert.equal(result.startedAt, "2026-06-11T09:00:00.000Z");
+        assert.equal(result.takenAt, null);
+    });
+
+    it("round-trips a submitted attempt with score and passed", () => {
+
+        const oid = new ObjectId();
+        const attempt = new ModuleTestAttempt({
+            userId: "user-1",
+            moduleId: "mod-1",
+            exerciseIds: ["ex-1"],
+            startedAt: "2026-06-11T09:00:00.000Z",
+            score: 85,
+            passed: true,
+            takenAt: "2026-06-11T10:00:00.000Z",
+            exerciseResults: [makeResult("ex-1", true)],
+        });
+
+        const bson = { _id: oid, ...attempt.toBSON() };
+        const result = ModuleTestAttempt.fromBSON(bson as any);
+
+        assert.equal(result.score, 85);
+        assert.equal(result.passed, true);
+        assert.equal(result.takenAt, "2026-06-11T10:00:00.000Z");
+        assert.equal(result.exerciseResults.length, 1);
+        assert.equal(result.exerciseResults[0].exerciseId, "ex-1");
+    });
+
+    it("defaults arrays and position when absent from the document", () => {
+
+        const oid = new ObjectId();
+        const doc: any = {
+            _id: oid,
+            userId: "user-1",
+            moduleId: "mod-1",
+            startedAt: "2026-06-11T09:00:00.000Z",
+        };
+
+        const result = ModuleTestAttempt.fromBSON(doc);
+
+        assert.deepEqual(result.exerciseIds, []);
+        assert.deepEqual(result.answers, []);
+        assert.equal(result.currentPosition, 0);
+        assert.deepEqual(result.verifiedExerciseIds, []);
+        assert.equal(result.score, null);
+        assert.equal(result.passed, null);
+        assert.equal(result.takenAt, null);
+        assert.deepEqual(result.exerciseResults, []);
+    });
+});

--- a/test/model/UserModuleProgress.model.test.ts
+++ b/test/model/UserModuleProgress.model.test.ts
@@ -1,11 +1,11 @@
 import { strict as assert } from "assert";
-import { ModuleTestAttempt, UserModuleProgress } from "../../src/model/UserModuleProgress";
+import { TestAttemptRecord, UserModuleProgress } from "../../src/model/UserModuleProgress";
 
-describe("ModuleTestAttempt.fromBSON", () => {
+describe("TestAttemptRecord.fromBSON", () => {
 
     it("round-trips all fields through toBSON and fromBSON", () => {
-        const attempt = new ModuleTestAttempt({ id: "att-1", score: 85, passed: true, takenAt: "2026-06-01T10:00:00.000Z" });
-        const result = ModuleTestAttempt.fromBSON(attempt.toBSON());
+        const attempt = new TestAttemptRecord({ id: "att-1", score: 85, passed: true, takenAt: "2026-06-01T10:00:00.000Z" });
+        const result = TestAttemptRecord.fromBSON(attempt.toBSON());
 
         assert.equal(result.id, "att-1");
         assert.equal(result.score, 85);
@@ -14,8 +14,8 @@ describe("ModuleTestAttempt.fromBSON", () => {
     });
 
     it("preserves a failed attempt", () => {
-        const attempt = new ModuleTestAttempt({ id: "att-2", score: 40, passed: false, takenAt: "2026-06-02T08:00:00.000Z" });
-        const result = ModuleTestAttempt.fromBSON(attempt.toBSON());
+        const attempt = new TestAttemptRecord({ id: "att-2", score: 40, passed: false, takenAt: "2026-06-02T08:00:00.000Z" });
+        const result = TestAttemptRecord.fromBSON(attempt.toBSON());
 
         assert.equal(result.passed, false);
         assert.equal(result.score, 40);
@@ -57,7 +57,7 @@ describe("UserModuleProgress.fromBSON", () => {
     });
 
     it("round-trips embedded testAttempts", () => {
-        const attempt = new ModuleTestAttempt({ id: "att-1", score: 90, passed: true, takenAt: "2026-06-03T12:00:00.000Z" });
+        const attempt = new TestAttemptRecord({ id: "att-1", score: 90, passed: true, takenAt: "2026-06-03T12:00:00.000Z" });
         const progress = new UserModuleProgress({
             userId: "user-1",
             moduleId: "mod-1",

--- a/test/store/ModuleTestAttemptStore.test.ts
+++ b/test/store/ModuleTestAttemptStore.test.ts
@@ -50,7 +50,14 @@ function makeMockCollection(initialDocs: any[] = []) {
             return docs.find(d => Object.keys(filter).every(k => d[k] === filter[k])) ?? null;
         },
         updateOne: async (filter: any, update: any) => {
-            const doc = docs.find(d => filter._id ? d._id.equals(filter._id) : Object.keys(filter).every(k => d[k] === filter[k]));
+            const doc = docs.find(d => filter._id ? d._id.equals(filter._id) : Object.keys(filter).every(k => {
+                if (k.includes('.')) {
+                    // nested filter like "answers.exerciseId": "ex-1"
+                    const [field, subField] = k.split('.');
+                    return Array.isArray(d[field]) && d[field].some((item: any) => item[subField] === filter[k]);
+                }
+                return d[k] === filter[k];
+            }));
             if (!doc) return { matchedCount: 0 };
             if (update.$push) {
                 for (const [field, value] of Object.entries(update.$push as Record<string, any>)) {
@@ -64,7 +71,20 @@ function makeMockCollection(initialDocs: any[] = []) {
             }
             if (update.$set) {
                 for (const [field, value] of Object.entries(update.$set as Record<string, any>)) {
-                    doc[field] = value;
+                    // Handle positional operator e.g. "answers.$.isCorrect"
+                    const positional = field.match(/^(\w+)\.\$\.(.+)$/);
+                    if (positional) {
+                        const [, arrayField, subField] = positional;
+                        const arrayMatchKey = Object.keys(filter).find(k => k.startsWith(`${arrayField}.`));
+                        if (arrayMatchKey) {
+                            const matchSubField = arrayMatchKey.split('.')[1];
+                            const matchValue = filter[arrayMatchKey];
+                            const item = (doc[arrayField] ?? []).find((x: any) => x[matchSubField] === matchValue);
+                            if (item) item[subField] = value;
+                        }
+                    } else {
+                        doc[field] = value;
+                    }
                 }
             }
             return { matchedCount: 1 };

--- a/test/store/ModuleTestAttemptStore.test.ts
+++ b/test/store/ModuleTestAttemptStore.test.ts
@@ -1,0 +1,237 @@
+import { assert } from "chai";
+import { ObjectId } from "mongodb";
+import { ModuleTestAttempt, TestAnswer } from "../../src/model/ModuleTestAttempt";
+import { ExerciseResult } from "../../src/model/ExerciseResult";
+import { ModuleTestAttemptStore } from "../../src/store/ModuleTestAttemptStore";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAttempt(overrides: Partial<ConstructorParameters<typeof ModuleTestAttempt>[0]> = {}): ModuleTestAttempt {
+    return new ModuleTestAttempt({
+        userId: "user-1",
+        moduleId: "mod-1",
+        exerciseIds: ["ex-1", "ex-2", "ex-3"],
+        answers: [],
+        currentPosition: 0,
+        verifiedExerciseIds: [],
+        score: null,
+        passed: null,
+        startedAt: "2026-06-11T09:00:00.000Z",
+        takenAt: null,
+        exerciseResults: [],
+        ...overrides,
+    });
+}
+
+function makeAnswer(exerciseId: string, isCorrect = true): TestAnswer {
+    return { exerciseId, isCorrect, userAnswer: "hej", answeredAt: "2026-06-11T10:00:00.000Z" };
+}
+
+/**
+ * Builds an in-memory mock collection for the moduleTestAttempts collection.
+ * Supports: insertOne, findOne, updateOne.
+ * Stores documents in a mutable `docs` array for inspection.
+ */
+function makeMockCollection(initialDocs: any[] = []) {
+
+    const docs = [...initialDocs];
+
+    return {
+        docs,
+        insertOne: async (doc: any) => {
+            const oid = new ObjectId();
+            docs.push({ _id: oid, ...doc });
+            return { insertedId: oid };
+        },
+        findOne: async (filter: any) => {
+            if (filter._id) return docs.find(d => d._id.equals(filter._id)) ?? null;
+            return docs.find(d => Object.keys(filter).every(k => d[k] === filter[k])) ?? null;
+        },
+        updateOne: async (filter: any, update: any) => {
+            const doc = docs.find(d => filter._id ? d._id.equals(filter._id) : Object.keys(filter).every(k => d[k] === filter[k]));
+            if (!doc) return { matchedCount: 0 };
+            if (update.$push) {
+                for (const [field, value] of Object.entries(update.$push as Record<string, any>)) {
+                    doc[field] = [...(doc[field] ?? []), value];
+                }
+            }
+            if (update.$inc) {
+                for (const [field, delta] of Object.entries(update.$inc as Record<string, any>)) {
+                    doc[field] = (doc[field] ?? 0) + delta;
+                }
+            }
+            if (update.$set) {
+                for (const [field, value] of Object.entries(update.$set as Record<string, any>)) {
+                    doc[field] = value;
+                }
+            }
+            return { matchedCount: 1 };
+        },
+    };
+}
+
+function makeMockDb(collection: any) {
+    return { collection: () => collection } as any;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ModuleTestAttemptStore.create", () => {
+
+    it("inserts the attempt and returns the generated _id as a string", async () => {
+
+        const col = makeMockCollection();
+        const store = new ModuleTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+
+        const id = await store.create(makeAttempt());
+
+        assert.isString(id);
+        assert.equal(id.length, 24);
+        assert.equal(col.docs.length, 1);
+    });
+});
+
+describe("ModuleTestAttemptStore.findById", () => {
+
+    it("returns the matching attempt when it exists", async () => {
+
+        const col = makeMockCollection();
+        const store = new ModuleTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+        const id = await store.create(makeAttempt());
+
+        const found = await store.findById(id);
+
+        assert.isNotNull(found);
+        assert.equal(found!.id, id);
+        assert.equal(found!.userId, "user-1");
+    });
+
+    it("returns null when no attempt has the given id", async () => {
+
+        const col = makeMockCollection();
+        const store = new ModuleTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+
+        const found = await store.findById(new ObjectId().toString());
+
+        assert.isNull(found);
+    });
+});
+
+describe("ModuleTestAttemptStore.findActiveByUserAndModule", () => {
+
+    it("returns an in-progress attempt (takenAt is null)", async () => {
+
+        const col = makeMockCollection();
+        const store = new ModuleTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+        const id = await store.create(makeAttempt({ userId: "user-1", moduleId: "mod-1", takenAt: null }));
+
+        const found = await store.findActiveByUserAndModule("user-1", "mod-1");
+
+        assert.isNotNull(found);
+        assert.equal(found!.id, id);
+    });
+
+    it("returns null when no in-progress attempt exists", async () => {
+
+        const col = makeMockCollection();
+        const store = new ModuleTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+
+        const found = await store.findActiveByUserAndModule("user-1", "mod-1");
+
+        assert.isNull(found);
+    });
+});
+
+describe("ModuleTestAttemptStore.appendAnswer", () => {
+
+    it("pushes the answer to the answers array", async () => {
+
+        const col = makeMockCollection();
+        const store = new ModuleTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+        const id = await store.create(makeAttempt());
+        const answer = makeAnswer("ex-1", true);
+
+        await store.appendAnswer(id, answer);
+
+        const doc = col.docs[0];
+        assert.equal(doc.answers.length, 1);
+        assert.equal(doc.answers[0].exerciseId, "ex-1");
+        assert.equal(doc.answers[0].isCorrect, true);
+    });
+});
+
+describe("ModuleTestAttemptStore.advancePosition", () => {
+
+    it("increments currentPosition by 1", async () => {
+
+        const col = makeMockCollection();
+        const store = new ModuleTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+        const id = await store.create(makeAttempt({ currentPosition: 0 }));
+
+        await store.advancePosition(id);
+
+        const doc = col.docs[0];
+        assert.equal(doc.currentPosition, 1);
+    });
+});
+
+describe("ModuleTestAttemptStore.addVerifiedExerciseId", () => {
+
+    it("pushes the exerciseId to verifiedExerciseIds", async () => {
+
+        const col = makeMockCollection();
+        const store = new ModuleTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+        const id = await store.create(makeAttempt());
+
+        await store.addVerifiedExerciseId(id, "ex-1");
+
+        const doc = col.docs[0];
+        assert.deepEqual(doc.verifiedExerciseIds, ["ex-1"]);
+    });
+});
+
+describe("ModuleTestAttemptStore.flipAnswerToCorrect", () => {
+
+    it("sets isCorrect=true on the matching answer entry in the answers array", async () => {
+
+        const oid = new ObjectId();
+        const existingDoc = {
+            _id: oid,
+            ...makeAttempt({
+                answers: [{ exerciseId: "ex-1", isCorrect: false, userAnswer: "forkert", answeredAt: "2026-06-11T10:00:00.000Z" }],
+            }).toBSON(),
+        };
+
+        const col = makeMockCollection([existingDoc]);
+        const store = new ModuleTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+
+        await store.flipAnswerToCorrect(oid.toString(), "ex-1");
+
+        const doc = col.docs[0];
+        assert.equal(doc.answers[0].isCorrect, true);
+    });
+});
+
+describe("ModuleTestAttemptStore.submit", () => {
+
+    it("sets score, passed, takenAt, and exerciseResults on the attempt", async () => {
+
+        const col = makeMockCollection();
+        const store = new ModuleTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+        const id = await store.create(makeAttempt());
+
+        const exerciseResults = [new ExerciseResult({ exerciseId: "ex-1", type: "translation_active", isCorrect: true, userAnswer: "hej", correctAnswer: "hej", timestamp: "2026-06-11T10:00:00.000Z", moduleId: "mod-1" })];
+
+        await store.submit(id, { score: 80, passed: true, takenAt: "2026-06-11T11:00:00.000Z", exerciseResults });
+
+        const doc = col.docs[0];
+        assert.equal(doc.score, 80);
+        assert.equal(doc.passed, true);
+        assert.equal(doc.takenAt, "2026-06-11T11:00:00.000Z");
+        assert.equal(doc.exerciseResults.length, 1);
+    });
+});

--- a/test/store/UserModuleProgressStore.appendTestAttempt.test.ts
+++ b/test/store/UserModuleProgressStore.appendTestAttempt.test.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import { UserModuleProgress, ModuleTestAttempt } from "../../src/model/UserModuleProgress";
+import { UserModuleProgress, TestAttemptRecord } from "../../src/model/UserModuleProgress";
 import { UserModuleProgressStore } from "../../src/store/UserModuleProgressStore";
 
 function makeProgress(overrides: Partial<ConstructorParameters<typeof UserModuleProgress>[0]> = {}): UserModuleProgress {
@@ -41,7 +41,7 @@ describe("UserModuleProgressStore.appendTestAttempt", () => {
     it("appends the attempt to testAttempts and returns the updated record", async () => {
         const docs = [makeProgress().toBSON()];
         const store = new UserModuleProgressStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });
-        const attempt = new ModuleTestAttempt({ id: "att-1", score: 85, passed: true, takenAt: "2026-06-02T10:00:00.000Z" });
+        const attempt = new TestAttemptRecord({ id: "att-1", score: 85, passed: true, takenAt: "2026-06-02T10:00:00.000Z" });
 
         const result = await store.appendTestAttempt("user-1", "mod-1", attempt);
 
@@ -52,10 +52,10 @@ describe("UserModuleProgressStore.appendTestAttempt", () => {
     });
 
     it("accumulates multiple attempts", async () => {
-        const firstAttempt = new ModuleTestAttempt({ id: "att-1", score: 50, passed: false, takenAt: "2026-06-01T10:00:00.000Z" });
+        const firstAttempt = new TestAttemptRecord({ id: "att-1", score: 50, passed: false, takenAt: "2026-06-01T10:00:00.000Z" });
         const docs = [makeProgress({ testAttempts: [firstAttempt] }).toBSON()];
         const store = new UserModuleProgressStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });
-        const secondAttempt = new ModuleTestAttempt({ id: "att-2", score: 90, passed: true, takenAt: "2026-06-02T10:00:00.000Z" });
+        const secondAttempt = new TestAttemptRecord({ id: "att-2", score: 90, passed: true, takenAt: "2026-06-02T10:00:00.000Z" });
 
         const result = await store.appendTestAttempt("user-1", "mod-1", secondAttempt);
 
@@ -64,7 +64,7 @@ describe("UserModuleProgressStore.appendTestAttempt", () => {
 
     it("returns null when no progress record exists", async () => {
         const store = new UserModuleProgressStore({ db: makeMockDb(makeMockCollection([])), config: {} as any });
-        const attempt = new ModuleTestAttempt({ id: "att-1", score: 85, passed: true, takenAt: "2026-06-02T10:00:00.000Z" });
+        const attempt = new TestAttemptRecord({ id: "att-1", score: 85, passed: true, takenAt: "2026-06-02T10:00:00.000Z" });
 
         const result = await store.appendTestAttempt("user-1", "mod-1", attempt);
 

--- a/test/store/UserModuleProgressStore.read.test.ts
+++ b/test/store/UserModuleProgressStore.read.test.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import { UserModuleProgress, ModuleTestAttempt } from "../../src/model/UserModuleProgress";
+import { UserModuleProgress, TestAttemptRecord } from "../../src/model/UserModuleProgress";
 import { UserModuleProgressStore } from "../../src/store/UserModuleProgressStore";
 
 function makeProgress(overrides: Partial<ConstructorParameters<typeof UserModuleProgress>[0]> = {}): UserModuleProgress {

--- a/test/store/UserModuleProgressStore.transitionStatus.test.ts
+++ b/test/store/UserModuleProgressStore.transitionStatus.test.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import { UserModuleProgress, ModuleTestAttempt } from "../../src/model/UserModuleProgress";
+import { UserModuleProgress, TestAttemptRecord } from "../../src/model/UserModuleProgress";
 import { UserModuleProgressStore } from "../../src/store/UserModuleProgressStore";
 
 function makeProgress(overrides: Partial<ConstructorParameters<typeof UserModuleProgress>[0]> = {}): UserModuleProgress {
@@ -68,7 +68,7 @@ describe("UserModuleProgressStore.transitionStatus", () => {
     });
 
     it("preserves testAttempts from the existing record during a status transition", async () => {
-        const attempt = new ModuleTestAttempt({ id: "att-1", score: 75, passed: false, takenAt: "2026-06-01T10:00:00.000Z" });
+        const attempt = new TestAttemptRecord({ id: "att-1", score: 75, passed: false, takenAt: "2026-06-01T10:00:00.000Z" });
         const docs = [makeProgress({ status: "in_progress", testAttempts: [attempt] }).toBSON()];
         const store = new UserModuleProgressStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });
 

--- a/test/store/UserModuleProgressStore.upsert.test.ts
+++ b/test/store/UserModuleProgressStore.upsert.test.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import { UserModuleProgress, ModuleTestAttempt } from "../../src/model/UserModuleProgress";
+import { UserModuleProgress, TestAttemptRecord } from "../../src/model/UserModuleProgress";
 import { UserModuleProgressStore } from "../../src/store/UserModuleProgressStore";
 
 function makeProgress(overrides: Partial<ConstructorParameters<typeof UserModuleProgress>[0]> = {}): UserModuleProgress {
@@ -60,7 +60,7 @@ describe("UserModuleProgressStore.upsert", () => {
     });
 
     it("preserves testAttempts stored on the record", async () => {
-        const attempt = new ModuleTestAttempt({ id: "att-1", score: 80, passed: true, takenAt: "2026-06-02T10:00:00.000Z" });
+        const attempt = new TestAttemptRecord({ id: "att-1", score: 80, passed: true, takenAt: "2026-06-02T10:00:00.000Z" });
         const existing = makeProgress({ status: "in_progress", testAttempts: [attempt] }).toBSON();
         const docs: any[] = [existing];
         const store = new UserModuleProgressStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });


### PR DESCRIPTION
## Summary

Implements F11 (Module Test) — the graded, single-pass, resumable assessment that completes a module.

## What's included

- **Config constants**: MODULE_TEST_SIZE=20, TEST_UNLOCK_DELAY_HOURS=4, TEST_PASS_THRESHOLD=80, TEST_RETRY_DELAY_MINUTES=20
- **Model** (src/model/ModuleTestAttempt.ts): full stateful attempt entity with exerciseIds, nswers, currentPosition, erifiedExerciseIds, score, passed, startedAt, 	akenAt, exerciseResults
- **Rename** ModuleTestAttempt → TestAttemptRecord in UserModuleProgress (the embedded summary) to avoid name collision
- **Store** (src/store/ModuleTestAttemptStore.ts): create, indById, indActiveByUserAndModule, ppendAnswer, dvancePosition, ddVerifiedExerciseId, lipAnswerToCorrect, submit
- **6 delegates** in src/dlg/moduleTests/:
  - GetTestEligibility — unlock/retry timing gate
  - StartModuleTest — eligibility check, 20-exercise F08 draw, 409-resume
  - GetModuleTest — resume without exposing answers
  - SubmitTestAnswer — single-pass answer check with immediate feedback (no retry queue)
  - SubmitModuleTest — score, mastery update (F06), module completion transition
  - GetTestReview — post-submit review with correct answers exposed
- **6 endpoints** wired in src/index.ts
- **API docs** updated in docs/interfaces/api-endpoints.md
- **Feature docs** updated: F11 marked implemented, OQ-03 resolved

## Open questions resolved
- **OQ-03**: No retakes — once a module is completed, POST .../tests returns 400
- **OQ-04**: Never expires — deferred to a future improvement (mirrors F10 OQ-03)

## Out of scope
- F13 extension to module tests (deferred to issue #64)

## Tests
460 tests pass. All new behaviour is covered by unit tests under 	est/dlg/moduleTests/, 	est/store/ModuleTestAttemptStore.test.ts, and 	est/model/ModuleTestAttempt.model.test.ts.

Closes #70