### PR TITLE
F24 — Activity Stats Rolling Window (GET /me/stats/dailyActivity)

### DIFF
--- a/docs/features/F24-activity-stats.md
+++ b/docs/features/F24-activity-stats.md
@@ -1,6 +1,6 @@
 # F24 — Activity Stats (Rolling Window)
 
-![Status](https://img.shields.io/badge/status-todo-lightgrey?style=flat-square)
+![Status](https://img.shields.io/badge/status-implemented-brightgreen?style=flat-square)
 
 ## 1. Purpose & Scope
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -73,7 +73,7 @@ Features are grouped by layer. Lower groups depend on higher ones.
 ### Group I — Activity & engagement stats
 | # | Feature | Primary model | Status |
 |---|---------|---------------|--------|
-| F24 | [Activity Stats (Rolling Window)](./F24-activity-stats.md) | — (read-only aggregate over PracticeSession, ModuleTestAttempt, LevelTestAttempt) | ![Todo](https://img.shields.io/badge/status-todo-lightgrey?style=flat-square) |
+| F24 | [Activity Stats (Rolling Window)](./F24-activity-stats.md) | — (read-only aggregate over PracticeSession, ModuleTestAttempt, LevelTestAttempt) | ![Implemented](https://img.shields.io/badge/status-implemented-brightgreen?style=flat-square) |
 
 ## Build order
 

--- a/docs/interfaces/api-endpoints.md
+++ b/docs/interfaces/api-endpoints.md
@@ -16,6 +16,7 @@
 - [Module Tests (F11)](#module-tests-f11)
 - [Level Test Banks (F20)](#level-test-banks-f20)
 - [Level Test (F21)](#level-test-f21)
+- [Activity Stats (F24)](#activity-stats-f24)
 - [API Design compliance](#api-design-compliance)
 
 ---
@@ -325,6 +326,17 @@
 ### GET /users/:userId/levelTests/:attemptId/review
 **Used for:** Fetching the full graded review for a submitted level test attempt. Returns `score`, `passed`, a `questions` array (each exercise's `prompt`, `isCorrect`, `userAnswer`, `correctAnswer`), and a `weakAreas` summary `{ vocabulary[], grammar[] }` — the distinct vocab items and grammar concepts the user answered incorrectly (any incorrect answer flags the item — OQ-03). Only valid after submission (`takenAt` set); **exposes correct answers**. Unanswered exercises appear with `isCorrect: false` and `userAnswer: ""`. Enables "Explain my mistake" (F12) per incorrect item. Verifies ownership (403 otherwise).
 **Request & Response:** `GetLevelTestReviewRequest` / `GetLevelTestReviewResponse` in `src/dlg/levelTests/GetLevelTestReview.ts`
+
+---
+
+## Activity Stats (F24)
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET | `/me/stats/dailyActivity` | Per-day activity counts over the rolling 7-day window ending today |
+
+### GET /me/stats/dailyActivity
+**Used for:** Backing the Home Dashboard's "This week" activity chart. Returns per-day counts of completed practice sessions, passed module tests, and passed level tests across a rolling 7-day window. The user is resolved from the auth token. Optional `from` query param (YYYYMMDD) sets the first day of the window; defaults to `today − 6` so the window always ends today. Returns exactly 7 entries (oldest → newest), zero-filled for days with no activity.
+**Request & Response:** `GetDailyActivityRequest` / `GetDailyActivityResponse` in `src/dlg/stats/GetDailyActivity.ts`
 
 ---
 

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -67,6 +67,12 @@ export const LEVEL_TEST_PASS_THRESHOLD = 75;
  */
 export const LEVEL_TEST_RETRY_DELAY_MINUTES = 30;
 
+/**
+ * IANA timezone used as the single reference civil-day boundary for F24 activity bucketing.
+ * All per-day counts bucket timestamps into this timezone — not UTC, not per-user.
+ */
+export const REFERENCE_TIMEZONE = 'Europe/Copenhagen';
+
 export class ControllerConfig extends TotoControllerConfig {
 
     getMongoSecretNames(): { userSecretName: string; pwdSecretName: string; } | null {

--- a/src/dlg/stats/GetDailyActivity.ts
+++ b/src/dlg/stats/GetDailyActivity.ts
@@ -1,0 +1,74 @@
+import { Request } from "express";
+import * as moment from "moment-timezone";
+import { TotoDelegate, UserContext, ValidationError } from "totoms";
+import { ControllerConfig, REFERENCE_TIMEZONE } from "../../Config";
+import { PracticeSessionStore } from "../../store/PracticeSessionStore";
+import { ModuleTestAttemptStore } from "../../store/ModuleTestAttemptStore";
+import { LevelTestAttemptStore } from "../../store/LevelTestAttemptStore";
+
+export class GetDailyActivity extends TotoDelegate<GetDailyActivityRequest, GetDailyActivityResponse> {
+
+    parseRequest(req: Request): GetDailyActivityRequest {
+        const from = req.query.from as string | undefined;
+        return { from };
+    }
+
+    async do(req: GetDailyActivityRequest, userContext?: UserContext): Promise<GetDailyActivityResponse> {
+
+        const config = this.config as ControllerConfig;
+        const tz = REFERENCE_TIMEZONE;
+
+        const fromDate = resolveFrom(req.from, tz);
+        const toDate = moment.tz(fromDate, "YYYYMMDD", tz).add(6, "days").format("YYYYMMDD");
+
+        const db = await config.getMongoDb(config.getDBName());
+        const userId = userContext!.userId;
+
+        const [practiceMap, moduleTestMap, levelTestMap] = await Promise.all([
+            new PracticeSessionStore({ db, config }).countCompletedByDay(userId, fromDate, toDate, tz),
+            new ModuleTestAttemptStore({ db, config }).countPassedByDay(userId, fromDate, toDate, tz),
+            new LevelTestAttemptStore({ db, config }).countPassedByDay(userId, fromDate, toDate, tz),
+        ]);
+
+        const days: DayActivity[] = [];
+        for (let i = 0; i < 7; i++) {
+            const day = moment.tz(fromDate, "YYYYMMDD", tz).add(i, "days").format("YYYYMMDD");
+            days.push({
+                date: day,
+                practiceSessions: practiceMap.get(day) ?? 0,
+                successfulModuleTests: moduleTestMap.get(day) ?? 0,
+                successfulLevelTests: levelTestMap.get(day) ?? 0,
+            });
+        }
+
+        return { from: fromDate, to: toDate, days };
+    }
+}
+
+function resolveFrom(from: string | undefined, tz: string): string {
+    if (!from) {
+        return moment.tz(tz).subtract(6, "days").format("YYYYMMDD");
+    }
+    const parsed = moment.tz(from, "YYYYMMDD", true, tz);
+    if (!parsed.isValid()) {
+        throw new ValidationError(400, "'from' must be a valid YYYYMMDD date");
+    }
+    return from;
+}
+
+interface GetDailyActivityRequest {
+    from?: string;
+}
+
+interface DayActivity {
+    date: string;
+    practiceSessions: number;
+    successfulModuleTests: number;
+    successfulLevelTests: number;
+}
+
+interface GetDailyActivityResponse {
+    from: string;
+    to: string;
+    days: DayActivity[];
+}

--- a/src/dlg/stats/GetDailyActivity.ts
+++ b/src/dlg/stats/GetDailyActivity.ts
@@ -5,6 +5,7 @@ import { ControllerConfig, REFERENCE_TIMEZONE } from "../../Config";
 import { PracticeSessionStore } from "../../store/PracticeSessionStore";
 import { ModuleTestAttemptStore } from "../../store/ModuleTestAttemptStore";
 import { LevelTestAttemptStore } from "../../store/LevelTestAttemptStore";
+import { UserStore } from "../../store/UserStore";
 
 export class GetDailyActivity extends TotoDelegate<GetDailyActivityRequest, GetDailyActivityResponse> {
 
@@ -22,12 +23,15 @@ export class GetDailyActivity extends TotoDelegate<GetDailyActivityRequest, GetD
         const toDate = moment.tz(fromDate, "YYYYMMDD", tz).add(6, "days").format("YYYYMMDD");
 
         const db = await config.getMongoDb(config.getDBName());
-        const userId = userContext!.userId;
+        
+        const user = await new UserStore({ db, config }).findByEmail(userContext!.email); 
+
+        if (!user) throw new ValidationError(404, "User not found");
 
         const [practiceMap, moduleTestMap, levelTestMap] = await Promise.all([
-            new PracticeSessionStore({ db, config }).countCompletedByDay(userId, fromDate, toDate, tz),
-            new ModuleTestAttemptStore({ db, config }).countPassedByDay(userId, fromDate, toDate, tz),
-            new LevelTestAttemptStore({ db, config }).countPassedByDay(userId, fromDate, toDate, tz),
+            new PracticeSessionStore({ db, config }).countCompletedByDay(user.id, fromDate, toDate, tz),
+            new ModuleTestAttemptStore({ db, config }).countPassedByDay(user.id, fromDate, toDate, tz),
+            new LevelTestAttemptStore({ db, config }).countPassedByDay(user.id, fromDate, toDate, tz),
         ]);
 
         const days: DayActivity[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ import { GetLevelTest } from './dlg/levelTests/GetLevelTest';
 import { SubmitLevelTestAnswer } from './dlg/levelTests/SubmitLevelTestAnswer';
 import { SubmitLevelTest } from './dlg/levelTests/SubmitLevelTest';
 import { GetLevelTestReview } from './dlg/levelTests/GetLevelTestReview';
+import { GetDailyActivity } from './dlg/stats/GetDailyActivity';
 
 const config: TotoMicroserviceConfiguration = {
     serviceName: "tome-ms-language",
@@ -81,6 +82,7 @@ const config: TotoMicroserviceConfiguration = {
             { method: 'GET', path: '/vocabularyItems/:id', delegate: GetVocabularyItem },
 
             { method: 'GET', path: '/me/progress', delegate: GetMeProgress },
+            { method: 'GET', path: '/me/stats/dailyActivity', delegate: GetDailyActivity },
 
             { method: 'GET', path: '/users/:userId/vocabularyProgress', delegate: GetUserVocabularyProgress },
             { method: 'GET', path: '/users/:userId/vocabularyProgress/:vocabularyItemId', delegate: GetUserVocabularyProgressItem },

--- a/src/store/LevelTestAttemptStore.ts
+++ b/src/store/LevelTestAttemptStore.ts
@@ -1,4 +1,5 @@
 import { Db, ObjectId } from "mongodb";
+import * as moment from "moment-timezone";
 import { ControllerConfig } from "../Config";
 import { LevelTestAttempt } from "../model/LevelTestAttempt";
 import { TestAnswer } from "../model/ModuleTestAttempt";
@@ -166,6 +167,37 @@ export class LevelTestAttemptStore {
                 },
             } as any
         );
+    }
+
+    /**
+     * Returns a map of YYYYMMDD → passed-attempt count for the given user and date window.
+     * Only attempts with `passed = true` and a non-null `takenAt` that falls within [from, to]
+     * (inclusive, in the given timezone) are counted. Days with no qualifying attempts are absent.
+     *
+     * @param {string} userId - The user whose attempts to count.
+     * @param {string} from - First day of the window (YYYYMMDD).
+     * @param {string} to - Last day of the window (YYYYMMDD).
+     * @param {string} timezone - IANA timezone for civil-day bucketing.
+     */
+    async countPassedByDay(userId: string, from: string, to: string, timezone: string): Promise<Map<string, number>> {
+
+        const startIso = moment.tz(from, "YYYYMMDD", timezone).startOf("day").toISOString();
+        const endIso = moment.tz(to, "YYYYMMDD", timezone).endOf("day").toISOString();
+
+        const docs = await this.db.collection(COLLECTION).find({
+            userId,
+            passed: true,
+            takenAt: { $gte: startIso, $lte: endIso },
+        }).toArray();
+
+        const counts = new Map<string, number>();
+        for (const doc of docs) {
+            if (!doc.takenAt) continue;
+            const day = moment.tz(doc.takenAt as string, timezone).format("YYYYMMDD");
+            counts.set(day, (counts.get(day) ?? 0) + 1);
+        }
+
+        return counts;
     }
 }
 

--- a/src/store/ModuleTestAttemptStore.ts
+++ b/src/store/ModuleTestAttemptStore.ts
@@ -1,4 +1,5 @@
 import { Db, ObjectId } from "mongodb";
+import * as moment from "moment-timezone";
 import { ControllerConfig } from "../Config";
 import { ModuleTestAttempt, TestAnswer } from "../model/ModuleTestAttempt";
 import { ExerciseResult } from "../model/ExerciseResult";
@@ -151,6 +152,37 @@ export class ModuleTestAttemptStore {
                 },
             } as any
         );
+    }
+
+    /**
+     * Returns a map of YYYYMMDD → passed-attempt count for the given user and date window.
+     * Only attempts with `passed = true` and a non-null `takenAt` that falls within [from, to]
+     * (inclusive, in the given timezone) are counted. Days with no qualifying attempts are absent.
+     *
+     * @param {string} userId - The user whose attempts to count.
+     * @param {string} from - First day of the window (YYYYMMDD).
+     * @param {string} to - Last day of the window (YYYYMMDD).
+     * @param {string} timezone - IANA timezone for civil-day bucketing.
+     */
+    async countPassedByDay(userId: string, from: string, to: string, timezone: string): Promise<Map<string, number>> {
+
+        const startIso = moment.tz(from, "YYYYMMDD", timezone).startOf("day").toISOString();
+        const endIso = moment.tz(to, "YYYYMMDD", timezone).endOf("day").toISOString();
+
+        const docs = await this.db.collection(COLLECTION).find({
+            userId,
+            passed: true,
+            takenAt: { $gte: startIso, $lte: endIso },
+        }).toArray();
+
+        const counts = new Map<string, number>();
+        for (const doc of docs) {
+            if (!doc.takenAt) continue;
+            const day = moment.tz(doc.takenAt as string, timezone).format("YYYYMMDD");
+            counts.set(day, (counts.get(day) ?? 0) + 1);
+        }
+
+        return counts;
     }
 }
 

--- a/src/store/PracticeSessionStore.ts
+++ b/src/store/PracticeSessionStore.ts
@@ -1,4 +1,5 @@
 import { Db, ObjectId } from "mongodb";
+import * as moment from "moment-timezone";
 import { ControllerConfig } from "../Config";
 import { PracticeAnswer, PracticeSession } from "../model/PracticeSession";
 
@@ -125,5 +126,35 @@ export class PracticeSessionStore {
             { _id: new ObjectId(sessionId) },
             { $pull: { retryQueue: exerciseId } } as any
         );
+    }
+
+    /**
+     * Returns a map of YYYYMMDD → completed-session count for the given user and date window.
+     * Only sessions with a non-null completedAt that falls within [from, to] (inclusive, in
+     * the given timezone) are counted. Days with no activity are absent from the map.
+     *
+     * @param {string} userId - The user whose sessions to count.
+     * @param {string} from - First day of the window (YYYYMMDD).
+     * @param {string} to - Last day of the window (YYYYMMDD).
+     * @param {string} timezone - IANA timezone for civil-day bucketing.
+     */
+    async countCompletedByDay(userId: string, from: string, to: string, timezone: string): Promise<Map<string, number>> {
+
+        const startIso = moment.tz(from, "YYYYMMDD", timezone).startOf("day").toISOString();
+        const endIso = moment.tz(to, "YYYYMMDD", timezone).endOf("day").toISOString();
+
+        const docs = await this.db.collection(COLLECTION).find({
+            userId,
+            completedAt: { $gte: startIso, $lte: endIso },
+        }).toArray();
+
+        const counts = new Map<string, number>();
+        for (const doc of docs) {
+            if (!doc.completedAt) continue;
+            const day = moment.tz(doc.completedAt as string, timezone).format("YYYYMMDD");
+            counts.set(day, (counts.get(day) ?? 0) + 1);
+        }
+
+        return counts;
     }
 }

--- a/test/dlg/stats/GetDailyActivity.test.ts
+++ b/test/dlg/stats/GetDailyActivity.test.ts
@@ -2,13 +2,13 @@ import { assert } from "chai";
 import { Request } from "express";
 import { GetDailyActivity } from "../../../src/dlg/stats/GetDailyActivity";
 
-const userContext = { email: "alice@example.com", userId: "u1", authProvider: "test" };
+const userContext = { email: "u1@u1.com", authProvider: "test", userId: "SHOULD-NOT-BE-USED" };
 
 // ---------------------------------------------------------------------------
 // Mock collection factory — supports find().toArray() per collection name
 // ---------------------------------------------------------------------------
 
-function makeMockDb(practiceSessionDocs: any[], moduleTestDocs: any[], levelTestDocs: any[]) {
+function makeMockDb(practiceSessionDocs: any[], moduleTestDocs: any[], levelTestDocs: any[], user: {userId: string, email: string} = {userId: "u1", email: "u1@u1.com"}) {
     function makeCol(docs: any[], timestampField: string, passedFilter?: boolean) {
         return {
             find: (filter: any) => ({
@@ -27,11 +27,23 @@ function makeMockDb(practiceSessionDocs: any[], moduleTestDocs: any[], levelTest
         };
     }
 
+    function makeUserCol(user: {email: string, userId: string}) {
+        return {
+            findOne: async (filter: any) => {
+                if (filter.email === user.email) {
+                    return { id: user.userId, email: user.email };
+                }
+                return null;
+            }
+        }
+    }
+
     return {
         collection: (name: string) => {
             if (name === "practiceSessions") return makeCol(practiceSessionDocs, "completedAt");
             if (name === "moduleTestAttempts") return makeCol(moduleTestDocs, "takenAt", true);
             if (name === "levelTestAttempts") return makeCol(levelTestDocs, "takenAt", true);
+            if (name === "users") return makeUserCol(user);
             throw new Error(`Unknown collection: ${name}`);
         },
     } as any;
@@ -105,6 +117,32 @@ describe("GetDailyActivity.do", () => {
         assert.equal(day27.practiceSessions, 0);
         assert.equal(day27.successfulModuleTests, 0);
         assert.equal(day27.successfulLevelTests, 1);
+    });
+
+    it("returns empty days when no data is available for the user", async () => {
+        const practiceSessionDocs = [
+            { userId: "u2", completedAt: "2026-06-21T10:00:00.000Z" },
+            { userId: "u2", completedAt: "2026-06-21T14:00:00.000Z" },
+            { userId: "u2", completedAt: "2026-06-23T09:00:00.000Z" },
+        ];
+        const moduleTestDocs = [
+            { userId: "u2", passed: true, takenAt: "2026-06-23T11:00:00.000Z" },
+        ];
+        const levelTestDocs = [
+            { userId: "u2", passed: true, takenAt: "2026-06-27T15:00:00.000Z" },
+        ];
+
+        const db = makeMockDb(practiceSessionDocs, moduleTestDocs, levelTestDocs);
+        const delegate = new GetDailyActivity({} as any, makeMockConfig(db));
+
+        const result = await delegate.do({ from: "20260621" }, userContext);
+        
+        assert.equal(result.days.length, 7);
+        for (const day of result.days) {
+            assert.equal(day.practiceSessions, 0);
+            assert.equal(day.successfulModuleTests, 0);
+            assert.equal(day.successfulLevelTests, 0);
+        }
     });
 
     it("fills empty days with zero counts so the array is always dense", async () => {

--- a/test/dlg/stats/GetDailyActivity.test.ts
+++ b/test/dlg/stats/GetDailyActivity.test.ts
@@ -1,0 +1,171 @@
+import { assert } from "chai";
+import { Request } from "express";
+import { GetDailyActivity } from "../../../src/dlg/stats/GetDailyActivity";
+
+const userContext = { email: "alice@example.com", userId: "u1", authProvider: "test" };
+
+// ---------------------------------------------------------------------------
+// Mock collection factory — supports find().toArray() per collection name
+// ---------------------------------------------------------------------------
+
+function makeMockDb(practiceSessionDocs: any[], moduleTestDocs: any[], levelTestDocs: any[]) {
+    function makeCol(docs: any[], timestampField: string, passedFilter?: boolean) {
+        return {
+            find: (filter: any) => ({
+                toArray: async () => {
+                    return docs.filter(d => {
+                        if (d.userId !== filter.userId) return false;
+                        if (passedFilter !== undefined && d.passed !== passedFilter) return false;
+                        const ts = d[timestampField];
+                        if (!ts) return false;
+                        if (filter[timestampField]?.$gte && ts < filter[timestampField].$gte) return false;
+                        if (filter[timestampField]?.$lte && ts > filter[timestampField].$lte) return false;
+                        return true;
+                    });
+                },
+            }),
+        };
+    }
+
+    return {
+        collection: (name: string) => {
+            if (name === "practiceSessions") return makeCol(practiceSessionDocs, "completedAt");
+            if (name === "moduleTestAttempts") return makeCol(moduleTestDocs, "takenAt", true);
+            if (name === "levelTestAttempts") return makeCol(levelTestDocs, "takenAt", true);
+            throw new Error(`Unknown collection: ${name}`);
+        },
+    } as any;
+}
+
+function makeMockConfig(db: any) {
+    return {
+        getDBName: () => "test",
+        getMongoDb: async () => db,
+    } as any;
+}
+
+function makeReq(from?: string): Request {
+    return { params: {}, query: from ? { from } : {}, body: {} } as unknown as Request;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GetDailyActivity.parseRequest", () => {
+
+    it("captures the from query param when provided", () => {
+        const delegate = new GetDailyActivity({} as any, makeMockConfig(makeMockDb([], [], [])));
+        const result = delegate.parseRequest(makeReq("20260621"));
+        assert.equal(result.from, "20260621");
+    });
+
+    it("returns undefined from when param is omitted", () => {
+        const delegate = new GetDailyActivity({} as any, makeMockConfig(makeMockDb([], [], [])));
+        const result = delegate.parseRequest(makeReq());
+        assert.isUndefined(result.from);
+    });
+});
+
+describe("GetDailyActivity.do", () => {
+
+    it("returns a dense 7-day array with correct counts from all three stores", async () => {
+        const practiceSessionDocs = [
+            { userId: "u1", completedAt: "2026-06-21T10:00:00.000Z" },
+            { userId: "u1", completedAt: "2026-06-21T14:00:00.000Z" },
+            { userId: "u1", completedAt: "2026-06-23T09:00:00.000Z" },
+        ];
+        const moduleTestDocs = [
+            { userId: "u1", passed: true, takenAt: "2026-06-23T11:00:00.000Z" },
+        ];
+        const levelTestDocs = [
+            { userId: "u1", passed: true, takenAt: "2026-06-27T15:00:00.000Z" },
+        ];
+
+        const db = makeMockDb(practiceSessionDocs, moduleTestDocs, levelTestDocs);
+        const delegate = new GetDailyActivity({} as any, makeMockConfig(db));
+
+        const result = await delegate.do({ from: "20260621" }, userContext);
+
+        assert.equal(result.from, "20260621");
+        assert.equal(result.to, "20260627");
+        assert.equal(result.days.length, 7);
+
+        const day21 = result.days.find(d => d.date === "20260621")!;
+        assert.equal(day21.practiceSessions, 2);
+        assert.equal(day21.successfulModuleTests, 0);
+        assert.equal(day21.successfulLevelTests, 0);
+
+        const day23 = result.days.find(d => d.date === "20260623")!;
+        assert.equal(day23.practiceSessions, 1);
+        assert.equal(day23.successfulModuleTests, 1);
+        assert.equal(day23.successfulLevelTests, 0);
+
+        const day27 = result.days.find(d => d.date === "20260627")!;
+        assert.equal(day27.practiceSessions, 0);
+        assert.equal(day27.successfulModuleTests, 0);
+        assert.equal(day27.successfulLevelTests, 1);
+    });
+
+    it("fills empty days with zero counts so the array is always dense", async () => {
+        const db = makeMockDb([], [], []);
+        const delegate = new GetDailyActivity({} as any, makeMockConfig(db));
+
+        const result = await delegate.do({ from: "20260621" }, userContext);
+
+        assert.equal(result.days.length, 7);
+        for (const day of result.days) {
+            assert.equal(day.practiceSessions, 0);
+            assert.equal(day.successfulModuleTests, 0);
+            assert.equal(day.successfulLevelTests, 0);
+        }
+    });
+
+    it("orders days oldest-first", async () => {
+        const db = makeMockDb([], [], []);
+        const delegate = new GetDailyActivity({} as any, makeMockConfig(db));
+
+        const result = await delegate.do({ from: "20260621" }, userContext);
+
+        for (let i = 1; i < result.days.length; i++) {
+            assert.isTrue(result.days[i].date > result.days[i - 1].date);
+        }
+    });
+
+    it("defaults from to today-6 when omitted, returning a 7-day window ending today", async () => {
+        const db = makeMockDb([], [], []);
+        const delegate = new GetDailyActivity({} as any, makeMockConfig(db));
+
+        const result = await delegate.do({}, userContext);
+
+        assert.equal(result.days.length, 7);
+        // to should be after from by exactly 6 days
+        assert.isTrue(result.to > result.from);
+        assert.equal(result.days[0].date, result.from);
+        assert.equal(result.days[6].date, result.to);
+    });
+
+    it("throws a 400 ValidationError when from is not a valid YYYYMMDD date", async () => {
+        const db = makeMockDb([], [], []);
+        const delegate = new GetDailyActivity({} as any, makeMockConfig(db));
+
+        try {
+            await delegate.do({ from: "not-a-date" }, userContext);
+            assert.fail("Expected a ValidationError");
+        } catch (err: any) {
+            assert.equal(err.code, 400);
+        }
+    });
+
+    it("throws a 400 ValidationError when from has wrong format (8 digits but invalid date)", async () => {
+        const db = makeMockDb([], [], []);
+        const delegate = new GetDailyActivity({} as any, makeMockConfig(db));
+
+        try {
+            await delegate.do({ from: "20261399" }, userContext);
+            assert.fail("Expected a ValidationError");
+        } catch (err: any) {
+            assert.equal(err.code, 400);
+        }
+    });
+});

--- a/test/store/LevelTestAttemptStore.countPassedByDay.test.ts
+++ b/test/store/LevelTestAttemptStore.countPassedByDay.test.ts
@@ -1,0 +1,92 @@
+import { assert } from "chai";
+import { ObjectId } from "mongodb";
+import { LevelTestAttemptStore } from "../../src/store/LevelTestAttemptStore";
+
+const TZ = "Europe/Copenhagen";
+
+function makeDoc(userId: string, passed: boolean | null, takenAt: string | null): any {
+    return { _id: new ObjectId(), userId, cefrLevel: "A1", passed, takenAt };
+}
+
+function makeMockCollection(initialDocs: any[]) {
+    const docs = [...initialDocs];
+    return {
+        find: (filter: any) => ({
+            toArray: async () => {
+                return docs.filter(d => {
+                    if (d.userId !== filter.userId) return false;
+                    if (filter.passed !== undefined && d.passed !== filter.passed) return false;
+                    const ta = d.takenAt;
+                    if (!ta) return false;
+                    if (filter.takenAt?.$gte && ta < filter.takenAt.$gte) return false;
+                    if (filter.takenAt?.$lte && ta > filter.takenAt.$lte) return false;
+                    return true;
+                });
+            },
+        }),
+    };
+}
+
+function makeMockDb(col: any) {
+    return { collection: () => col } as any;
+}
+
+describe("LevelTestAttemptStore.countPassedByDay", () => {
+
+    it("counts passed attempts bucketed by calendar day in the reference timezone", async () => {
+        const docs = [
+            makeDoc("u1", true, "2026-06-21T10:00:00.000Z"),
+            makeDoc("u1", true, "2026-06-22T08:00:00.000Z"),
+            makeDoc("u1", true, "2026-06-22T20:00:00.000Z"),
+        ];
+        const store = new LevelTestAttemptStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });
+
+        const result = await store.countPassedByDay("u1", "20260621", "20260627", TZ);
+
+        assert.equal(result.get("20260621"), 1);
+        assert.equal(result.get("20260622"), 2);
+        assert.isUndefined(result.get("20260623"));
+    });
+
+    it("excludes failed attempts", async () => {
+        const docs = [
+            makeDoc("u1", false, "2026-06-21T10:00:00.000Z"),
+            makeDoc("u1", true, "2026-06-21T11:00:00.000Z"),
+        ];
+        const store = new LevelTestAttemptStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });
+
+        const result = await store.countPassedByDay("u1", "20260621", "20260627", TZ);
+
+        assert.equal(result.get("20260621"), 1);
+    });
+
+    it("excludes un-submitted attempts with null takenAt", async () => {
+        const docs = [
+            makeDoc("u1", null, null),
+            makeDoc("u1", true, "2026-06-21T10:00:00.000Z"),
+        ];
+        const store = new LevelTestAttemptStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });
+
+        const result = await store.countPassedByDay("u1", "20260621", "20260627", TZ);
+
+        assert.equal(result.get("20260621"), 1);
+    });
+
+    it("excludes attempts belonging to a different user", async () => {
+        const docs = [makeDoc("u2", true, "2026-06-21T10:00:00.000Z")];
+        const store = new LevelTestAttemptStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });
+
+        const result = await store.countPassedByDay("u1", "20260621", "20260627", TZ);
+
+        assert.equal(result.size, 0);
+    });
+
+    it("returns an empty map when no attempts fall in the window", async () => {
+        const docs = [makeDoc("u1", true, "2026-06-10T10:00:00.000Z")];
+        const store = new LevelTestAttemptStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });
+
+        const result = await store.countPassedByDay("u1", "20260621", "20260627", TZ);
+
+        assert.equal(result.size, 0);
+    });
+});

--- a/test/store/ModuleTestAttemptStore.countPassedByDay.test.ts
+++ b/test/store/ModuleTestAttemptStore.countPassedByDay.test.ts
@@ -1,0 +1,92 @@
+import { assert } from "chai";
+import { ObjectId } from "mongodb";
+import { ModuleTestAttemptStore } from "../../src/store/ModuleTestAttemptStore";
+
+const TZ = "Europe/Copenhagen";
+
+function makeDoc(userId: string, passed: boolean | null, takenAt: string | null): any {
+    return { _id: new ObjectId(), userId, moduleId: "mod-1", passed, takenAt };
+}
+
+function makeMockCollection(initialDocs: any[]) {
+    const docs = [...initialDocs];
+    return {
+        find: (filter: any) => ({
+            toArray: async () => {
+                return docs.filter(d => {
+                    if (d.userId !== filter.userId) return false;
+                    if (filter.passed !== undefined && d.passed !== filter.passed) return false;
+                    const ta = d.takenAt;
+                    if (!ta) return false;
+                    if (filter.takenAt?.$gte && ta < filter.takenAt.$gte) return false;
+                    if (filter.takenAt?.$lte && ta > filter.takenAt.$lte) return false;
+                    return true;
+                });
+            },
+        }),
+    };
+}
+
+function makeMockDb(col: any) {
+    return { collection: () => col } as any;
+}
+
+describe("ModuleTestAttemptStore.countPassedByDay", () => {
+
+    it("counts passed attempts bucketed by calendar day in the reference timezone", async () => {
+        const docs = [
+            makeDoc("u1", true, "2026-06-21T10:00:00.000Z"),
+            makeDoc("u1", true, "2026-06-21T15:00:00.000Z"),
+            makeDoc("u1", true, "2026-06-22T09:00:00.000Z"),
+        ];
+        const store = new ModuleTestAttemptStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });
+
+        const result = await store.countPassedByDay("u1", "20260621", "20260627", TZ);
+
+        assert.equal(result.get("20260621"), 2);
+        assert.equal(result.get("20260622"), 1);
+        assert.isUndefined(result.get("20260623"));
+    });
+
+    it("excludes failed attempts", async () => {
+        const docs = [
+            makeDoc("u1", false, "2026-06-21T10:00:00.000Z"),
+            makeDoc("u1", true, "2026-06-21T11:00:00.000Z"),
+        ];
+        const store = new ModuleTestAttemptStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });
+
+        const result = await store.countPassedByDay("u1", "20260621", "20260627", TZ);
+
+        assert.equal(result.get("20260621"), 1);
+    });
+
+    it("excludes un-submitted attempts with null takenAt", async () => {
+        const docs = [
+            makeDoc("u1", null, null),
+            makeDoc("u1", true, "2026-06-21T10:00:00.000Z"),
+        ];
+        const store = new ModuleTestAttemptStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });
+
+        const result = await store.countPassedByDay("u1", "20260621", "20260627", TZ);
+
+        assert.equal(result.get("20260621"), 1);
+    });
+
+    it("excludes attempts belonging to a different user", async () => {
+        const docs = [makeDoc("u2", true, "2026-06-21T10:00:00.000Z")];
+        const store = new ModuleTestAttemptStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });
+
+        const result = await store.countPassedByDay("u1", "20260621", "20260627", TZ);
+
+        assert.equal(result.size, 0);
+    });
+
+    it("returns an empty map when no attempts fall in the window", async () => {
+        const docs = [makeDoc("u1", true, "2026-06-10T10:00:00.000Z")];
+        const store = new ModuleTestAttemptStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });
+
+        const result = await store.countPassedByDay("u1", "20260621", "20260627", TZ);
+
+        assert.equal(result.size, 0);
+    });
+});

