### PR TITLE
F21 — Level Test

### DIFF
--- a/docs/features/F21-level-test.md
+++ b/docs/features/F21-level-test.md
@@ -2,7 +2,9 @@
 
 ## 1. Purpose & Scope
 
-The Level Test is the comprehensive assessment that unlocks the next CEFR level. It covers the full scope of the current level (all vocabulary from completed modules + all grammar concepts introduced at the level). It is offered only after the user has completed all modules at the level (F07 gate). It draws 20–30 exercises from the level test bank (F20) via mastery-aware selection (F08), grades them (pass ≥ 75%), updates mastery (F06), advances the user's level on a pass (F05), and surfaces a weak-areas summary. Retries are free (no cooldown in v2.0).
+The Level Test is the comprehensive assessment that unlocks the next CEFR level. It covers the full scope of the current level (all vocabulary + all grammar concepts represented in the level test bank). It is offered only after the user has completed all curated modules at the level (F07 gate). It is a **graded parallel of the practice session (F10) / module test (F11)**: a stateful, resumable session where the user answers one question at a time, each answer is checked and stored in the backend with **immediate per-answer feedback**, the cursor advances, and the attempt is resumable after an app close (via a **409-resume** on start). It differs from practice only by being **graded**, **eligibility-gated**, **single-pass** (first answer is final — no retry queue), and drawn from the level test bank.
+
+It draws **40** exercises from the level test bank (F20) via mastery-aware selection (F08) — prioritizing the level's lowest-mastery vocabulary and grammar items — grades them (pass ≥ 75%), updates mastery (F06), advances the user's level on a pass (F05), and surfaces a weak-areas summary. A **30-minute cooldown** applies between attempts.
 
 **Out of scope**:
 - The level bank storage (→ [F20](./F20-level-test-bank.md))
@@ -17,47 +19,57 @@ The Level Test is the comprehensive assessment that unlocks the next CEFR level.
 
 | Term | Definition |
 |------|-----------|
-| Level Test | Cross-module assessment that unlocks the next CEFR level |
-| Eligibility | All modules at the current level must be `completed` (F07) |
+| Level Test | Cross-module, graded, resumable assessment that unlocks the next CEFR level |
+| Eligibility | All **curated** (non-user-generated) modules at the current level must be `completed` (F07) |
 | Pass threshold | 75% correct |
-| Weak areas | Grammar concepts + vocab items the user underperformed on, derived from attempt results |
-| LevelTestAttempt | Recorded attempt incl. full exerciseResults |
+| Cooldown | 30 minutes must elapse since the most recent submitted attempt before a new attempt may start |
+| Weak areas | Grammar concepts + vocab items the user answered incorrectly, derived from attempt results |
+| LevelTestAttempt | Stateful, resumable attempt incl. per-answer state and full exerciseResults |
 
 ### 2.2. Requirements
 
 #### 2.2.1. Data Models
 
-**LevelTestAttempt**
+**LevelTestAttempt** (stored in its own `levelTestAttempts` collection)
 
 | Field | Type | Description | Rules |
 |-------|------|-------------|-------|
 | id | ObjectId | Unique attempt id | Auto-generated |
 | userId | string | User id | Required |
 | cefrLevel | string | Level being tested | Required |
-| exerciseIds | string[] | Exercises presented in this attempt | Set at start |
-| answers | object[] | Submitted answers (exerciseId, userAnswer) | Set on submit |
-| score | number | Percentage correct | 0–100 |
-| passed | boolean | Whether score ≥ 75% | Required |
-| takenAt | Date | When the attempt was submitted | Auto-set |
-| exerciseResults | ExerciseResult[] | Full per-exercise detail | Used by F06 apply-results and weak-areas summary |
+| exerciseIds | string[] | Ordered exercises presented in this attempt | Set at start, never changed |
+| answers | TestAnswer[] | Per-exercise answers (`exerciseId`, `isCorrect`, `userAnswer`, `answeredAt`) | First answer per exercise is final |
+| currentPosition | number | 0-based index of the next unanswered exercise | Advances on each answer |
+| verifiedExerciseIds | string[] | Exercises for which AI verification (F13) was used this attempt | One-per-attempt guard |
+| score | number \| null | Percentage correct | 0–100; null until submitted |
+| passed | boolean \| null | Whether score ≥ 75% | null until submitted |
+| startedAt | Date | When the attempt was started | Auto-set |
+| takenAt | Date \| null | When the attempt was submitted | null while in-progress |
+| exerciseResults | ExerciseResult[] | Full per-exercise detail | Populated on submit; used by F06 apply-results and weak-areas summary |
 
 #### 2.2.2. Endpoints
 
-- `GET /users/:userId/levelTest/eligibility` — report whether the Level Test is available for the user's current level.
-- `POST /users/:userId/levelTests` — start a new Level Test attempt; returns questions without answers.
-- `POST /users/:userId/levelTests/:attemptId/submit` — accept all answers; body: array of `{ exerciseId, userAnswer }`.
-- `GET /users/:userId/levelTests/:attemptId` — return the full result: score, per-question review, and weak-areas summary.
+- `GET /users/:userId/levelTest/eligibility` — report whether the Level Test is available for the user's current level (incl. cooldown / active-attempt state).
+- `POST /users/:userId/levelTests` — start a new Level Test attempt; returns questions without answers. **409-resume** when an active un-submitted attempt already exists (returns the existing `attemptId`).
+- `GET /users/:userId/levelTests/:attemptId` — resume an in-progress attempt: returns exercises (without correct answers), accumulated answers, and `currentPosition`.
+- `POST /users/:userId/levelTests/:attemptId/answers` — submit a single answer; body `{ exerciseId, userAnswer }`; checks it, stores `isCorrect`, advances the cursor, and returns **immediate feedback** (`isCorrect`, `correctAnswer`).
+- `POST /users/:userId/levelTests/:attemptId/submit` — finalize and grade the already-scored attempt; updates mastery, persists, advances the user's level on a pass.
+- `GET /users/:userId/levelTests/:attemptId/review` — return the full result (post-submit only): score, per-question review with correct answers, and weak-areas summary.
 
 #### 2.2.4. Business Logic
 
-- Eligibility check: requires all modules at the user's current CEFR level to be `completed` (query F07's completion-gate endpoint). Returns `{ eligible: boolean, reason?: string }`.
-- Starting a test: draw 20–30 exercises from the level's LevelTestBank (F20) via F08, scoped to the full level's vocabulary and grammar. Return questions **without** answers.
-- Submitting: grade all answers via normalized matching. Compute score; pass if ≥ 75%.
+- **Eligibility check**: requires all **curated** (non-user-generated) modules at the user's current CEFR level to be `completed` (F07). User-generated modules do not block. Also reports cooldown state and any active attempt. Returns `{ eligible: boolean, reason?: string, retryAvailableAt?, activeAttemptId? }`.
+- **Starting a test**: 
+  - **409-resume** if an active (un-submitted) attempt already exists for the user + level — the client must resume it via `GET …/levelTests/:attemptId`.
+  - Reject if not eligible (modules not all completed) or if the 30-minute cooldown since the most recent submitted attempt at this level has not elapsed.
+  - Draw **40** exercises from the level's LevelTestBank (F20) via F08, using a **level-wide mastery map** (the user's mastery for every vocabulary item and grammar concept linked by the bank's exercises) so the **lowest-mastery items are prioritized**. Return questions **without** answers.
+- **Submitting an answer** (`…/answers`): check via normalized matching (same as F10/F11). The first answer to each exercise is final for grading. Store `isCorrect`, advance `currentPosition`, increment the exercise's `timesShown`, and return immediate feedback (incl. `correctAnswer`).
+- **Submitting the test** (`…/submit`): score = % of `exerciseIds` whose final `isCorrect` is true; unanswered exercises count as wrong. Pass if ≥ 75%.
   - **Update mastery**: call F06 apply-results with the attempt's ExerciseResults (vocab + grammar).
-  - Persist the LevelTestAttempt.
+  - Persist the grading outcome on the LevelTestAttempt (`score`, `passed`, `takenAt`, `exerciseResults`).
   - On pass: invoke F05's advance-level operation to promote the user to the next CEFR level.
-- Results (`GET …/:attemptId`): return final score, all questions with correct answers (incorrect ones alongside the user's answer), and a weak-areas summary. Weak areas are derived from `exerciseResults`: items where the user answered incorrectly, grouped by grammar concept and vocabulary item.
-- Free retry: on fail, the user may retry with no cooldown; a new selection is drawn from the bank on each attempt.
+- **Review** (`…/review`, post-submit only): return final score, all questions with correct answers (incorrect ones alongside the user's answer), and a weak-areas summary. Weak areas = items answered **incorrectly**, grouped by grammar concept and vocabulary item.
+- **Cooldown retry**: on fail, the user may retry once the 30-minute cooldown since the most recent submitted attempt has elapsed; a new selection is drawn from the bank on each attempt.
 - "Explain my mistake" (F12) is available per incorrect item in the review.
 
 ---
@@ -66,27 +78,31 @@ The Level Test is the comprehensive assessment that unlocks the next CEFR level.
 
 | # | As a Consumer, I want to… | So that… |
 |---|--------------------------|----------|
-| CS-01 | Check level test eligibility for a user | the app shows or hides the Level Test CTA based on module completion state |
+| CS-01 | Check level test eligibility for a user | the app shows or hides the Level Test CTA based on module completion + cooldown state |
 | CS-02 | Start a Level Test and receive questions without answers | the app presents a comprehensive cross-module assessment |
-| CS-03 | Submit all answers and receive a score with pass/fail outcome | mastery is updated and the user is promoted to the next level on a pass |
-| CS-04 | Fetch the full result with a weak-areas summary | the app shows the user exactly what to study next |
+| CS-03 | Resume an in-progress Level Test after closing the app | I don't lose progress mid-test |
+| CS-04 | Submit one answer at a time and see immediate feedback | I learn as I go, exactly like practice and the module test |
+| CS-05 | Submit the test and receive a score with pass/fail outcome | mastery is updated and I'm promoted to the next level on a pass |
+| CS-06 | Fetch the full review with a weak-areas summary | the app shows me exactly what to study next |
 
 ---
 
 ## 4. Constraints and Assumptions
 
-- **Constraint** — Offered only after all current-level modules are completed.
+- **Constraint** — Offered only after all current-level **curated** modules are completed.
 - **Constraint** — Pass threshold 75% (vs 80% for module tests).
 - **Constraint** — Mastery updated here, like F11 and practice (F10); all three update mastery via F06's apply-results.
-- **Constraint** — Free retry, no cooldown (idea OQ-04, v2.0).
-- **Assumption** — 20–30 questions drawn per attempt.
+- **Constraint** — **30-minute cooldown** between attempts, anchored on the most recent submitted attempt at the level (v2.0 change — replaces the earlier "free retry, no cooldown").
+- **Constraint** — Single-pass: first answer to each exercise is final for grading; no retry queue.
+- **Constraint** — **40** questions drawn per attempt.
+- **Assumption** — The level test bank (F20) defines the level's vocab/grammar scope; the mastery map is built from the items linked by the bank's exercises.
 
 ---
 
 ## 5. Open Questions
 
-| # | Question | Options / Notes |
-|---|----------|-----------------|
-| OQ-01 | Exact question count within 20–30? | Fixed value or scale with level scope |
-| OQ-02 | How is "vocabulary from completed modules" scoped if some level modules are user-generated? | Define whether user-generated modules count toward level scope |
-| OQ-03 | What defines "underperformed" for weak areas? | e.g. any incorrect, or below a per-item correctness ratio |
+| # | Question | Resolution |
+|---|----------|-----------|
+| OQ-01 | Exact question count? | **Resolved**: fixed at 40. |
+| OQ-02 | How is level scope handled if some level modules are user-generated? | **Resolved**: eligibility counts only curated (non-user-generated) modules; the bank (F20) defines vocab/grammar scope. |
+| OQ-03 | What defines "underperformed" for weak areas? | **Resolved**: any incorrect answer, grouped by grammar concept / vocabulary item. |

--- a/docs/features/F21-level-test.md
+++ b/docs/features/F21-level-test.md
@@ -1,5 +1,7 @@
 # F21 — Level Test
 
+![Status](https://img.shields.io/badge/status-implemented-brightgreen?style=flat-square)
+
 ## 1. Purpose & Scope
 
 The Level Test is the comprehensive assessment that unlocks the next CEFR level. It covers the full scope of the current level (all vocabulary + all grammar concepts represented in the level test bank). It is offered only after the user has completed all curated modules at the level (F07 gate). It is a **graded parallel of the practice session (F10) / module test (F11)**: a stateful, resumable session where the user answers one question at a time, each answer is checked and stored in the backend with **immediate per-answer feedback**, the cursor advances, and the attempt is resumable after an app close (via a **409-resume** on start). It differs from practice only by being **graded**, **eligibility-gated**, **single-pass** (first answer is final — no retry queue), and drawn from the level test bank.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -58,7 +58,7 @@ Features are grouped by layer. Lower groups depend on higher ones.
 | # | Feature | Primary model | Status |
 |---|---------|---------------|--------|
 | F20 | [Level Test Bank](./F20-level-test-bank.md) | LevelTestBank | ![Implemented](https://img.shields.io/badge/status-implemented-brightgreen?style=flat-square) |
-| F21 | [Level Test](./F21-level-test.md) | LevelTestAttempt | |
+| F21 | [Level Test](./F21-level-test.md) | LevelTestAttempt | ![Implemented](https://img.shields.io/badge/status-implemented-brightgreen?style=flat-square) |
 
 ### Group G — User-added vocabulary
 | # | Feature | Primary model |

--- a/docs/interfaces/api-endpoints.md
+++ b/docs/interfaces/api-endpoints.md
@@ -15,6 +15,7 @@
 - [Practice Sessions (F10)](#practice-sessions-f10)
 - [Module Tests (F11)](#module-tests-f11)
 - [Level Test Banks (F20)](#level-test-banks-f20)
+- [Level Test (F21)](#level-test-f21)
 - [Legacy endpoints (pending removal)](#legacy-endpoints-pending-removal)
 - [API Design compliance](#api-design-compliance)
 
@@ -289,6 +290,42 @@
 ### GET /levelTestBanks/:cefrLevel
 **Used for:** The selection engine (F08) drawing from the full pool when assembling a Level Test (F21). Returns the bank metadata plus its `exerciseIds`. Returns **404** if no bank exists for the level.
 **Request & Response:** `GetLevelTestBankRequest` / `GetLevelTestBankResponse` in `src/dlg/levelTestBanks/GetLevelTestBank.ts`
+
+---
+
+## Level Test (F21)
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET | `/users/:userId/levelTest/eligibility` | Authoritative eligibility + cooldown check for the level test |
+| POST | `/users/:userId/levelTests` | Start a new level test attempt (409-resume if one is active) |
+| GET | `/users/:userId/levelTests/:attemptId` | Get the current state of a level test attempt (for resume) |
+| POST | `/users/:userId/levelTests/:attemptId/answers` | Submit an answer for one exercise in the test |
+| POST | `/users/:userId/levelTests/:attemptId/submit` | Finalise the attempt; grade, update mastery, advance level on pass |
+| GET | `/users/:userId/levelTests/:attemptId/review` | Fetch the full graded review + weak-areas for a submitted attempt |
+
+### GET /users/:userId/levelTest/eligibility
+**Used for:** Checking whether the Level Test is available for the user's current CEFR level. Eligible requires all **curated** (non-user-generated) modules at the level to be `completed` (F07); user-generated modules do not block, and a level with no curated modules is not eligible. An in-progress attempt makes the user eligible to *resume* it (returns `activeAttemptId`), bypassing the cooldown. Otherwise the 30-minute inter-attempt cooldown (`LEVEL_TEST_RETRY_DELAY_MINUTES`) must have elapsed since the most recent submitted attempt's `takenAt`, else returns `{ eligible: false, retryAvailableAt, remainingMs }`. The user's level is resolved from their profile.
+**Request & Response:** `GetLevelTestEligibilityRequest` / `GetLevelTestEligibilityResponse` in `src/dlg/levelTests/GetLevelTestEligibility.ts`
+
+### POST /users/:userId/levelTests
+**Used for:** Starting a new Level Test attempt at the user's current level. Verifies all eligibility conditions (all curated modules completed, cooldown elapsed). Draws exactly **40** exercises from the level test bank (F20) via F08's mastery-aware selection, using a **level-wide mastery map** (the user's mastery for every vocab/grammar item the bank's exercises link to) so the lowest-mastery items are prioritized. Returns the 40 questions as **full exercise objects — the same payload/shape as a practice session**. Returns **409** with `{ code: 409, message, attemptId }` if an active (un-submitted) attempt already exists — the client resumes it via `GET .../levelTests/:attemptId`. Returns **404** if no level test bank exists for the level.
+**Request & Response:** `StartLevelTestRequest` / `StartLevelTestResponse` in `src/dlg/levelTests/StartLevelTest.ts`
+
+### GET /users/:userId/levelTests/:attemptId
+**Used for:** Resuming an in-progress level test after the app is closed. Returns the full attempt state — `cefrLevel`, `answers` recorded so far, `currentPosition` — plus the full exercise objects (same payload/shape as a practice session) in stored `exerciseIds` order. An in-progress attempt is always resumable regardless of cooldown timing. Verifies ownership (403 otherwise).
+**Request & Response:** `GetLevelTestRequest` / `GetLevelTestResponse` in `src/dlg/levelTests/GetLevelTest.ts`
+
+### POST /users/:userId/levelTests/:attemptId/answers
+**Used for:** Submitting a user's answer for one exercise during a level test. Body: `{ exerciseId, userAnswer }`. Normalises and checks the answer (same logic as F10/F11). **The first answer is final for grading — no retry queue.** Returns immediate feedback `{ isCorrect, correctAnswer }` (correct answer always returned so the client can show it on a wrong answer). Increments `timesShown` on the exercise.
+**Request & Response:** `SubmitLevelTestAnswerRequest` / `SubmitLevelTestAnswerResponse` in `src/dlg/levelTests/SubmitLevelTestAnswer.ts`
+
+### POST /users/:userId/levelTests/:attemptId/submit
+**Used for:** Finalising a level test attempt. Computes the score as `% of exerciseIds whose final isCorrect is true`; unanswered exercises count as wrong. Determines pass/fail against `LEVEL_TEST_PASS_THRESHOLD` (75%). Updates mastery (F06) for every answered exercise — same SRS loop as practice completion. On pass: advances the user's CEFR level (F05) to the next tier — a no-op if already at the highest level (C2). Returns `{ score, passed, advancedTo }` where `advancedTo` is the new level or `null`.
+**Request & Response:** `SubmitLevelTestRequest` / `SubmitLevelTestResponse` in `src/dlg/levelTests/SubmitLevelTest.ts`
+
+### GET /users/:userId/levelTests/:attemptId/review
+**Used for:** Fetching the full graded review for a submitted level test attempt. Returns `score`, `passed`, a `questions` array (each exercise's `prompt`, `isCorrect`, `userAnswer`, `correctAnswer`), and a `weakAreas` summary `{ vocabulary[], grammar[] }` — the distinct vocab items and grammar concepts the user answered incorrectly (any incorrect answer flags the item — OQ-03). Only valid after submission (`takenAt` set); **exposes correct answers**. Unanswered exercises appear with `isCorrect: false` and `userAnswer: ""`. Enables "Explain my mistake" (F12) per incorrect item. Verifies ownership (403 otherwise).
+**Request & Response:** `GetLevelTestReviewRequest` / `GetLevelTestReviewResponse` in `src/dlg/levelTests/GetLevelTestReview.ts`
 
 ---
 

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -48,6 +48,25 @@ export const TEST_PASS_THRESHOLD = 80;
  */
 export const TEST_RETRY_DELAY_MINUTES = 20;
 
+/**
+ * Number of questions drawn for each Level Test (F21).
+ * Fixed at 40 in v2.0.
+ */
+export const LEVEL_TEST_SIZE = 40;
+
+/**
+ * Minimum percentage of correct answers required to pass a Level Test (F21).
+ * Expressed as a value between 0 and 100. Lower than the Module Test (80%).
+ */
+export const LEVEL_TEST_PASS_THRESHOLD = 75;
+
+/**
+ * Minutes that must elapse after the most recent submitted Level Test attempt's
+ * `takenAt` timestamp before the user may start a new attempt at the same level (F21).
+ * This is the inter-attempt cooldown.
+ */
+export const LEVEL_TEST_RETRY_DELAY_MINUTES = 30;
+
 export class ControllerConfig extends TotoControllerConfig {
 
     getMongoSecretNames(): { userSecretName: string; pwdSecretName: string; } | null {

--- a/src/dlg/levelTests/GetLevelTest.ts
+++ b/src/dlg/levelTests/GetLevelTest.ts
@@ -1,0 +1,80 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../../Config";
+import { Exercise } from "../../model/Exercise";
+import { TestAnswer } from "../../model/ModuleTestAttempt";
+import { ExerciseStore } from "../../store/ExerciseStore";
+import { LevelTestAttemptStore } from "../../store/LevelTestAttemptStore";
+
+/**
+ * Returns the current state of a Level Test attempt for resume after an app close (F21).
+ *
+ * Exercises are returned as full objects in the stored exerciseIds order — the same payload/shape
+ * as a practice session, so the frontend can reuse the same exercise components. Correct answers
+ * are not hidden in the exercise objects (identical to the module-test resume contract); the
+ * per-answer feedback and review endpoints are the authoritative grading reads.
+ * An in-progress attempt is always resumable regardless of cooldown timing.
+ */
+export class GetLevelTest extends TotoDelegate<GetLevelTestRequest, GetLevelTestResponse> {
+
+    /**
+     * Extracts userId and attemptId from the route parameters.
+     */
+    parseRequest(req: Request): GetLevelTestRequest {
+
+        const userId = req.params.userId;
+        const attemptId = req.params.attemptId;
+
+        if (!userId) throw new ValidationError(400, "userId is required");
+        if (!attemptId) throw new ValidationError(400, "attemptId is required");
+
+        return { userId, attemptId };
+    }
+
+    /**
+     * Returns the attempt state enriched with full exercise objects. Verifies ownership.
+     *
+     * @param {GetLevelTestRequest} req - The userId and attemptId.
+     *
+     * @returns {Promise<GetLevelTestResponse>} The resumable attempt state.
+     */
+    async do(req: GetLevelTestRequest, _userContext?: UserContext): Promise<GetLevelTestResponse> {
+
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+
+        const attemptStore = new LevelTestAttemptStore({ db, config });
+        const attempt = await attemptStore.findById(req.attemptId);
+
+        if (!attempt) throw new ValidationError(404, `Level test attempt ${req.attemptId} not found`);
+        if (attempt.userId !== req.userId) throw new ValidationError(403, "Attempt does not belong to the specified user");
+
+        const exerciseStore = new ExerciseStore(db);
+        const exercises = await exerciseStore.findByIds(attempt.exerciseIds);
+
+        return {
+            attemptId: attempt.id!,
+            cefrLevel: attempt.cefrLevel,
+            exercises,
+            answers: attempt.answers,
+            currentPosition: attempt.currentPosition,
+            startedAt: attempt.startedAt,
+            takenAt: attempt.takenAt,
+        };
+    }
+}
+
+interface GetLevelTestRequest {
+    userId: string;     // The user id making the request
+    attemptId: string;  // The id of the level test attempt to retrieve
+}
+
+interface GetLevelTestResponse {
+    attemptId: string;          // The attempt id
+    cefrLevel: string;          // The CEFR level being tested
+    exercises: Exercise[];      // Full exercise objects, same shape as a practice session
+    answers: TestAnswer[];      // Answers submitted so far
+    currentPosition: number;    // 0-based index of the next unanswered exercise
+    startedAt: string;          // ISO-8601 timestamp of when the attempt was started
+    takenAt: string | null;     // ISO-8601 submission timestamp; null if in-progress
+}

--- a/src/dlg/levelTests/GetLevelTestEligibility.ts
+++ b/src/dlg/levelTests/GetLevelTestEligibility.ts
@@ -1,0 +1,107 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig, LEVEL_TEST_RETRY_DELAY_MINUTES } from "../../Config";
+import { LevelTestAttemptStore } from "../../store/LevelTestAttemptStore";
+import { ModuleStore } from "../../store/ModuleStore";
+import { UserModuleProgressStore } from "../../store/UserModuleProgressStore";
+import { UserStore } from "../../store/UserStore";
+
+/**
+ * Returns the authoritative Level Test eligibility state for a user at their current CEFR level (F21).
+ *
+ * Eligibility rules:
+ * - All **curated** (non-user-generated) modules at the user's current level must be `completed`.
+ *   User-generated modules do not block. A level with no curated modules is not eligible.
+ * - An in-progress (un-submitted) attempt makes the user eligible to *resume* it (`activeAttemptId`),
+ *   bypassing the cooldown.
+ * - Otherwise, the 30-minute inter-attempt cooldown must have elapsed since the most recent
+ *   submitted attempt's `takenAt`.
+ */
+export class GetLevelTestEligibility extends TotoDelegate<GetLevelTestEligibilityRequest, GetLevelTestEligibilityResponse> {
+
+    /**
+     * Extracts userId from the route parameters.
+     */
+    parseRequest(req: Request): GetLevelTestEligibilityRequest {
+
+        const userId = req.params.userId;
+
+        if (!userId) throw new ValidationError(400, "userId is required");
+
+        return { userId, now: new Date() };
+    }
+
+    /**
+     * Evaluates Level Test eligibility for the given user at their current level.
+     *
+     * @param {GetLevelTestEligibilityRequest} req - The userId and current time.
+     *
+     * @returns {Promise<GetLevelTestEligibilityResponse>} The eligibility verdict.
+     */
+    async do(req: GetLevelTestEligibilityRequest, _userContext?: UserContext): Promise<GetLevelTestEligibilityResponse> {
+
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+        const now = req.now;
+
+        const user = await new UserStore({ db, config }).findById(req.userId);
+
+        if (!user) throw new ValidationError(404, `User ${req.userId} not found`);
+
+        const cefrLevel = user.cefrLevel;
+
+        const curatedModules = await new ModuleStore(db).list(cefrLevel, false);
+
+        if (curatedModules.length === 0) {
+            return { eligible: false, reason: `No curated modules exist for level ${cefrLevel}` };
+        }
+
+        const progressList = await new UserModuleProgressStore({ db, config }).listByUser(req.userId, curatedModules.map(m => m.id));
+        const completedModuleIds = new Set(progressList.filter(p => p.status === "completed").map(p => p.moduleId));
+
+        const allCompleted = curatedModules.every(m => completedModuleIds.has(m.id));
+
+        if (!allCompleted) {
+            return { eligible: false, reason: `Not all curated modules at level ${cefrLevel} are completed` };
+        }
+
+        const attemptStore = new LevelTestAttemptStore({ db, config });
+
+        const activeAttempt = await attemptStore.findActiveByUserAndLevel(req.userId, cefrLevel);
+
+        if (activeAttempt) {
+            return { eligible: true, activeAttemptId: activeAttempt.id! };
+        }
+
+        const mostRecent = await attemptStore.findMostRecentSubmittedByUserAndLevel(req.userId, cefrLevel);
+
+        if (mostRecent?.takenAt) {
+
+            const retryAvailableAt = new Date(new Date(mostRecent.takenAt).getTime() + LEVEL_TEST_RETRY_DELAY_MINUTES * 60 * 1000);
+
+            if (now < retryAvailableAt) {
+                return {
+                    eligible: false,
+                    reason: "Cooldown not yet elapsed since the most recent attempt",
+                    retryAvailableAt: retryAvailableAt.toISOString(),
+                    remainingMs: retryAvailableAt.getTime() - now.getTime(),
+                };
+            }
+        }
+
+        return { eligible: true };
+    }
+}
+
+interface GetLevelTestEligibilityRequest {
+    userId: string;     // The user id
+    now: Date;          // The current time (injectable for testability)
+}
+
+interface GetLevelTestEligibilityResponse {
+    eligible: boolean;              // Whether the Level Test may be started/resumed right now
+    reason?: string;               // Human-readable reason when not eligible
+    retryAvailableAt?: string;     // ISO-8601 timestamp when the cooldown elapses; present only during cooldown
+    remainingMs?: number;          // Milliseconds until eligible; present only during cooldown
+    activeAttemptId?: string;      // Id of an in-progress attempt to resume; present only when one exists
+}

--- a/src/dlg/levelTests/GetLevelTestReview.ts
+++ b/src/dlg/levelTests/GetLevelTestReview.ts
@@ -1,0 +1,115 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../../Config";
+import { ExerciseStore } from "../../store/ExerciseStore";
+import { LevelTestAttemptStore } from "../../store/LevelTestAttemptStore";
+
+/**
+ * Returns the full review of a completed Level Test attempt (F21).
+ *
+ * Exposes correct answers for every question — unlike `GetLevelTest`, which is the in-progress
+ * resume read. For each question the review includes the prompt, `isCorrect`, `userAnswer` and
+ * `correctAnswer`. Unanswered exercises are represented as incorrect with an empty `userAnswer`.
+ *
+ * It also returns a weak-areas summary: the distinct vocabulary items and grammar concepts the
+ * user answered incorrectly (any incorrect answer flags the linked item — OQ-03). Enables
+ * "Explain my mistake" (F12) per incorrect item.
+ */
+export class GetLevelTestReview extends TotoDelegate<GetLevelTestReviewRequest, GetLevelTestReviewResponse> {
+
+    /**
+     * Extracts userId and attemptId from the route parameters.
+     */
+    parseRequest(req: Request): GetLevelTestReviewRequest {
+
+        const userId = req.params.userId;
+        const attemptId = req.params.attemptId;
+
+        if (!userId) throw new ValidationError(400, "userId is required");
+        if (!attemptId) throw new ValidationError(400, "attemptId is required");
+
+        return { userId, attemptId };
+    }
+
+    /**
+     * Returns the graded review for a submitted attempt, including the weak-areas summary.
+     * Validates ownership and submission state first.
+     *
+     * @param {GetLevelTestReviewRequest} req - The userId and attemptId.
+     *
+     * @returns {Promise<GetLevelTestReviewResponse>} Score, per-question review, and weak areas.
+     */
+    async do(req: GetLevelTestReviewRequest, _userContext?: UserContext): Promise<GetLevelTestReviewResponse> {
+
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+
+        const attemptStore = new LevelTestAttemptStore({ db, config });
+        const attempt = await attemptStore.findById(req.attemptId);
+
+        if (!attempt) throw new ValidationError(404, `Level test attempt ${req.attemptId} not found`);
+        if (attempt.userId !== req.userId) throw new ValidationError(403, "Attempt does not belong to the specified user");
+        if (attempt.takenAt === null) throw new ValidationError(400, "Attempt is not yet submitted");
+
+        const exerciseStore = new ExerciseStore(db);
+        const exercises = await exerciseStore.findByIds(attempt.exerciseIds);
+        const exerciseById = new Map(exercises.map(e => [e.id, e]));
+
+        const answerByExerciseId = new Map(attempt.answers.map(a => [a.exerciseId, a]));
+
+        const weakVocabulary = new Set<string>();
+        const weakGrammar = new Set<string>();
+
+        const questions: ReviewQuestion[] = attempt.exerciseIds.map(exerciseId => {
+
+            const exercise = exerciseById.get(exerciseId);
+            const answer = answerByExerciseId.get(exerciseId);
+            const isCorrect = answer?.isCorrect ?? false;
+
+            if (!isCorrect && exercise) {
+                if (exercise.vocabularyItemId) weakVocabulary.add(exercise.vocabularyItemId);
+                else if (exercise.grammarConceptId) weakGrammar.add(exercise.grammarConceptId);
+            }
+
+            return {
+                exerciseId,
+                prompt: exercise?.prompt ?? "",
+                isCorrect,
+                userAnswer: answer?.userAnswer ?? "",
+                correctAnswer: exercise?.answer ?? "",
+            };
+        });
+
+        return {
+            score: attempt.score!,
+            passed: attempt.passed!,
+            questions,
+            weakAreas: { vocabulary: [...weakVocabulary], grammar: [...weakGrammar] },
+        };
+    }
+}
+
+interface ReviewQuestion {
+    exerciseId: string;     // The exercise id
+    prompt: string;         // The exercise prompt
+    isCorrect: boolean;     // Whether the user's answer was correct
+    userAnswer: string;     // The user's submitted answer (empty string if unanswered)
+    correctAnswer: string;  // The correct answer — always exposed in the review
+}
+
+interface WeakAreas {
+    vocabulary: string[];   // Distinct vocabulary item ids the user answered incorrectly
+    grammar: string[];      // Distinct grammar concept ids the user answered incorrectly
+}
+
+interface GetLevelTestReviewRequest {
+    userId: string;     // The user id making the request
+    attemptId: string;  // The attempt id to review
+}
+
+interface GetLevelTestReviewResponse {
+    score: number;                  // Percentage correct (0–100)
+    passed: boolean;                // Whether the attempt passed
+    questions: ReviewQuestion[];    // Per-question review items
+    weakAreas: WeakAreas;           // Vocabulary + grammar the user underperformed on
+}

--- a/src/dlg/levelTests/StartLevelTest.ts
+++ b/src/dlg/levelTests/StartLevelTest.ts
@@ -1,0 +1,170 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig, LEVEL_TEST_RETRY_DELAY_MINUTES, LEVEL_TEST_SIZE } from "../../Config";
+import { Exercise } from "../../model/Exercise";
+import { LevelTestAttempt } from "../../model/LevelTestAttempt";
+import { ExerciseStore } from "../../store/ExerciseStore";
+import { LevelTestAttemptStore } from "../../store/LevelTestAttemptStore";
+import { LevelTestBankStore } from "../../store/LevelTestBankStore";
+import { ModuleStore } from "../../store/ModuleStore";
+import { UserGrammarConceptProgressStore } from "../../store/UserGrammarConceptProgressStore";
+import { UserModuleProgressStore } from "../../store/UserModuleProgressStore";
+import { UserStore } from "../../store/UserStore";
+import { UserVocabularyProgressStore } from "../../store/UserVocabularyProgressStore";
+import { selectExercises } from "../../util/ExerciseSelector";
+
+/**
+ * Thrown when an active (un-submitted) Level Test attempt already exists for the user + level.
+ * The client must resume the existing attempt via GET …/levelTests/:attemptId.
+ */
+class ActiveAttemptError extends ValidationError {
+
+    attemptId: string;  // The id of the already-active attempt to resume
+
+    constructor(attemptId: string) {
+        super(409, "An active level test attempt already exists for this level");
+        this.attemptId = attemptId;
+    }
+}
+
+/**
+ * Starts a new Level Test attempt for the given user at their current CEFR level (F21).
+ *
+ * Business rules enforced:
+ * - 404 if the user does not exist.
+ * - 409 (with `attemptId`) if an active (un-submitted) attempt already exists (resume it).
+ * - 400 if not all curated (non-user-generated) modules at the level are `completed`.
+ * - 400 if the 30-minute cooldown since the most recent submitted attempt has not elapsed.
+ * - 404 if no level test bank exists for the level.
+ * - Otherwise: draws 40 exercises from the level bank via F08 using a level-wide mastery map
+ *   (lowest-mastery items prioritized), creates the attempt, and returns the questions without answers.
+ */
+export class StartLevelTest extends TotoDelegate<StartLevelTestRequest, StartLevelTestResponse> {
+
+    /**
+     * Extracts userId from the route parameters.
+     */
+    parseRequest(req: Request): StartLevelTestRequest {
+
+        const userId = req.params.userId;
+
+        if (!userId) throw new ValidationError(400, "userId is required");
+
+        return { userId, now: new Date() };
+    }
+
+    /**
+     * Creates a new Level Test attempt after verifying all eligibility conditions.
+     * Returns the 40 selected exercises (full objects, same shape as a practice session) without answers.
+     *
+     * @param {StartLevelTestRequest} req - The userId and current time.
+     *
+     * @returns {Promise<StartLevelTestResponse>} The created attempt id, level, and selected exercises.
+     */
+    async do(req: StartLevelTestRequest, _userContext?: UserContext): Promise<StartLevelTestResponse> {
+
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+        const now = req.now;
+
+        const user = await new UserStore({ db, config }).findById(req.userId);
+
+        if (!user) throw new ValidationError(404, `User ${req.userId} not found`);
+
+        const cefrLevel = user.cefrLevel;
+
+        const attemptStore = new LevelTestAttemptStore({ db, config });
+
+        const active = await attemptStore.findActiveByUserAndLevel(req.userId, cefrLevel);
+
+        if (active) throw new ActiveAttemptError(active.id!);
+
+        // Eligibility: all curated modules at the level must be completed
+        const curatedModules = await new ModuleStore(db).list(cefrLevel, false);
+
+        if (curatedModules.length === 0) {
+            throw new ValidationError(400, `No curated modules exist for level ${cefrLevel}`);
+        }
+
+        const progressList = await new UserModuleProgressStore({ db, config }).listByUser(req.userId, curatedModules.map(m => m.id));
+        const completedModuleIds = new Set(progressList.filter(p => p.status === "completed").map(p => p.moduleId));
+
+        if (!curatedModules.every(m => completedModuleIds.has(m.id))) {
+            throw new ValidationError(400, `Not all curated modules at level ${cefrLevel} are completed`);
+        }
+
+        // Cooldown: 30 minutes must have elapsed since the most recent submitted attempt
+        const mostRecent = await attemptStore.findMostRecentSubmittedByUserAndLevel(req.userId, cefrLevel);
+
+        if (mostRecent?.takenAt) {
+
+            const retryAvailableAt = new Date(new Date(mostRecent.takenAt).getTime() + LEVEL_TEST_RETRY_DELAY_MINUTES * 60 * 1000);
+
+            if (now < retryAvailableAt) {
+                throw new ValidationError(400, `Cooldown not elapsed — retry after ${retryAvailableAt.toISOString()}`);
+            }
+        }
+
+        // Load the level bank and its exercises
+        const bank = await new LevelTestBankStore(db).findByCefrLevel(cefrLevel);
+
+        if (!bank) throw new ValidationError(404, `No level test bank found for level ${cefrLevel}`);
+
+        const exerciseStore = new ExerciseStore(db);
+        const bankExercises = await exerciseStore.findByIds(bank.exerciseIds);
+
+        // Build a level-wide mastery map from the user's progress on every item the bank's exercises link to,
+        // so F08 prioritizes the lowest-mastery vocabulary and grammar items.
+        const vocabIds = [...new Set(bankExercises.map(e => e.vocabularyItemId).filter((id): id is string => !!id))];
+        const grammarIds = [...new Set(bankExercises.map(e => e.grammarConceptId).filter((id): id is string => !!id))];
+
+        const vocabProgressList = await new UserVocabularyProgressStore({ db, config }).listByUser(req.userId, vocabIds);
+        const grammarProgressList = await new UserGrammarConceptProgressStore({ db, config }).listByUser(req.userId, grammarIds);
+
+        const masteryByItemId = new Map<string, number>([
+            ...vocabProgressList.map((p): [string, number] => [p.vocabularyItemId, p.masteryScore]),
+            ...grammarProgressList.map((p): [string, number] => [p.grammarConceptId, p.masteryScore]),
+        ]);
+
+        const selected = selectExercises({
+            pool: bankExercises,
+            masteryByItemId,
+            recentMisses: new Set(),
+            targetCount: LEVEL_TEST_SIZE,
+        });
+
+        const startedAt = now.toISOString();
+
+        const attempt = new LevelTestAttempt({
+            userId: req.userId,
+            cefrLevel,
+            exerciseIds: selected.map(e => e.id),
+            answers: [],
+            currentPosition: 0,
+            verifiedExerciseIds: [],
+            score: null,
+            passed: null,
+            startedAt,
+            takenAt: null,
+            exerciseResults: [],
+        });
+
+        const attemptId = await attemptStore.create(attempt);
+
+        // Return the full exercise objects — identical payload/shape to a practice session, since the
+        // frontend reuses the same exercise components.
+        return { attemptId, cefrLevel, exercises: selected, startedAt };
+    }
+}
+
+interface StartLevelTestRequest {
+    userId: string;     // The user id
+    now: Date;          // The current time (injectable for testability)
+}
+
+interface StartLevelTestResponse {
+    attemptId: string;      // The id of the newly created attempt
+    cefrLevel: string;      // The CEFR level being tested
+    exercises: Exercise[];  // Selected exercises — full objects, same shape as a practice session
+    startedAt: string;      // ISO-8601 timestamp of when the attempt was started
+}

--- a/src/dlg/levelTests/SubmitLevelTest.ts
+++ b/src/dlg/levelTests/SubmitLevelTest.ts
@@ -1,0 +1,135 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig, LEVEL_TEST_PASS_THRESHOLD } from "../../Config";
+import { nextLevel } from "../../model/CefrLevels";
+import { ExerciseResult } from "../../model/ExerciseResult";
+import { ExerciseStore } from "../../store/ExerciseStore";
+import { LevelTestAttemptStore } from "../../store/LevelTestAttemptStore";
+import { UserGrammarConceptProgressStore } from "../../store/UserGrammarConceptProgressStore";
+import { UserStore } from "../../store/UserStore";
+import { UserVocabularyProgressStore } from "../../store/UserVocabularyProgressStore";
+
+/**
+ * Finalises a Level Test attempt (F21).
+ *
+ * Steps:
+ * 1. Load the attempt; validate it is in-progress.
+ * 2. Compute the score: % of `exerciseIds` whose final `isCorrect` is true; unanswered count as wrong.
+ * 3. Determine pass/fail against `LEVEL_TEST_PASS_THRESHOLD` (75%).
+ * 4. Update mastery (F06) for every answered exercise — same loop as the module test.
+ * 5. Persist the grading outcome on the attempt (`score`, `passed`, `takenAt`, `exerciseResults`).
+ * 6. On pass: advance the user's CEFR level (F05) — no-op if already at the highest level.
+ */
+export class SubmitLevelTest extends TotoDelegate<SubmitLevelTestRequest, SubmitLevelTestResponse> {
+
+    /**
+     * Extracts userId and attemptId from the route parameters.
+     */
+    parseRequest(req: Request): SubmitLevelTestRequest {
+
+        const userId = req.params.userId;
+        const attemptId = req.params.attemptId;
+
+        if (!userId) throw new ValidationError(400, "userId is required");
+        if (!attemptId) throw new ValidationError(400, "attemptId is required");
+
+        return { userId, attemptId };
+    }
+
+    /**
+     * Grades the attempt and performs all downstream effects (mastery, persistence, level advance).
+     *
+     * @param {SubmitLevelTestRequest} req - The userId and attemptId.
+     *
+     * @returns {Promise<SubmitLevelTestResponse>} The score, pass verdict, and the level advanced to (if any).
+     */
+    async do(req: SubmitLevelTestRequest, _userContext?: UserContext): Promise<SubmitLevelTestResponse> {
+
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+
+        const attemptStore = new LevelTestAttemptStore({ db, config });
+        const attempt = await attemptStore.findById(req.attemptId);
+
+        if (!attempt) throw new ValidationError(404, `Level test attempt ${req.attemptId} not found`);
+        if (attempt.takenAt !== null) throw new ValidationError(400, "Attempt is already submitted");
+
+        // Unanswered exercises count as wrong — iterate exerciseIds (not answers) as the source of truth
+        const answerByExerciseId = new Map(attempt.answers.map(a => [a.exerciseId, a]));
+
+        const correctCount = attempt.exerciseIds.filter(id => answerByExerciseId.get(id)?.isCorrect === true).length;
+        const score = attempt.exerciseIds.length > 0 ? Math.round((correctCount / attempt.exerciseIds.length) * 100) : 0;
+        const passed = score >= LEVEL_TEST_PASS_THRESHOLD;
+        const takenAt = new Date().toISOString();
+
+        // Update mastery (F06) — bulk-fetch exercises to avoid N+1 queries
+        const exerciseStore = new ExerciseStore(db);
+        const exercises = await exerciseStore.findByIds(attempt.exerciseIds);
+        const exerciseById = new Map(exercises.map(e => [e.id, e]));
+
+        const vocabProgressStore = new UserVocabularyProgressStore({ db, config });
+        const grammarProgressStore = new UserGrammarConceptProgressStore({ db, config });
+
+        const exerciseResults: ExerciseResult[] = [];
+
+        for (const answer of attempt.answers) {
+
+            const exercise = exerciseById.get(answer.exerciseId);
+
+            if (!exercise) continue;
+
+            const result = new ExerciseResult({
+                exerciseId: exercise.id,
+                type: exercise.type,
+                isCorrect: answer.isCorrect,
+                userAnswer: answer.userAnswer,
+                correctAnswer: exercise.answer,
+                timestamp: answer.answeredAt,
+                moduleId: exercise.moduleId,
+            });
+
+            exerciseResults.push(result);
+
+            if (exercise.vocabularyItemId) {
+                await vocabProgressStore.appendResultAndRecompute(req.userId, exercise.vocabularyItemId, result);
+            } else if (exercise.grammarConceptId) {
+                await grammarProgressStore.appendResultAndRecompute(req.userId, exercise.grammarConceptId, result);
+            }
+        }
+
+        // Persist the grading outcome on the attempt
+        await attemptStore.submit(req.attemptId, { score, passed, takenAt, exerciseResults });
+
+        // On pass: advance the user's CEFR level (F05). No-op if already at the highest level.
+        let advancedTo: string | null = null;
+
+        if (passed) {
+
+            const userStore = new UserStore({ db, config });
+            const user = await userStore.findById(req.userId);
+
+            if (user) {
+
+                const next = nextLevel(user.cefrLevel);
+
+                if (next) {
+                    await userStore.updateCefrLevel(user.email, next);
+                    advancedTo = next;
+                }
+            }
+        }
+
+        return { score, passed, advancedTo };
+    }
+}
+
+interface SubmitLevelTestRequest {
+    userId: string;     // The user id
+    attemptId: string;  // The level test attempt id
+}
+
+interface SubmitLevelTestResponse {
+    score: number;              // Percentage correct (0–100)
+    passed: boolean;            // Whether the attempt passed (score >= 75%)
+    advancedTo: string | null;  // The CEFR level the user was promoted to on a pass; null if none
+}

--- a/src/dlg/levelTests/SubmitLevelTestAnswer.ts
+++ b/src/dlg/levelTests/SubmitLevelTestAnswer.ts
@@ -1,0 +1,90 @@
+import { Request } from "express";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig } from "../../Config";
+import { ExerciseStore } from "../../store/ExerciseStore";
+import { LevelTestAttemptStore } from "../../store/LevelTestAttemptStore";
+import { checkAnswer } from "../../util/AnswerChecker";
+
+/**
+ * Submits a single answer for one exercise in an in-progress Level Test attempt (F21).
+ *
+ * Business rules (identical to the module test, F11):
+ * - The attempt must exist and not yet be submitted (`takenAt` null).
+ * - The `exerciseId` must belong to the attempt's `exerciseIds` list.
+ * - The answer is checked via normalised matching (same logic as F10).
+ * - The first answer to each exercise is final for grading — there is no retry queue.
+ * - Immediate feedback is returned: the correct answer is always included.
+ * - `timesShown` is incremented on the exercise (same as practice).
+ */
+export class SubmitLevelTestAnswer extends TotoDelegate<SubmitLevelTestAnswerRequest, SubmitLevelTestAnswerResponse> {
+
+    /**
+     * Extracts userId, attemptId, exerciseId, and userAnswer from the request.
+     */
+    parseRequest(req: Request): SubmitLevelTestAnswerRequest {
+
+        const userId = req.params.userId;
+        const attemptId = req.params.attemptId;
+        const exerciseId = req.body?.exerciseId;
+        const userAnswer = req.body?.userAnswer;
+
+        if (!userId) throw new ValidationError(400, "userId is required");
+        if (!attemptId) throw new ValidationError(400, "attemptId is required");
+        if (!exerciseId) throw new ValidationError(400, "exerciseId is required");
+        if (userAnswer === undefined || userAnswer === null) throw new ValidationError(400, "userAnswer is required");
+
+        return { userId, attemptId, exerciseId, userAnswer: String(userAnswer) };
+    }
+
+    /**
+     * Checks the answer, stores the result, advances the cursor, and returns immediate feedback.
+     *
+     * @param {SubmitLevelTestAnswerRequest} req - The answer payload.
+     *
+     * @returns {Promise<SubmitLevelTestAnswerResponse>} Immediate feedback (isCorrect, correctAnswer).
+     */
+    async do(req: SubmitLevelTestAnswerRequest, _userContext?: UserContext): Promise<SubmitLevelTestAnswerResponse> {
+
+        const config = this.config as ControllerConfig;
+        const db = await config.getMongoDb(config.getDBName());
+
+        const attemptStore = new LevelTestAttemptStore({ db, config });
+        const attempt = await attemptStore.findById(req.attemptId);
+
+        if (!attempt) throw new ValidationError(404, `Level test attempt ${req.attemptId} not found`);
+        if (attempt.takenAt !== null) throw new ValidationError(400, "Attempt is already submitted");
+
+        if (!attempt.exerciseIds.includes(req.exerciseId)) {
+            throw new ValidationError(400, `Exercise ${req.exerciseId} is not part of this attempt`);
+        }
+
+        const exerciseStore = new ExerciseStore(db);
+        const exercise = await exerciseStore.findById(req.exerciseId);
+
+        if (!exercise) throw new ValidationError(404, `Exercise ${req.exerciseId} not found`);
+
+        const { isCorrect, correctAnswer } = checkAnswer(req.userAnswer, exercise);
+
+        const now = new Date().toISOString();
+
+        await attemptStore.appendAnswer(req.attemptId, { exerciseId: req.exerciseId, isCorrect, userAnswer: req.userAnswer, answeredAt: now });
+
+        await attemptStore.advancePosition(req.attemptId);
+
+        await exerciseStore.incrementTimesShown(req.exerciseId);
+
+        return { isCorrect, correctAnswer };
+    }
+}
+
+interface SubmitLevelTestAnswerRequest {
+    userId: string;     // The user id
+    attemptId: string;  // The level test attempt id
+    exerciseId: string; // The exercise being answered
+    userAnswer: string; // The raw answer string submitted by the user
+}
+
+interface SubmitLevelTestAnswerResponse {
+    isCorrect: boolean;     // Whether the answer was judged correct
+    correctAnswer: string;  // The correct answer; always returned for immediate feedback
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,12 @@ import { GetTestReview } from './dlg/moduleTests/GetTestReview';
 import { PostLevelTestBank } from './dlg/levelTestBanks/PostLevelTestBank';
 import { PostLevelTestBankExercises } from './dlg/levelTestBanks/PostLevelTestBankExercises';
 import { GetLevelTestBank } from './dlg/levelTestBanks/GetLevelTestBank';
+import { GetLevelTestEligibility } from './dlg/levelTests/GetLevelTestEligibility';
+import { StartLevelTest } from './dlg/levelTests/StartLevelTest';
+import { GetLevelTest } from './dlg/levelTests/GetLevelTest';
+import { SubmitLevelTestAnswer } from './dlg/levelTests/SubmitLevelTestAnswer';
+import { SubmitLevelTest } from './dlg/levelTests/SubmitLevelTest';
+import { GetLevelTestReview } from './dlg/levelTests/GetLevelTestReview';
 
 const config: TotoMicroserviceConfiguration = {
     serviceName: "tome-ms-language",
@@ -124,6 +130,13 @@ const config: TotoMicroserviceConfiguration = {
             { method: 'POST', path: '/levelTestBanks', delegate: PostLevelTestBank },
             { method: 'POST', path: '/levelTestBanks/:cefrLevel/exercises', delegate: PostLevelTestBankExercises },
             { method: 'GET', path: '/levelTestBanks/:cefrLevel', delegate: GetLevelTestBank },
+
+            { method: 'GET', path: '/users/:userId/levelTest/eligibility', delegate: GetLevelTestEligibility },
+            { method: 'POST', path: '/users/:userId/levelTests', delegate: StartLevelTest },
+            { method: 'GET', path: '/users/:userId/levelTests/:attemptId', delegate: GetLevelTest },
+            { method: 'POST', path: '/users/:userId/levelTests/:attemptId/answers', delegate: SubmitLevelTestAnswer },
+            { method: 'POST', path: '/users/:userId/levelTests/:attemptId/submit', delegate: SubmitLevelTest },
+            { method: 'GET', path: '/users/:userId/levelTests/:attemptId/review', delegate: GetLevelTestReview },
         ],
         apiOptions: { noCorrelationId: true }
     },

--- a/src/model/LevelTestAttempt.ts
+++ b/src/model/LevelTestAttempt.ts
@@ -1,0 +1,111 @@
+import { WithId } from "mongodb";
+import { ExerciseResult } from "./ExerciseResult";
+import { TestAnswer } from "./ModuleTestAttempt";
+
+/**
+ * A stateful, resumable Level Test attempt (F21).
+ *
+ * The Level Test is a graded parallel of the practice session (F10) / module test (F11),
+ * scoped to a full CEFR level rather than a single module. Lifecycle:
+ * created on POST .../levelTests → answers accumulated via POST .../levelTests/:id/answers
+ * → finalised on POST .../levelTests/:id/submit (takenAt set, score/passed computed).
+ * While takenAt is null the attempt is in-progress and can be resumed.
+ *
+ * The full document lives in the `levelTestAttempts` collection. Unlike the module test,
+ * there is no per-module progress doc: the most recent submitted attempt for a
+ * (userId, cefrLevel) pair is queried directly to enforce the inter-attempt cooldown.
+ */
+export class LevelTestAttempt {
+
+    id?: string;                        // MongoDB _id as a hex string; absent before first save
+    userId: string;                     // The user who owns this attempt
+    cefrLevel: string;                  // The CEFR level being tested (A1..C2)
+    exerciseIds: string[];              // Ordered list of exercise ids for this attempt (set at start, never changed)
+    answers: TestAnswer[];              // All answers submitted so far — one per exercise, first answer is final
+    currentPosition: number;            // 0-based index of the next unanswered exercise
+    verifiedExerciseIds: string[];      // Exercise ids for which AI answer verification (F13) was already used this attempt
+    score: number | null;               // Percentage correct (0–100); null until the attempt is submitted
+    passed: boolean | null;             // Whether score >= LEVEL_TEST_PASS_THRESHOLD; null until the attempt is submitted
+    startedAt: string;                  // ISO-8601 timestamp of when the attempt was started
+    takenAt: string | null;             // ISO-8601 timestamp of submission; null while in-progress
+    exerciseResults: ExerciseResult[];  // Per-exercise mastery results (F06); populated on submit
+
+    constructor({ id, userId, cefrLevel, exerciseIds, answers, currentPosition, verifiedExerciseIds, score, passed, startedAt, takenAt, exerciseResults }: LevelTestAttemptInput) {
+
+        this.id = id;
+        this.userId = userId;
+        this.cefrLevel = cefrLevel;
+        this.exerciseIds = exerciseIds ?? [];
+        this.answers = answers ?? [];
+        this.currentPosition = currentPosition ?? 0;
+        this.verifiedExerciseIds = verifiedExerciseIds ?? [];
+        this.score = score ?? null;
+        this.passed = passed ?? null;
+        this.startedAt = startedAt;
+        this.takenAt = takenAt ?? null;
+        this.exerciseResults = exerciseResults ?? [];
+    }
+
+    /**
+     * Creates a LevelTestAttempt from a raw MongoDB BSON document.
+     *
+     * @param {WithId<any>} data - The BSON document read from MongoDB.
+     *
+     * @returns {LevelTestAttempt} The reconstructed attempt instance.
+     */
+    static fromBSON(data: WithId<any>): LevelTestAttempt {
+
+        return new LevelTestAttempt({
+            id: data._id.toString(),
+            userId: data.userId,
+            cefrLevel: data.cefrLevel,
+            exerciseIds: data.exerciseIds ?? [],
+            answers: data.answers ?? [],
+            currentPosition: data.currentPosition ?? 0,
+            verifiedExerciseIds: data.verifiedExerciseIds ?? [],
+            score: data.score ?? null,
+            passed: data.passed ?? null,
+            startedAt: data.startedAt,
+            takenAt: data.takenAt ?? null,
+            exerciseResults: (data.exerciseResults ?? []).map((r: any) => ExerciseResult.fromBSON(r)),
+        });
+    }
+
+    /**
+     * Serializes the attempt to a plain object for MongoDB storage.
+     * Does not include _id — MongoDB generates it on insert.
+     *
+     * @returns {any} The BSON-ready plain object.
+     */
+    toBSON(): any {
+
+        return {
+            userId: this.userId,
+            cefrLevel: this.cefrLevel,
+            exerciseIds: this.exerciseIds,
+            answers: this.answers,
+            currentPosition: this.currentPosition,
+            verifiedExerciseIds: this.verifiedExerciseIds,
+            score: this.score,
+            passed: this.passed,
+            startedAt: this.startedAt,
+            takenAt: this.takenAt,
+            exerciseResults: this.exerciseResults.map(r => r.toBSON()),
+        };
+    }
+}
+
+export interface LevelTestAttemptInput {
+    id?: string;                            // MongoDB _id as a hex string; absent before first save
+    userId: string;                         // The user who owns this attempt
+    cefrLevel: string;                      // The CEFR level being tested
+    exerciseIds?: string[];                 // Ordered list of exercise ids for this attempt
+    answers?: TestAnswer[];                 // Answers submitted so far
+    currentPosition?: number;               // 0-based index of the next unanswered exercise
+    verifiedExerciseIds?: string[];         // Exercise ids AI-verified this attempt (F13)
+    score?: number | null;                  // Percentage correct (0–100); null until submitted
+    passed?: boolean | null;                // Whether the attempt passed; null until submitted
+    startedAt: string;                      // ISO-8601 timestamp of when the attempt was started
+    takenAt?: string | null;                // ISO-8601 submission timestamp; null while in-progress
+    exerciseResults?: ExerciseResult[];     // Per-exercise mastery results; populated on submit
+}

--- a/src/store/LevelTestAttemptStore.ts
+++ b/src/store/LevelTestAttemptStore.ts
@@ -1,0 +1,177 @@
+import { Db, ObjectId } from "mongodb";
+import { ControllerConfig } from "../Config";
+import { LevelTestAttempt } from "../model/LevelTestAttempt";
+import { TestAnswer } from "../model/ModuleTestAttempt";
+import { ExerciseResult } from "../model/ExerciseResult";
+
+const COLLECTION = "levelTestAttempts";
+
+/**
+ * Encapsulates all database access for the `levelTestAttempts` collection.
+ * Each document is a full stateful Level Test attempt (F21).
+ */
+export class LevelTestAttemptStore {
+
+    private db: Db;
+    private config: ControllerConfig;
+
+    constructor({ db, config }: { db: Db; config: ControllerConfig }) {
+
+        this.db = db;
+        this.config = config;
+    }
+
+    /**
+     * Inserts a new LevelTestAttempt document and returns the MongoDB-generated _id as a string.
+     *
+     * @param {LevelTestAttempt} attempt - The attempt to persist.
+     *
+     * @returns {Promise<string>} The inserted document's _id as a hex string.
+     */
+    async create(attempt: LevelTestAttempt): Promise<string> {
+
+        const result = await this.db.collection(COLLECTION).insertOne(attempt.toBSON());
+
+        return result.insertedId.toString();
+    }
+
+    /**
+     * Finds a single attempt by its MongoDB _id. Returns null if no document matches.
+     *
+     * @param {string} attemptId - The hex-string _id to look up.
+     *
+     * @returns {Promise<LevelTestAttempt | null>} The found attempt, or null.
+     */
+    async findById(attemptId: string): Promise<LevelTestAttempt | null> {
+
+        const doc = await this.db.collection(COLLECTION).findOne({ _id: new ObjectId(attemptId) });
+
+        if (!doc) return null;
+
+        return LevelTestAttempt.fromBSON(doc as any);
+    }
+
+    /**
+     * Returns the single in-progress (un-submitted) attempt for a user + level pair.
+     * An attempt is in-progress when its `takenAt` field is null.
+     *
+     * @param {string} userId - The user id.
+     * @param {string} cefrLevel - The CEFR level.
+     *
+     * @returns {Promise<LevelTestAttempt | null>} The active attempt, or null.
+     */
+    async findActiveByUserAndLevel(userId: string, cefrLevel: string): Promise<LevelTestAttempt | null> {
+
+        const doc = await this.db.collection(COLLECTION).findOne({ userId, cefrLevel, takenAt: null });
+
+        if (!doc) return null;
+
+        return LevelTestAttempt.fromBSON(doc as any);
+    }
+
+    /**
+     * Returns the most recently submitted attempt for a user + level pair, used to
+     * enforce the inter-attempt cooldown (F21). Submitted attempts have a non-null `takenAt`.
+     *
+     * @param {string} userId - The user id.
+     * @param {string} cefrLevel - The CEFR level.
+     *
+     * @returns {Promise<LevelTestAttempt | null>} The most recent submitted attempt, or null.
+     */
+    async findMostRecentSubmittedByUserAndLevel(userId: string, cefrLevel: string): Promise<LevelTestAttempt | null> {
+
+        const docs = await this.db.collection(COLLECTION).find({ userId, cefrLevel, takenAt: { $ne: null } }).sort({ takenAt: -1 }).limit(1).toArray();
+
+        if (docs.length === 0) return null;
+
+        return LevelTestAttempt.fromBSON(docs[0] as any);
+    }
+
+    /**
+     * Appends a TestAnswer to the attempt's answers array.
+     * The first answer to each exercise is final for grading — there is no retry mechanism.
+     *
+     * @param {string} attemptId - The attempt _id.
+     * @param {TestAnswer} answer - The answer to append.
+     */
+    async appendAnswer(attemptId: string, answer: TestAnswer): Promise<void> {
+
+        await this.db.collection(COLLECTION).updateOne(
+            { _id: new ObjectId(attemptId) },
+            { $push: { answers: answer } } as any
+        );
+    }
+
+    /**
+     * Increments `currentPosition` by 1, advancing the cursor to the next exercise.
+     *
+     * @param {string} attemptId - The attempt _id.
+     */
+    async advancePosition(attemptId: string): Promise<void> {
+
+        await this.db.collection(COLLECTION).updateOne(
+            { _id: new ObjectId(attemptId) },
+            { $inc: { currentPosition: 1 } }
+        );
+    }
+
+    /**
+     * Appends an exercise id to `verifiedExerciseIds`.
+     * Used by the F13 answer verification flow to enforce the one-per-attempt guard.
+     *
+     * @param {string} attemptId - The attempt _id.
+     * @param {string} exerciseId - The exercise id to mark as AI-verified.
+     */
+    async addVerifiedExerciseId(attemptId: string, exerciseId: string): Promise<void> {
+
+        await this.db.collection(COLLECTION).updateOne(
+            { _id: new ObjectId(attemptId) },
+            { $push: { verifiedExerciseIds: exerciseId } } as any
+        );
+    }
+
+    /**
+     * Flips the stored `isCorrect` flag to true for the given exercise in the answers array.
+     * Called by the F13 answer verification flow when the AI validates a translation.
+     *
+     * @param {string} attemptId - The attempt _id.
+     * @param {string} exerciseId - The exercise id whose answer should be flipped to correct.
+     */
+    async flipAnswerToCorrect(attemptId: string, exerciseId: string): Promise<void> {
+
+        await this.db.collection(COLLECTION).updateOne(
+            { _id: new ObjectId(attemptId), "answers.exerciseId": exerciseId },
+            { $set: { "answers.$.isCorrect": true } } as any
+        );
+    }
+
+    /**
+     * Finalises a Level Test attempt by persisting the computed score, pass/fail verdict,
+     * submission timestamp, and per-exercise mastery results. Sets `takenAt` to mark the
+     * attempt as submitted — after this call `findActiveByUserAndLevel` no longer returns it.
+     *
+     * @param {string} attemptId - The attempt _id.
+     * @param {SubmitParams} params - The grading outcome to persist.
+     */
+    async submit(attemptId: string, { score, passed, takenAt, exerciseResults }: SubmitParams): Promise<void> {
+
+        await this.db.collection(COLLECTION).updateOne(
+            { _id: new ObjectId(attemptId) },
+            {
+                $set: {
+                    score,
+                    passed,
+                    takenAt,
+                    exerciseResults: exerciseResults.map(r => r.toBSON()),
+                },
+            } as any
+        );
+    }
+}
+
+interface SubmitParams {
+    score: number;                      // Percentage correct (0–100)
+    passed: boolean;                    // Whether score >= LEVEL_TEST_PASS_THRESHOLD
+    takenAt: string;                    // ISO-8601 submission timestamp
+    exerciseResults: ExerciseResult[];  // Per-exercise mastery results for F06
+}

--- a/src/store/UserStore.ts
+++ b/src/store/UserStore.ts
@@ -27,6 +27,23 @@ export class UserStore {
     }
 
     /**
+     * Finds a user by their internal id (the `id` field used across progress records).
+     * Returns null if not found.
+     *
+     * @param {string} userId - The user's internal id.
+     *
+     * @returns {Promise<User | null>} The user, or null.
+     */
+    async findById(userId: string): Promise<User | null> {
+
+        const doc = await this.db.collection(USERS_COLLECTION).findOne({ id: userId });
+
+        if (!doc) return null;
+
+        return User.fromBSON(doc as any);
+    }
+
+    /**
      * Inserts a new user document. Returns the created user.
      */
     async create(user: User): Promise<User> {

--- a/test/dlg/levelTests/GetLevelTest.do.test.ts
+++ b/test/dlg/levelTests/GetLevelTest.do.test.ts
@@ -1,0 +1,88 @@
+import { assert } from "chai";
+import { ObjectId } from "mongodb";
+import { GetLevelTest } from "../../../src/dlg/levelTests/GetLevelTest";
+import { Exercise } from "../../../src/model/Exercise";
+
+function makeExerciseBSON(id: string): any {
+    return new Exercise({ id, moduleId: null, type: "translation_active", prompt: `prompt-${id}`, answer: `answer-${id}`, vocabularyItemId: "v-1", grammarConceptId: null }).toBSON();
+}
+
+function makeAttemptBSON(oid: ObjectId, overrides: any = {}): any {
+    return {
+        _id: oid,
+        userId: "user-1",
+        cefrLevel: "A1",
+        exerciseIds: ["ex-1", "ex-2"],
+        answers: [{ exerciseId: "ex-1", isCorrect: true, userAnswer: "hej", answeredAt: "2026-06-16T10:00:00.000Z" }],
+        currentPosition: 1,
+        verifiedExerciseIds: [],
+        score: null,
+        passed: null,
+        startedAt: "2026-06-16T09:00:00.000Z",
+        takenAt: null,
+        exerciseResults: [],
+        ...overrides,
+    };
+}
+
+function makeMockConfig(attemptDoc: any | null, exerciseDocs: any[]) {
+
+    const collections: Record<string, any> = {
+        levelTestAttempts: { findOne: async (f: any) => (attemptDoc && attemptDoc._id.equals(f._id) ? attemptDoc : null) },
+        exercises: { find: () => ({ toArray: async () => exerciseDocs }) },
+    };
+
+    return { getDBName: () => "test", getMongoDb: async () => ({ collection: (name: string) => collections[name] }) } as any;
+}
+
+describe("GetLevelTest.do", () => {
+
+    it("returns the attempt state with full exercises, answers and currentPosition", async () => {
+
+        const oid = new ObjectId();
+        const config = makeMockConfig(makeAttemptBSON(oid), [makeExerciseBSON("ex-1"), makeExerciseBSON("ex-2")]);
+        const delegate = new GetLevelTest({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        assert.equal(result.attemptId, oid.toString());
+        assert.equal(result.cefrLevel, "A1");
+        assert.equal(result.exercises.length, 2);
+        assert.equal(result.answers.length, 1);
+        assert.equal(result.currentPosition, 1);
+        assert.equal(result.takenAt, null);
+    });
+
+    it("throws 404 when the attempt does not exist", async () => {
+
+        const config = makeMockConfig(null, []);
+        const delegate = new GetLevelTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", attemptId: new ObjectId().toString() }, {} as any);
+            assert.fail("Expected 404");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 404);
+        }
+    });
+
+    it("throws 403 when the attempt belongs to a different user", async () => {
+
+        const oid = new ObjectId();
+        const config = makeMockConfig(makeAttemptBSON(oid, { userId: "someone-else" }), [makeExerciseBSON("ex-1")]);
+        const delegate = new GetLevelTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+            assert.fail("Expected 403");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 403);
+        }
+    });
+});

--- a/test/dlg/levelTests/GetLevelTestEligibility.do.test.ts
+++ b/test/dlg/levelTests/GetLevelTestEligibility.do.test.ts
@@ -1,0 +1,202 @@
+import { assert } from "chai";
+import { ObjectId } from "mongodb";
+import { GetLevelTestEligibility } from "../../../src/dlg/levelTests/GetLevelTestEligibility";
+import { Module } from "../../../src/model/Module";
+import { User } from "../../../src/model/User";
+import { UserModuleProgress } from "../../../src/model/UserModuleProgress";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeModule(id: string, isUserGenerated = false): Module {
+    return new Module({
+        id,
+        title: id,
+        theme: "t",
+        communicationGoal: "g",
+        cefrLevel: "A1",
+        vocabularyItemIds: ["v-1"],
+        grammarConceptIds: [],
+        isUserGenerated,
+    });
+}
+
+function makeProgress(moduleId: string, status: "available" | "in_progress" | "completed"): UserModuleProgress {
+    return new UserModuleProgress({
+        userId: "user-1",
+        moduleId,
+        status,
+        startedAt: "2026-06-01T09:00:00.000Z",
+        completedAt: status === "completed" ? "2026-06-02T09:00:00.000Z" : null,
+        testAttempts: [],
+        practiceCompletedAt: null,
+    });
+}
+
+/**
+ * Builds a mock config wiring users, modules, userModuleProgress and levelTestAttempts.
+ * `modules` respects the cefrLevel + isUserGenerated filter so curated/user-generated
+ * scoping can be asserted.
+ */
+function makeMockConfig(opts: { user?: any; modules: Module[]; progress: UserModuleProgress[]; activeAttempt?: any | null; submittedAttempts?: any[]; }) {
+
+    const userDoc = opts.user ?? new User({ id: "user-1", email: "u@e.com", cefrLevel: "A1", createdAt: "2026-01-01T00:00:00.000Z" }).toBSON();
+    const moduleDocs = opts.modules.map(m => m.toBSON());
+    const progressDocs = opts.progress.map(p => p.toBSON());
+    const submitted = opts.submittedAttempts ?? [];
+
+    const collections: Record<string, any> = {
+        users: {
+            findOne: async (f: any) => (userDoc && userDoc.id === f.id ? userDoc : null),
+        },
+        modules: {
+            find: (filter: any) => ({
+                sort: () => ({
+                    toArray: async () => moduleDocs.filter(d =>
+                        (filter.cefrLevel === undefined || d.cefrLevel === filter.cefrLevel) &&
+                        (filter.isUserGenerated === undefined || d.isUserGenerated === filter.isUserGenerated)
+                    ),
+                }),
+            }),
+        },
+        userModuleProgress: {
+            find: () => ({ toArray: async () => progressDocs }),
+        },
+        levelTestAttempts: {
+            findOne: async (f: any) => (f.takenAt === null ? (opts.activeAttempt ?? null) : null),
+            find: () => ({ sort: () => ({ limit: () => ({ toArray: async () => submitted }) }) }),
+        },
+    };
+
+    return {
+        getDBName: () => "test",
+        getMongoDb: async () => ({ collection: (name: string) => collections[name] }),
+    } as any;
+}
+
+const NOW = new Date("2026-06-16T14:00:00.000Z");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GetLevelTestEligibility.do", () => {
+
+    it("is eligible when all curated modules at the level are completed", async () => {
+
+        const config = makeMockConfig({
+            modules: [makeModule("m1"), makeModule("m2")],
+            progress: [makeProgress("m1", "completed"), makeProgress("m2", "completed")],
+        });
+        const delegate = new GetLevelTestEligibility({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", now: NOW }, {} as any);
+
+        assert.isTrue(result.eligible);
+    });
+
+    it("is NOT eligible when a curated module is not completed", async () => {
+
+        const config = makeMockConfig({
+            modules: [makeModule("m1"), makeModule("m2")],
+            progress: [makeProgress("m1", "completed"), makeProgress("m2", "in_progress")],
+        });
+        const delegate = new GetLevelTestEligibility({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", now: NOW }, {} as any);
+
+        assert.isFalse(result.eligible);
+        assert.isString(result.reason);
+    });
+
+    it("ignores user-generated modules — eligible when only curated modules are completed", async () => {
+
+        const config = makeMockConfig({
+            // user-generated module is incomplete but must not block
+            modules: [makeModule("m1"), makeModule("ug", true)],
+            progress: [makeProgress("m1", "completed"), makeProgress("ug", "in_progress")],
+        });
+        const delegate = new GetLevelTestEligibility({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", now: NOW }, {} as any);
+
+        assert.isTrue(result.eligible);
+    });
+
+    it("is NOT eligible when the level has no curated modules", async () => {
+
+        const config = makeMockConfig({ modules: [makeModule("ug", true)], progress: [] });
+        const delegate = new GetLevelTestEligibility({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", now: NOW }, {} as any);
+
+        assert.isFalse(result.eligible);
+    });
+
+    it("is NOT eligible within the 30-minute cooldown after the most recent submitted attempt", async () => {
+
+        const tenMinutesAgo = new Date(NOW.getTime() - 10 * 60 * 1000).toISOString();
+        const config = makeMockConfig({
+            modules: [makeModule("m1")],
+            progress: [makeProgress("m1", "completed")],
+            submittedAttempts: [{ _id: new ObjectId(), userId: "user-1", cefrLevel: "A1", takenAt: tenMinutesAgo, passed: false, startedAt: tenMinutesAgo }],
+        });
+        const delegate = new GetLevelTestEligibility({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", now: NOW }, {} as any);
+
+        assert.isFalse(result.eligible);
+        assert.isString(result.retryAvailableAt);
+        assert.isNumber(result.remainingMs);
+    });
+
+    it("is eligible once the 30-minute cooldown has elapsed", async () => {
+
+        const fortyMinutesAgo = new Date(NOW.getTime() - 40 * 60 * 1000).toISOString();
+        const config = makeMockConfig({
+            modules: [makeModule("m1")],
+            progress: [makeProgress("m1", "completed")],
+            submittedAttempts: [{ _id: new ObjectId(), userId: "user-1", cefrLevel: "A1", takenAt: fortyMinutesAgo, passed: false, startedAt: fortyMinutesAgo }],
+        });
+        const delegate = new GetLevelTestEligibility({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", now: NOW }, {} as any);
+
+        assert.isTrue(result.eligible);
+    });
+
+    it("reports an active attempt so the client can resume it (eligible, bypasses cooldown)", async () => {
+
+        const tenMinutesAgo = new Date(NOW.getTime() - 10 * 60 * 1000).toISOString();
+        const activeOid = new ObjectId();
+        const config = makeMockConfig({
+            modules: [makeModule("m1")],
+            progress: [makeProgress("m1", "completed")],
+            activeAttempt: { _id: activeOid, userId: "user-1", cefrLevel: "A1", takenAt: null, startedAt: NOW.toISOString() },
+            submittedAttempts: [{ _id: new ObjectId(), userId: "user-1", cefrLevel: "A1", takenAt: tenMinutesAgo, passed: false, startedAt: tenMinutesAgo }],
+        });
+        const delegate = new GetLevelTestEligibility({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", now: NOW }, {} as any);
+
+        assert.isTrue(result.eligible);
+        assert.equal(result.activeAttemptId, activeOid.toString());
+    });
+
+    it("throws 404 when the user does not exist", async () => {
+
+        const config = makeMockConfig({ user: null, modules: [], progress: [] });
+        const delegate = new GetLevelTestEligibility({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "ghost", now: NOW }, {} as any);
+            assert.fail("Expected 404");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 404);
+        }
+    });
+});

--- a/test/dlg/levelTests/GetLevelTestReview.do.test.ts
+++ b/test/dlg/levelTests/GetLevelTestReview.do.test.ts
@@ -1,0 +1,170 @@
+import { assert } from "chai";
+import { ObjectId } from "mongodb";
+import { GetLevelTestReview } from "../../../src/dlg/levelTests/GetLevelTestReview";
+import { Exercise } from "../../../src/model/Exercise";
+
+function makeVocabExercise(id: string, vocabId: string): any {
+    return new Exercise({ id, moduleId: null, type: "translation_active", prompt: `prompt-${id}`, answer: `answer-${id}`, vocabularyItemId: vocabId, grammarConceptId: null }).toBSON();
+}
+
+function makeGrammarExercise(id: string, grammarId: string): any {
+    return new Exercise({ id, moduleId: null, type: "sentence_reorder", prompt: `prompt-${id}`, answer: `answer-${id}`, vocabularyItemId: null, grammarConceptId: grammarId }).toBSON();
+}
+
+function makeAttemptBSON(oid: ObjectId, overrides: any = {}): any {
+    return {
+        _id: oid,
+        userId: "user-1",
+        cefrLevel: "A1",
+        exerciseIds: ["ex-1", "ex-2", "ex-3"],
+        answers: [
+            { exerciseId: "ex-1", isCorrect: true, userAnswer: "answer-ex-1", answeredAt: "2026-06-16T10:00:00.000Z" },
+            { exerciseId: "ex-2", isCorrect: false, userAnswer: "oops", answeredAt: "2026-06-16T10:01:00.000Z" },
+            { exerciseId: "ex-3", isCorrect: false, userAnswer: "nope", answeredAt: "2026-06-16T10:02:00.000Z" },
+        ],
+        currentPosition: 3,
+        verifiedExerciseIds: [],
+        score: 33,
+        passed: false,
+        startedAt: "2026-06-16T09:00:00.000Z",
+        takenAt: "2026-06-16T10:05:00.000Z",
+        exerciseResults: [],
+        ...overrides,
+    };
+}
+
+function makeMockConfig(attemptDoc: any | null, exerciseDocs: any[]) {
+
+    const collections: Record<string, any> = {
+        levelTestAttempts: { findOne: async (f: any) => (attemptDoc && attemptDoc._id.equals(f._id) ? attemptDoc : null) },
+        exercises: { find: () => ({ toArray: async () => exerciseDocs }) },
+    };
+
+    return { getDBName: () => "test", getMongoDb: async () => ({ collection: (name: string) => collections[name] }) } as any;
+}
+
+describe("GetLevelTestReview.do", () => {
+
+    it("returns the score, passed flag, and per-question review with correct answers", async () => {
+
+        const oid = new ObjectId();
+        const exercises = [makeVocabExercise("ex-1", "v-1"), makeVocabExercise("ex-2", "v-2"), makeGrammarExercise("ex-3", "g-1")];
+        const config = makeMockConfig(makeAttemptBSON(oid), exercises);
+        const delegate = new GetLevelTestReview({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        assert.equal(result.score, 33);
+        assert.isFalse(result.passed);
+        assert.equal(result.questions.length, 3);
+        assert.equal(result.questions[0].correctAnswer, "answer-ex-1");
+        assert.equal(result.questions[1].userAnswer, "oops");
+    });
+
+    it("derives weak areas from incorrect answers grouped by vocabulary item and grammar concept", async () => {
+
+        const oid = new ObjectId();
+        const exercises = [makeVocabExercise("ex-1", "v-1"), makeVocabExercise("ex-2", "v-2"), makeGrammarExercise("ex-3", "g-1")];
+        const config = makeMockConfig(makeAttemptBSON(oid), exercises);
+        const delegate = new GetLevelTestReview({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        // ex-1 correct (v-1 not weak); ex-2 wrong (v-2 weak); ex-3 wrong (g-1 weak)
+        assert.deepEqual(result.weakAreas.vocabulary, ["v-2"]);
+        assert.deepEqual(result.weakAreas.grammar, ["g-1"]);
+    });
+
+    it("reports empty weak areas when all answers are correct", async () => {
+
+        const oid = new ObjectId();
+        const allCorrect = makeAttemptBSON(oid, {
+            answers: [
+                { exerciseId: "ex-1", isCorrect: true, userAnswer: "a", answeredAt: "2026-06-16T10:00:00.000Z" },
+                { exerciseId: "ex-2", isCorrect: true, userAnswer: "b", answeredAt: "2026-06-16T10:01:00.000Z" },
+                { exerciseId: "ex-3", isCorrect: true, userAnswer: "c", answeredAt: "2026-06-16T10:02:00.000Z" },
+            ],
+            score: 100,
+            passed: true,
+        });
+        const exercises = [makeVocabExercise("ex-1", "v-1"), makeVocabExercise("ex-2", "v-2"), makeGrammarExercise("ex-3", "g-1")];
+        const config = makeMockConfig(allCorrect, exercises);
+        const delegate = new GetLevelTestReview({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        assert.deepEqual(result.weakAreas.vocabulary, []);
+        assert.deepEqual(result.weakAreas.grammar, []);
+    });
+
+    it("treats unanswered exercises as incorrect (empty userAnswer) and weak", async () => {
+
+        const oid = new ObjectId();
+        const partial = makeAttemptBSON(oid, {
+            answers: [{ exerciseId: "ex-1", isCorrect: true, userAnswer: "answer-ex-1", answeredAt: "2026-06-16T10:00:00.000Z" }],
+            score: 33,
+            passed: false,
+        });
+        const exercises = [makeVocabExercise("ex-1", "v-1"), makeVocabExercise("ex-2", "v-2"), makeGrammarExercise("ex-3", "g-1")];
+        const config = makeMockConfig(partial, exercises);
+        const delegate = new GetLevelTestReview({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        const unanswered = result.questions.find(q => q.exerciseId === "ex-2");
+        assert.equal(unanswered!.userAnswer, "");
+        assert.isFalse(unanswered!.isCorrect);
+        assert.deepEqual(result.weakAreas.vocabulary, ["v-2"]);
+        assert.deepEqual(result.weakAreas.grammar, ["g-1"]);
+    });
+
+    it("throws 404 when the attempt does not exist", async () => {
+
+        const config = makeMockConfig(null, []);
+        const delegate = new GetLevelTestReview({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", attemptId: new ObjectId().toString() }, {} as any);
+            assert.fail("Expected 404");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 404);
+        }
+    });
+
+    it("throws 403 when the attempt belongs to a different user", async () => {
+
+        const oid = new ObjectId();
+        const config = makeMockConfig(makeAttemptBSON(oid, { userId: "someone-else" }), [makeVocabExercise("ex-1", "v-1")]);
+        const delegate = new GetLevelTestReview({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+            assert.fail("Expected 403");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 403);
+        }
+    });
+
+    it("throws 400 when the attempt is not yet submitted", async () => {
+
+        const oid = new ObjectId();
+        const config = makeMockConfig(makeAttemptBSON(oid, { takenAt: null }), [makeVocabExercise("ex-1", "v-1")]);
+        const delegate = new GetLevelTestReview({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+            assert.fail("Expected 400");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 400);
+        }
+    });
+});

--- a/test/dlg/levelTests/StartLevelTest.do.test.ts
+++ b/test/dlg/levelTests/StartLevelTest.do.test.ts
@@ -1,0 +1,226 @@
+import { assert } from "chai";
+import { ObjectId } from "mongodb";
+import { StartLevelTest } from "../../../src/dlg/levelTests/StartLevelTest";
+import { Exercise } from "../../../src/model/Exercise";
+import { Module } from "../../../src/model/Module";
+import { User } from "../../../src/model/User";
+import { UserModuleProgress } from "../../../src/model/UserModuleProgress";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeModule(id: string, isUserGenerated = false): Module {
+    return new Module({ id, title: id, theme: "t", communicationGoal: "g", cefrLevel: "A1", vocabularyItemIds: ["v-1"], grammarConceptIds: [], isUserGenerated });
+}
+
+function makeProgress(moduleId: string, status: "in_progress" | "completed"): UserModuleProgress {
+    return new UserModuleProgress({ userId: "user-1", moduleId, status, startedAt: "2026-06-01T09:00:00.000Z", completedAt: null, testAttempts: [], practiceCompletedAt: null });
+}
+
+function makeExercise(id: string, vocabId: string): Exercise {
+    return new Exercise({ id, moduleId: null, type: "translation_active", prompt: `prompt-${id}`, answer: `answer-${id}`, vocabularyItemId: vocabId, grammarConceptId: null });
+}
+
+/**
+ * Builds a bank exercise pool of `n` exercises spread across `vocabCount` vocab items
+ * (so the dedup-by-item draw has enough distinct items to reach 40).
+ */
+function makeBankPool(n: number, vocabCount: number): Exercise[] {
+    return Array.from({ length: n }, (_, i) => makeExercise(`ex-${i + 1}`, `v-${i % vocabCount}`));
+}
+
+interface MockOpts {
+    user?: any;
+    modules?: Module[];
+    progress?: UserModuleProgress[];
+    bank?: any | null;            // levelTestBank doc, or null for 404
+    exercises?: Exercise[];
+    activeAttempt?: any | null;
+    submittedAttempts?: any[];
+}
+
+function makeMockConfig(opts: MockOpts) {
+
+    const userDoc = opts.user === undefined ? new User({ id: "user-1", email: "u@e.com", cefrLevel: "A1", createdAt: "2026-01-01T00:00:00.000Z" }).toBSON() : opts.user;
+    const moduleDocs = (opts.modules ?? [makeModule("m1")]).map(m => m.toBSON());
+    const progressDocs = (opts.progress ?? [makeProgress("m1", "completed")]).map(p => p.toBSON());
+    const exerciseDocs = (opts.exercises ?? []).map(e => e.toBSON());
+    const exerciseMap = new Map(exerciseDocs.map((e: any) => [e.id, e]));
+    const insertedOid = new ObjectId();
+
+    let createdAttempt: any = null;
+
+    const collections: Record<string, any> = {
+        users: { findOne: async (f: any) => (userDoc && userDoc.id === f.id ? userDoc : null) },
+        modules: {
+            find: (filter: any) => ({ sort: () => ({ toArray: async () => moduleDocs.filter(d =>
+                (filter.cefrLevel === undefined || d.cefrLevel === filter.cefrLevel) &&
+                (filter.isUserGenerated === undefined || d.isUserGenerated === filter.isUserGenerated)) }) }),
+        },
+        userModuleProgress: { find: () => ({ toArray: async () => progressDocs }) },
+        levelTestBanks: { findOne: async () => (opts.bank === undefined ? { id: "bank-A1", cefrLevel: "A1", exerciseIds: exerciseDocs.map((e: any) => e.id), generatedAt: "2026-01-01", totalGenerated: exerciseDocs.length } : opts.bank) },
+        exercises: {
+            find: (filter: any) => {
+                const ids: string[] = filter?.id?.$in ?? [];
+                return { toArray: async () => ids.map(id => exerciseMap.get(id)).filter(Boolean) };
+            },
+        },
+        userVocabularyProgress: { find: () => ({ toArray: async () => [] }) },
+        userGrammarProgress: { find: () => ({ toArray: async () => [] }) },
+        levelTestAttempts: {
+            findOne: async (f: any) => (f.takenAt === null ? (opts.activeAttempt ?? null) : null),
+            find: () => ({ sort: () => ({ limit: () => ({ toArray: async () => opts.submittedAttempts ?? [] }) }) }),
+            insertOne: async (doc: any) => { createdAttempt = doc; return { insertedId: insertedOid }; },
+        },
+    };
+
+    return {
+        config: { getDBName: () => "test", getMongoDb: async () => ({ collection: (name: string) => collections[name] }) } as any,
+        getCreatedAttempt: () => createdAttempt,
+        insertedOid,
+    };
+}
+
+const NOW = new Date("2026-06-16T14:00:00.000Z");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("StartLevelTest.do", () => {
+
+    it("draws exactly 40 exercises from the level bank and returns full exercise objects", async () => {
+
+        const { config } = makeMockConfig({ exercises: makeBankPool(60, 60) });
+        const delegate = new StartLevelTest({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", now: NOW }, {} as any);
+
+        assert.isString(result.attemptId);
+        assert.equal(result.cefrLevel, "A1");
+        assert.equal(result.exercises.length, 40);
+        for (const ex of result.exercises) assert.isString((ex as any).answer);
+    });
+
+    it("persists the attempt with cefrLevel and the selected exerciseIds", async () => {
+
+        const { config, getCreatedAttempt } = makeMockConfig({ exercises: makeBankPool(60, 60) });
+        const delegate = new StartLevelTest({} as any, config);
+
+        await delegate.do({ userId: "user-1", now: NOW }, {} as any);
+
+        const created = getCreatedAttempt();
+        assert.equal(created.cefrLevel, "A1");
+        assert.equal(created.exerciseIds.length, 40);
+        assert.equal(created.takenAt, null);
+        assert.equal(created.currentPosition, 0);
+    });
+
+    it("throws 409 with the existing attemptId when an active attempt already exists", async () => {
+
+        const existingOid = new ObjectId();
+        const { config } = makeMockConfig({
+            exercises: makeBankPool(60, 60),
+            activeAttempt: { _id: existingOid, userId: "user-1", cefrLevel: "A1", takenAt: null, startedAt: NOW.toISOString(), exerciseIds: [], answers: [], currentPosition: 0, verifiedExerciseIds: [], score: null, passed: null, exerciseResults: [] },
+        });
+        const delegate = new StartLevelTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", now: NOW }, {} as any);
+            assert.fail("Expected 409");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 409);
+            assert.equal(err.attemptId, existingOid.toString());
+        }
+    });
+
+    it("throws 400 when not all curated modules are completed", async () => {
+
+        const { config } = makeMockConfig({
+            modules: [makeModule("m1"), makeModule("m2")],
+            progress: [makeProgress("m1", "completed"), makeProgress("m2", "in_progress")],
+            exercises: makeBankPool(60, 60),
+        });
+        const delegate = new StartLevelTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", now: NOW }, {} as any);
+            assert.fail("Expected 400");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 400);
+        }
+    });
+
+    it("throws 400 when the 30-minute cooldown has not elapsed", async () => {
+
+        const tenMinutesAgo = new Date(NOW.getTime() - 10 * 60 * 1000).toISOString();
+        const { config } = makeMockConfig({
+            exercises: makeBankPool(60, 60),
+            submittedAttempts: [{ _id: new ObjectId(), userId: "user-1", cefrLevel: "A1", takenAt: tenMinutesAgo, passed: false, startedAt: tenMinutesAgo }],
+        });
+        const delegate = new StartLevelTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", now: NOW }, {} as any);
+            assert.fail("Expected 400");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 400);
+        }
+    });
+
+    it("allows starting once the cooldown has elapsed", async () => {
+
+        const fortyMinutesAgo = new Date(NOW.getTime() - 40 * 60 * 1000).toISOString();
+        const { config } = makeMockConfig({
+            exercises: makeBankPool(60, 60),
+            submittedAttempts: [{ _id: new ObjectId(), userId: "user-1", cefrLevel: "A1", takenAt: fortyMinutesAgo, passed: false, startedAt: fortyMinutesAgo }],
+        });
+        const delegate = new StartLevelTest({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", now: NOW }, {} as any);
+
+        assert.equal(result.exercises.length, 40);
+    });
+
+    it("throws 404 when no level test bank exists for the user's level", async () => {
+
+        const { config } = makeMockConfig({ bank: null, exercises: makeBankPool(60, 60) });
+        const delegate = new StartLevelTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", now: NOW }, {} as any);
+            assert.fail("Expected 404");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 404);
+        }
+    });
+
+    it("throws 404 when the user does not exist", async () => {
+
+        const { config } = makeMockConfig({ user: null });
+        const delegate = new StartLevelTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "ghost", now: NOW }, {} as any);
+            assert.fail("Expected 404");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 404);
+        }
+    });
+});

--- a/test/dlg/levelTests/SubmitLevelTest.do.test.ts
+++ b/test/dlg/levelTests/SubmitLevelTest.do.test.ts
@@ -1,0 +1,230 @@
+import { assert } from "chai";
+import { ObjectId } from "mongodb";
+import { SubmitLevelTest } from "../../../src/dlg/levelTests/SubmitLevelTest";
+import { Exercise } from "../../../src/model/Exercise";
+import { User } from "../../../src/model/User";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeExerciseBSON(id: string, vocabId: string = "v-1"): any {
+    return new Exercise({ id, moduleId: null, type: "translation_active", prompt: `prompt-${id}`, answer: `answer-${id}`, vocabularyItemId: vocabId, grammarConceptId: null }).toBSON();
+}
+
+/**
+ * Builds an attempt BSON with `count` exercises, `correctCount` of which are answered correctly.
+ * The remaining (count - answeredCount) are left unanswered.
+ */
+function makeAttemptBSON(oid: ObjectId, count: number, correctCount: number, overrides: any = {}): any {
+
+    const exerciseIds = Array.from({ length: count }, (_, i) => `ex-${i + 1}`);
+    const answeredCount = overrides.answeredCount ?? count;
+    const answers = exerciseIds.slice(0, answeredCount).map((id, i) => ({ exerciseId: id, isCorrect: i < correctCount, userAnswer: "hej", answeredAt: "2026-06-16T10:00:00.000Z" }));
+    delete overrides.answeredCount;
+
+    return {
+        _id: oid,
+        userId: "user-1",
+        cefrLevel: "A1",
+        exerciseIds,
+        answers,
+        currentPosition: answeredCount,
+        verifiedExerciseIds: [],
+        score: null,
+        passed: null,
+        startedAt: "2026-06-16T09:00:00.000Z",
+        takenAt: null,
+        exerciseResults: [],
+        ...overrides,
+    };
+}
+
+function makeMockConfig(attemptDoc: any | null, exerciseDocs: any[], userLevel = "A1") {
+
+    const mutations: any[] = [];
+    let current: any = attemptDoc ? { ...attemptDoc } : null;
+    const userDoc = new User({ id: "user-1", email: "u@e.com", cefrLevel: userLevel as any, createdAt: "2026-01-01T00:00:00.000Z" }).toBSON();
+
+    const collections: Record<string, any> = {
+        levelTestAttempts: {
+            findOne: async (f: any) => (current && current._id.equals(f._id) ? current : null),
+            updateOne: async (_f: any, update: any) => { if (update.$set) Object.assign(current, update.$set); mutations.push({ op: "submitAttempt", update }); return { matchedCount: 1 }; },
+        },
+        exercises: { find: () => ({ toArray: async () => exerciseDocs }) },
+        userVocabularyProgress: {
+            findOne: async () => null,
+            replaceOne: async (_f: any, doc: any) => { mutations.push({ op: "upsertVocabProgress", doc }); return { upsertedCount: 1 }; },
+        },
+        userGrammarProgress: { findOne: async () => null, replaceOne: async () => ({ upsertedCount: 1 }) },
+        users: {
+            findOne: async (f: any) => (userDoc.id === f.id ? userDoc : null),
+            findOneAndUpdate: async (_f: any, update: any) => { mutations.push({ op: "advanceLevel", update }); return { ...userDoc, cefrLevel: update.$set.cefrLevel }; },
+        },
+    };
+
+    return { config: { getDBName: () => "test", getMongoDb: async () => ({ collection: (name: string) => collections[name] }) } as any, mutations, getCurrent: () => current };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SubmitLevelTest.do", () => {
+
+    it("computes a passing score (100%) when all exercises are correct", async () => {
+
+        const oid = new ObjectId();
+        const exercises = Array.from({ length: 40 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const { config } = makeMockConfig(makeAttemptBSON(oid, 40, 40), exercises);
+        const delegate = new SubmitLevelTest({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        assert.equal(result.score, 100);
+        assert.isTrue(result.passed);
+    });
+
+    it("passes at exactly 75% (threshold is inclusive)", async () => {
+
+        const oid = new ObjectId();
+        // 30 correct out of 40 = 75%
+        const exercises = Array.from({ length: 40 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const { config } = makeMockConfig(makeAttemptBSON(oid, 40, 30), exercises);
+        const delegate = new SubmitLevelTest({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        assert.equal(result.score, 75);
+        assert.isTrue(result.passed);
+    });
+
+    it("fails below 75%", async () => {
+
+        const oid = new ObjectId();
+        // 29 correct out of 40 = 72.5% → rounds to 73
+        const exercises = Array.from({ length: 40 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const { config } = makeMockConfig(makeAttemptBSON(oid, 40, 29), exercises);
+        const delegate = new SubmitLevelTest({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        assert.isFalse(result.passed);
+    });
+
+    it("counts unanswered exercises as wrong", async () => {
+
+        const oid = new ObjectId();
+        // 10 exercises, 8 answered all correct, 2 unanswered → 8/10 = 80%
+        const exercises = Array.from({ length: 10 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const { config } = makeMockConfig(makeAttemptBSON(oid, 10, 8, { answeredCount: 8 }), exercises);
+        const delegate = new SubmitLevelTest({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        assert.equal(result.score, 80);
+    });
+
+    it("persists score, passed, and takenAt on the attempt", async () => {
+
+        const oid = new ObjectId();
+        const exercises = Array.from({ length: 40 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const { config, getCurrent } = makeMockConfig(makeAttemptBSON(oid, 40, 32), exercises);
+        const delegate = new SubmitLevelTest({} as any, config);
+
+        await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        const submitted = getCurrent();
+        assert.isNumber(submitted.score);
+        assert.isBoolean(submitted.passed);
+        assert.isString(submitted.takenAt);
+    });
+
+    it("updates mastery (F06) for answered exercises", async () => {
+
+        const oid = new ObjectId();
+        const exercises = Array.from({ length: 40 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const { config, mutations } = makeMockConfig(makeAttemptBSON(oid, 40, 40), exercises);
+        const delegate = new SubmitLevelTest({} as any, config);
+
+        await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        assert.isTrue(mutations.some(m => m.op === "upsertVocabProgress"));
+    });
+
+    it("advances the user's CEFR level on a pass", async () => {
+
+        const oid = new ObjectId();
+        const exercises = Array.from({ length: 40 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const { config, mutations } = makeMockConfig(makeAttemptBSON(oid, 40, 40), exercises, "A1");
+        const delegate = new SubmitLevelTest({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        const advance = mutations.find(m => m.op === "advanceLevel");
+        assert.isTrue(!!advance, "expected level advancement");
+        assert.equal(advance.update.$set.cefrLevel, "A2");
+        assert.equal(result.advancedTo, "A2");
+    });
+
+    it("does NOT advance the level on a fail", async () => {
+
+        const oid = new ObjectId();
+        const exercises = Array.from({ length: 40 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const { config, mutations } = makeMockConfig(makeAttemptBSON(oid, 40, 10), exercises);
+        const delegate = new SubmitLevelTest({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        assert.isFalse(!!mutations.find(m => m.op === "advanceLevel"));
+        assert.isNull(result.advancedTo);
+    });
+
+    it("does not advance when already at the highest level (C2), but still passes", async () => {
+
+        const oid = new ObjectId();
+        const exercises = Array.from({ length: 40 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const { config, mutations } = makeMockConfig(makeAttemptBSON(oid, 40, 40, { cefrLevel: "C2" }), exercises, "C2");
+        const delegate = new SubmitLevelTest({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+
+        assert.isTrue(result.passed);
+        assert.isNull(result.advancedTo);
+        assert.isFalse(!!mutations.find(m => m.op === "advanceLevel"));
+    });
+
+    it("throws 404 when the attempt does not exist", async () => {
+
+        const { config } = makeMockConfig(null, []);
+        const delegate = new SubmitLevelTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", attemptId: new ObjectId().toString() }, {} as any);
+            assert.fail("Expected 404");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 404);
+        }
+    });
+
+    it("throws 400 when the attempt is already submitted", async () => {
+
+        const oid = new ObjectId();
+        const exercises = Array.from({ length: 5 }, (_, i) => makeExerciseBSON(`ex-${i + 1}`));
+        const { config } = makeMockConfig(makeAttemptBSON(oid, 5, 5, { takenAt: "2026-06-16T11:00:00.000Z" }), exercises);
+        const delegate = new SubmitLevelTest({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", attemptId: oid.toString() }, {} as any);
+            assert.fail("Expected 400");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 400);
+        }
+    });
+});

--- a/test/dlg/levelTests/SubmitLevelTestAnswer.do.test.ts
+++ b/test/dlg/levelTests/SubmitLevelTestAnswer.do.test.ts
@@ -1,0 +1,137 @@
+import { assert } from "chai";
+import { ObjectId } from "mongodb";
+import { SubmitLevelTestAnswer } from "../../../src/dlg/levelTests/SubmitLevelTestAnswer";
+import { Exercise } from "../../../src/model/Exercise";
+
+function makeExerciseBSON(id: string, answer: string): any {
+    return new Exercise({ id, moduleId: null, type: "translation_active", prompt: `prompt-${id}`, answer, vocabularyItemId: "v-1", grammarConceptId: null }).toBSON();
+}
+
+function makeAttemptBSON(oid: ObjectId, overrides: any = {}): any {
+    return {
+        _id: oid,
+        userId: "user-1",
+        cefrLevel: "A1",
+        exerciseIds: ["ex-1", "ex-2"],
+        answers: [],
+        currentPosition: 0,
+        verifiedExerciseIds: [],
+        score: null,
+        passed: null,
+        startedAt: "2026-06-16T09:00:00.000Z",
+        takenAt: null,
+        exerciseResults: [],
+        ...overrides,
+    };
+}
+
+function makeMockConfig(attemptDoc: any | null, exerciseDocs: any[]) {
+
+    const mutations: any[] = [];
+    const current = attemptDoc ? { ...attemptDoc } : null;
+    const exerciseMap = new Map(exerciseDocs.map((e: any) => [e.id, e]));
+
+    const collections: Record<string, any> = {
+        levelTestAttempts: {
+            findOne: async (f: any) => (current && current._id.equals(f._id) ? current : null),
+            updateOne: async (_f: any, update: any) => { mutations.push(update); if (update.$push) for (const [k, v] of Object.entries(update.$push as any)) (current as any)[k] = [...((current as any)[k] ?? []), v]; if (update.$inc) for (const [k, v] of Object.entries(update.$inc as any)) (current as any)[k] = ((current as any)[k] ?? 0) + (v as number); return { matchedCount: 1 }; },
+        },
+        exercises: {
+            findOne: async (f: any) => exerciseMap.get(f.id) ?? null,
+            updateOne: async () => ({ matchedCount: 1 }),
+        },
+    };
+
+    return { config: { getDBName: () => "test", getMongoDb: async () => ({ collection: (name: string) => collections[name] }) } as any, mutations, getCurrent: () => current };
+}
+
+describe("SubmitLevelTestAnswer.do", () => {
+
+    it("returns isCorrect=true and the correct answer for a correct submission", async () => {
+
+        const oid = new ObjectId();
+        const { config } = makeMockConfig(makeAttemptBSON(oid), [makeExerciseBSON("ex-1", "hej")]);
+        const delegate = new SubmitLevelTestAnswer({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString(), exerciseId: "ex-1", userAnswer: "hej" }, {} as any);
+
+        assert.isTrue(result.isCorrect);
+        assert.equal(result.correctAnswer, "hej");
+    });
+
+    it("returns isCorrect=false and the correct answer for a wrong submission (immediate feedback)", async () => {
+
+        const oid = new ObjectId();
+        const { config } = makeMockConfig(makeAttemptBSON(oid), [makeExerciseBSON("ex-1", "hej")]);
+        const delegate = new SubmitLevelTestAnswer({} as any, config);
+
+        const result = await delegate.do({ userId: "user-1", attemptId: oid.toString(), exerciseId: "ex-1", userAnswer: "wrong" }, {} as any);
+
+        assert.isFalse(result.isCorrect);
+        assert.equal(result.correctAnswer, "hej");
+    });
+
+    it("stores the answer and advances the cursor", async () => {
+
+        const oid = new ObjectId();
+        const { config, getCurrent } = makeMockConfig(makeAttemptBSON(oid), [makeExerciseBSON("ex-1", "hej")]);
+        const delegate = new SubmitLevelTestAnswer({} as any, config);
+
+        await delegate.do({ userId: "user-1", attemptId: oid.toString(), exerciseId: "ex-1", userAnswer: "hej" }, {} as any);
+
+        const current = getCurrent();
+        assert.equal(current.answers.length, 1);
+        assert.equal(current.answers[0].exerciseId, "ex-1");
+        assert.equal(current.currentPosition, 1);
+    });
+
+    it("throws 400 when the exercise is not part of the attempt", async () => {
+
+        const oid = new ObjectId();
+        const { config } = makeMockConfig(makeAttemptBSON(oid), [makeExerciseBSON("ex-1", "hej")]);
+        const delegate = new SubmitLevelTestAnswer({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", attemptId: oid.toString(), exerciseId: "ex-99", userAnswer: "hej" }, {} as any);
+            assert.fail("Expected 400");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 400);
+        }
+    });
+
+    it("throws 400 when the attempt is already submitted", async () => {
+
+        const oid = new ObjectId();
+        const { config } = makeMockConfig(makeAttemptBSON(oid, { takenAt: "2026-06-16T11:00:00.000Z" }), [makeExerciseBSON("ex-1", "hej")]);
+        const delegate = new SubmitLevelTestAnswer({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", attemptId: oid.toString(), exerciseId: "ex-1", userAnswer: "hej" }, {} as any);
+            assert.fail("Expected 400");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 400);
+        }
+    });
+
+    it("throws 404 when the attempt does not exist", async () => {
+
+        const { config } = makeMockConfig(null, []);
+        const delegate = new SubmitLevelTestAnswer({} as any, config);
+
+        try {
+
+            await delegate.do({ userId: "user-1", attemptId: new ObjectId().toString(), exerciseId: "ex-1", userAnswer: "hej" }, {} as any);
+            assert.fail("Expected 404");
+
+        } catch (err: any) {
+
+            assert.equal(err.code, 404);
+        }
+    });
+});

--- a/test/model/LevelTestAttempt.model.test.ts
+++ b/test/model/LevelTestAttempt.model.test.ts
@@ -1,0 +1,100 @@
+import { strict as assert } from "assert";
+import { ObjectId } from "mongodb";
+import { LevelTestAttempt } from "../../src/model/LevelTestAttempt";
+import { ExerciseResult } from "../../src/model/ExerciseResult";
+
+function makeResult(exerciseId: string, isCorrect: boolean): ExerciseResult {
+    return new ExerciseResult({
+        exerciseId,
+        type: "translation_active",
+        isCorrect,
+        userAnswer: "hej",
+        correctAnswer: "hej",
+        timestamp: "2026-06-16T10:00:00.000Z",
+        moduleId: null,
+    });
+}
+
+describe("LevelTestAttempt.fromBSON", () => {
+
+    it("round-trips all fields through toBSON / fromBSON", () => {
+
+        const oid = new ObjectId();
+
+        const attempt = new LevelTestAttempt({
+            userId: "user-1",
+            cefrLevel: "A1",
+            exerciseIds: ["ex-1", "ex-2"],
+            answers: [{ exerciseId: "ex-1", isCorrect: true, userAnswer: "hej", answeredAt: "2026-06-16T10:00:00.000Z" }],
+            currentPosition: 1,
+            verifiedExerciseIds: [],
+            score: null,
+            passed: null,
+            startedAt: "2026-06-16T09:00:00.000Z",
+            takenAt: null,
+            exerciseResults: [],
+        });
+
+        const bson = { _id: oid, ...attempt.toBSON() };
+        const result = LevelTestAttempt.fromBSON(bson as any);
+
+        assert.equal(result.id, oid.toString());
+        assert.equal(result.userId, "user-1");
+        assert.equal(result.cefrLevel, "A1");
+        assert.deepEqual(result.exerciseIds, ["ex-1", "ex-2"]);
+        assert.equal(result.answers.length, 1);
+        assert.equal(result.answers[0].exerciseId, "ex-1");
+        assert.equal(result.currentPosition, 1);
+        assert.deepEqual(result.verifiedExerciseIds, []);
+        assert.equal(result.score, null);
+        assert.equal(result.passed, null);
+        assert.equal(result.startedAt, "2026-06-16T09:00:00.000Z");
+        assert.equal(result.takenAt, null);
+    });
+
+    it("round-trips a submitted attempt with score and passed", () => {
+
+        const oid = new ObjectId();
+        const attempt = new LevelTestAttempt({
+            userId: "user-1",
+            cefrLevel: "A1",
+            exerciseIds: ["ex-1"],
+            startedAt: "2026-06-16T09:00:00.000Z",
+            score: 90,
+            passed: true,
+            takenAt: "2026-06-16T10:00:00.000Z",
+            exerciseResults: [makeResult("ex-1", true)],
+        });
+
+        const bson = { _id: oid, ...attempt.toBSON() };
+        const result = LevelTestAttempt.fromBSON(bson as any);
+
+        assert.equal(result.score, 90);
+        assert.equal(result.passed, true);
+        assert.equal(result.takenAt, "2026-06-16T10:00:00.000Z");
+        assert.equal(result.exerciseResults.length, 1);
+        assert.equal(result.exerciseResults[0].exerciseId, "ex-1");
+    });
+
+    it("defaults arrays and position when absent from the document", () => {
+
+        const oid = new ObjectId();
+        const doc: any = {
+            _id: oid,
+            userId: "user-1",
+            cefrLevel: "A1",
+            startedAt: "2026-06-16T09:00:00.000Z",
+        };
+
+        const result = LevelTestAttempt.fromBSON(doc);
+
+        assert.deepEqual(result.exerciseIds, []);
+        assert.deepEqual(result.answers, []);
+        assert.equal(result.currentPosition, 0);
+        assert.deepEqual(result.verifiedExerciseIds, []);
+        assert.equal(result.score, null);
+        assert.equal(result.passed, null);
+        assert.equal(result.takenAt, null);
+        assert.deepEqual(result.exerciseResults, []);
+    });
+});

--- a/test/store/LevelTestAttemptStore.test.ts
+++ b/test/store/LevelTestAttemptStore.test.ts
@@ -1,0 +1,260 @@
+import { assert } from "chai";
+import { ObjectId } from "mongodb";
+import { LevelTestAttempt } from "../../src/model/LevelTestAttempt";
+import { TestAnswer } from "../../src/model/ModuleTestAttempt";
+import { ExerciseResult } from "../../src/model/ExerciseResult";
+import { LevelTestAttemptStore } from "../../src/store/LevelTestAttemptStore";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAttempt(overrides: Partial<ConstructorParameters<typeof LevelTestAttempt>[0]> = {}): LevelTestAttempt {
+    return new LevelTestAttempt({
+        userId: "user-1",
+        cefrLevel: "A1",
+        exerciseIds: ["ex-1", "ex-2", "ex-3"],
+        answers: [],
+        currentPosition: 0,
+        verifiedExerciseIds: [],
+        score: null,
+        passed: null,
+        startedAt: "2026-06-16T09:00:00.000Z",
+        takenAt: null,
+        exerciseResults: [],
+        ...overrides,
+    });
+}
+
+function makeAnswer(exerciseId: string, isCorrect = true): TestAnswer {
+    return { exerciseId, isCorrect, userAnswer: "hej", answeredAt: "2026-06-16T10:00:00.000Z" };
+}
+
+/**
+ * Builds an in-memory mock collection for the levelTestAttempts collection.
+ * Supports: insertOne, findOne, find (with sort + limit), updateOne.
+ */
+function makeMockCollection(initialDocs: any[] = []) {
+
+    const docs = [...initialDocs];
+
+    const matches = (d: any, filter: any) => Object.keys(filter).every(k => {
+        if (k === "_id") return d._id.equals(filter._id);
+        if (k.includes('.')) {
+            const [field, subField] = k.split('.');
+            return Array.isArray(d[field]) && d[field].some((item: any) => item[subField] === filter[k]);
+        }
+        const condition = filter[k];
+        if (condition && typeof condition === "object" && "$ne" in condition) return d[k] !== condition.$ne;
+        return d[k] === condition;
+    });
+
+    return {
+        docs,
+        insertOne: async (doc: any) => {
+            const oid = new ObjectId();
+            docs.push({ _id: oid, ...doc });
+            return { insertedId: oid };
+        },
+        findOne: async (filter: any) => docs.find(d => matches(d, filter)) ?? null,
+        find: (filter: any) => {
+            let result = docs.filter(d => matches(d, filter));
+            return {
+                sort: (spec: any) => {
+                    const [field, dir] = Object.entries(spec)[0] as [string, number];
+                    result = [...result].sort((a, b) => (a[field] > b[field] ? 1 : a[field] < b[field] ? -1 : 0) * dir);
+                    return {
+                        limit: (n: number) => ({ toArray: async () => result.slice(0, n) }),
+                        toArray: async () => result,
+                    };
+                },
+            };
+        },
+        updateOne: async (filter: any, update: any) => {
+            const doc = docs.find(d => matches(d, filter));
+            if (!doc) return { matchedCount: 0 };
+            if (update.$push) for (const [field, value] of Object.entries(update.$push as Record<string, any>)) doc[field] = [...(doc[field] ?? []), value];
+            if (update.$inc) for (const [field, delta] of Object.entries(update.$inc as Record<string, any>)) doc[field] = (doc[field] ?? 0) + delta;
+            if (update.$set) {
+                for (const [field, value] of Object.entries(update.$set as Record<string, any>)) {
+                    const positional = field.match(/^(\w+)\.\$\.(.+)$/);
+                    if (positional) {
+                        const [, arrayField, subField] = positional;
+                        const arrayMatchKey = Object.keys(filter).find(k => k.startsWith(`${arrayField}.`));
+                        if (arrayMatchKey) {
+                            const matchSubField = arrayMatchKey.split('.')[1];
+                            const item = (doc[arrayField] ?? []).find((x: any) => x[matchSubField] === filter[arrayMatchKey]);
+                            if (item) item[subField] = value;
+                        }
+                    } else {
+                        doc[field] = value;
+                    }
+                }
+            }
+            return { matchedCount: 1 };
+        },
+    };
+}
+
+function makeMockDb(collection: any) {
+    return { collection: () => collection } as any;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LevelTestAttemptStore.create", () => {
+
+    it("inserts the attempt and returns the generated _id as a string", async () => {
+
+        const col = makeMockCollection();
+        const store = new LevelTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+
+        const id = await store.create(makeAttempt());
+
+        assert.isString(id);
+        assert.equal(id.length, 24);
+        assert.equal(col.docs.length, 1);
+    });
+});
+
+describe("LevelTestAttemptStore.findById", () => {
+
+    it("returns the matching attempt when it exists", async () => {
+
+        const col = makeMockCollection();
+        const store = new LevelTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+        const id = await store.create(makeAttempt());
+
+        const found = await store.findById(id);
+
+        assert.isNotNull(found);
+        assert.equal(found!.id, id);
+        assert.equal(found!.cefrLevel, "A1");
+    });
+
+    it("returns null when no attempt has the given id", async () => {
+
+        const col = makeMockCollection();
+        const store = new LevelTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+
+        const found = await store.findById(new ObjectId().toString());
+
+        assert.isNull(found);
+    });
+});
+
+describe("LevelTestAttemptStore.findActiveByUserAndLevel", () => {
+
+    it("returns an in-progress attempt (takenAt is null)", async () => {
+
+        const col = makeMockCollection();
+        const store = new LevelTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+        const id = await store.create(makeAttempt({ takenAt: null }));
+
+        const found = await store.findActiveByUserAndLevel("user-1", "A1");
+
+        assert.isNotNull(found);
+        assert.equal(found!.id, id);
+    });
+
+    it("returns null when only a submitted attempt exists", async () => {
+
+        const col = makeMockCollection();
+        const store = new LevelTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+        await store.create(makeAttempt({ takenAt: "2026-06-16T11:00:00.000Z" }));
+
+        const found = await store.findActiveByUserAndLevel("user-1", "A1");
+
+        assert.isNull(found);
+    });
+});
+
+describe("LevelTestAttemptStore.findMostRecentSubmittedByUserAndLevel", () => {
+
+    it("returns the most recently submitted attempt for the user + level", async () => {
+
+        const col = makeMockCollection();
+        const store = new LevelTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+        await store.create(makeAttempt({ takenAt: "2026-06-16T09:00:00.000Z", score: 50, passed: false }));
+        await store.create(makeAttempt({ takenAt: "2026-06-16T11:00:00.000Z", score: 60, passed: false }));
+
+        const found = await store.findMostRecentSubmittedByUserAndLevel("user-1", "A1");
+
+        assert.isNotNull(found);
+        assert.equal(found!.takenAt, "2026-06-16T11:00:00.000Z");
+    });
+
+    it("ignores in-progress attempts (takenAt null)", async () => {
+
+        const col = makeMockCollection();
+        const store = new LevelTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+        await store.create(makeAttempt({ takenAt: null }));
+
+        const found = await store.findMostRecentSubmittedByUserAndLevel("user-1", "A1");
+
+        assert.isNull(found);
+    });
+
+    it("returns null when no attempt exists for the level", async () => {
+
+        const col = makeMockCollection();
+        const store = new LevelTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+
+        const found = await store.findMostRecentSubmittedByUserAndLevel("user-1", "A1");
+
+        assert.isNull(found);
+    });
+});
+
+describe("LevelTestAttemptStore.appendAnswer", () => {
+
+    it("pushes the answer to the answers array", async () => {
+
+        const col = makeMockCollection();
+        const store = new LevelTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+        const id = await store.create(makeAttempt());
+
+        await store.appendAnswer(id, makeAnswer("ex-1", true));
+
+        const doc = col.docs[0];
+        assert.equal(doc.answers.length, 1);
+        assert.equal(doc.answers[0].exerciseId, "ex-1");
+        assert.equal(doc.answers[0].isCorrect, true);
+    });
+});
+
+describe("LevelTestAttemptStore.advancePosition", () => {
+
+    it("increments currentPosition by 1", async () => {
+
+        const col = makeMockCollection();
+        const store = new LevelTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+        const id = await store.create(makeAttempt({ currentPosition: 0 }));
+
+        await store.advancePosition(id);
+
+        assert.equal(col.docs[0].currentPosition, 1);
+    });
+});
+
+describe("LevelTestAttemptStore.submit", () => {
+
+    it("sets score, passed, takenAt, and exerciseResults on the attempt", async () => {
+
+        const col = makeMockCollection();
+        const store = new LevelTestAttemptStore({ db: makeMockDb(col), config: {} as any });
+        const id = await store.create(makeAttempt());
+
+        const exerciseResults = [new ExerciseResult({ exerciseId: "ex-1", type: "translation_active", isCorrect: true, userAnswer: "hej", correctAnswer: "hej", timestamp: "2026-06-16T10:00:00.000Z", moduleId: null })];
+
+        await store.submit(id, { score: 80, passed: true, takenAt: "2026-06-16T11:00:00.000Z", exerciseResults });
+
+        const doc = col.docs[0];
+        assert.equal(doc.score, 80);
+        assert.equal(doc.passed, true);
+        assert.equal(doc.takenAt, "2026-06-16T11:00:00.000Z");
+        assert.equal(doc.exerciseResults.length, 1);
+    });
+});

--- a/test/store/UserStore.findById.test.ts
+++ b/test/store/UserStore.findById.test.ts
@@ -1,0 +1,50 @@
+import { assert } from "chai";
+import { User } from "../../src/model/User";
+import { UserStore } from "../../src/store/UserStore";
+
+function makeUser(overrides: Partial<ConstructorParameters<typeof User>[0]> = {}): User {
+    return new User({
+        id: "uuid-001",
+        email: "alice@example.com",
+        cefrLevel: "A1",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        ...overrides,
+    });
+}
+
+function makeMockCollection(docs: any[] = []) {
+
+    return {
+        findOne: async (filter: any) => docs.find(d => d.id === filter.id) ?? null,
+    };
+}
+
+function makeMockDb(collection: any) {
+    return { collection: () => collection } as any;
+}
+
+describe("UserStore.findById", () => {
+
+    it("returns the user when a matching document exists", async () => {
+
+        const col = makeMockCollection([makeUser().toBSON()]);
+        const store = new UserStore({ db: makeMockDb(col), config: {} as any });
+
+        const result = await store.findById("uuid-001");
+
+        assert.isNotNull(result);
+        assert.equal(result!.id, "uuid-001");
+        assert.equal(result!.cefrLevel, "A1");
+    });
+
+    it("returns null when no document matches the id", async () => {
+
+        const col = makeMockCollection([]);
+        const store = new UserStore({ db: makeMockDb(col), config: {} as any });
+
+        const result = await store.findById("missing");
+
+        assert.isNull(result);
+    });
+
+});


### PR DESCRIPTION
Implements **F21 — Level Test** (closes #75).

The Level Test is a graded, resumable, cross-module assessment that unlocks the next CEFR level. It mirrors the Module Test (F11) lifecycle exactly: 409-resume on start, one answer at a time with immediate per-answer feedback, resume after app close, single-pass grading, then submit + review.

## Spec changes applied (feature doc updated)
- **40 exercises** per attempt (was 20–30).
- **Module-test-identical lifecycle**: resumable session (`GET …/levelTests/:attemptId`) + per-answer immediate feedback (`POST …/levelTests/:attemptId/answers`), first-answer-final grading.
- **Lowest-mastery prioritization**: a level-wide mastery map (the user's mastery for every vocab/grammar item the bank's exercises link to) feeds F08's `(1 - masteryScore)` weighting.
- **30-minute cooldown** between attempts, anchored on the most recent submitted attempt at the level (replaces the earlier "free retry, no cooldown").

## Resolved open questions
- OQ-01: question count fixed at **40**.
- OQ-02: eligibility counts only **curated** (non-user-generated) modules.
- OQ-03: weak area = **any incorrect** answer, grouped by grammar concept / vocab item.

## Endpoints
- `GET /users/:userId/levelTest/eligibility`
- `POST /users/:userId/levelTests`
- `GET /users/:userId/levelTests/:attemptId`
- `POST /users/:userId/levelTests/:attemptId/answers`
- `POST /users/:userId/levelTests/:attemptId/submit`
- `GET /users/:userId/levelTests/:attemptId/review`

## Testing
- Implemented via TDD. Build clean (`tsc`), full suite **591 passing** (+59 new tests).

## Notes
- F13 AI answer-verification *during* the level test is intentionally out of scope for this slice (`verifiedExerciseIds` exists on the model for parity); it can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