--- a/test/store/PracticeSessionStore.countCompletedByDay.test.ts
+++ b/test/store/PracticeSessionStore.countCompletedByDay.test.ts
@@ -1,0 +1,83 @@
+import { assert } from "chai";
+import { ObjectId } from "mongodb";
+import { PracticeSessionStore } from "../../src/store/PracticeSessionStore";
+
+const TZ = "Europe/Copenhagen";
+
+function makeDoc(userId: string, completedAt: string | null): any {
+    return { _id: new ObjectId(), userId, moduleId: "mod-1", completedAt };
+}
+
+function makeMockCollection(initialDocs: any[]) {
+    const docs = [...initialDocs];
+    return {
+        find: (filter: any) => ({
+            toArray: async () => {
+                return docs.filter(d => {
+                    if (d.userId !== filter.userId) return false;
+                    const ca = d.completedAt;
+                    if (!ca) return false;
+                    if (filter.completedAt?.$gte && ca < filter.completedAt.$gte) return false;
+                    if (filter.completedAt?.$lte && ca > filter.completedAt.$lte) return false;
+                    return true;
+                });
+            },
+        }),
+    };
+}
+
+function makeMockDb(col: any) {
+    return { collection: () => col } as any;
+}
+
+describe("PracticeSessionStore.countCompletedByDay", () => {
+
+    it("counts completed sessions bucketed by calendar day in the reference timezone", async () => {
+        const docs = [
+            makeDoc("u1", "2026-06-21T10:00:00.000Z"),
+            makeDoc("u1", "2026-06-21T14:00:00.000Z"),
+            makeDoc("u1", "2026-06-22T08:00:00.000Z"),
+        ];
+        const store = new PracticeSessionStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });
+
+        const result = await store.countCompletedByDay("u1", "20260621", "20260627", TZ);
+
+        assert.equal(result.get("20260621"), 2);
+        assert.equal(result.get("20260622"), 1);
+        assert.isUndefined(result.get("20260623"));
+    });
+
+    it("excludes sessions with null completedAt (in-progress)", async () => {
+        const docs = [
+            makeDoc("u1", null),
+            makeDoc("u1", "2026-06-21T10:00:00.000Z"),
+        ];
+        const store = new PracticeSessionStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });
+
+        const result = await store.countCompletedByDay("u1", "20260621", "20260627", TZ);
+
+        assert.equal(result.get("20260621"), 1);
+    });
+
+    it("excludes sessions belonging to a different user", async () => {
+        const docs = [
+            makeDoc("u2", "2026-06-21T10:00:00.000Z"),
+        ];
+        const store = new PracticeSessionStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });
+
+        const result = await store.countCompletedByDay("u1", "20260621", "20260627", TZ);
+
+        assert.equal(result.size, 0);
+    });
+
+    it("returns an empty map when no sessions fall in the window", async () => {
+        const docs = [
+            makeDoc("u1", "2026-06-10T10:00:00.000Z"),
+        ];
+        const store = new PracticeSessionStore({ db: makeMockDb(makeMockCollection(docs)), config: {} as any });
+
+        const result = await store.countCompletedByDay("u1", "20260621", "20260627", TZ);
+
+        assert.equal(result.size, 0);
+    });
+});


### PR DESCRIPTION
## Summary

Implements F24 — Activity Stats (Rolling Window) as described in [`docs/features/F24-activity-stats.md`](docs/features/F24-activity-stats.md).

- New endpoint `GET /me/stats/dailyActivity?from=YYYYMMDD` returning per-day activity counts over a rolling 7-day window
- Three counts per day: `practiceSessions` (completed F10 sessions), `successfulModuleTests` (passed F11 attempts), `successfulLevelTests` (passed F21 attempts)
- `from` defaults to `today − 6` in the `Europe/Copenhagen` reference timezone so the window always ends today
- Dense response — empty days are always present with zero counts; never sparse
- Read-only — no mutations to any existing collection

## Changes

- `src/Config.ts` — added `REFERENCE_TIMEZONE = 'Europe/Copenhagen'`
- `src/store/PracticeSessionStore.ts` — added `countCompletedByDay`
- `src/store/ModuleTestAttemptStore.ts` — added `countPassedByDay`
- `src/store/LevelTestAttemptStore.ts` — added `countPassedByDay`
- `src/dlg/stats/GetDailyActivity.ts` — new delegate
- `src/index.ts` — registered `GET /me/stats/dailyActivity`
- `docs/interfaces/api-endpoints.md` — documented new endpoint
- 22 new tests across 4 test files; 596 total passing

## Test plan

- [ ] All 596 tests pass (`npm test`)
- [ ] Build is clean (`npm run build`)
- [ ] `GET /me/stats/dailyActivity?from=20260621` returns exactly 7 day entries oldest→newest with correct per-day counts
- [ ] Omitting `from` returns a window ending today
- [ ] Invalid `from` (non-YYYYMMDD) returns 400

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)